### PR TITLE
Fix precommit for imports linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,45 +51,45 @@ repos:
     hooks:
 
       # note: this is used in lieu of autopep8 and yapf
-      - id: system
+      - id: black
         name: black
         entry: poetry run black src tests
         pass_filenames: false
         language: system
 
-      - id: system
+      - id: unimport
         name: unimport
-        entry: poetry run unimport -c pyproject.toml
+        entry: poetry run unimport --gitignore -r src/ tests/
         pass_filenames: false
         language: system
 
-      - id: system
+      - id: autoflake
         name: autoflake
         entry: poetry run autoflake --in-place -r src/vunnel
         pass_filenames: false
         language: system
 
-      - id: system
+      - id: isort
         name: isort
         entry: poetry run isort tests src --filter-files
         pass_filenames: false
         language: system
         files: \.py$
 
-      - id: system
+      - id: bandit
         name: bandit
         entry: poetry run bandit -r -v -c 'pyproject.toml' src/vunnel
         pass_filenames: false
         language: system
 
-      # note: flake8 is a metalinter combinding Pyflakes, pycodestyle, and mccabe
-      - id: system
+      # note: flake8 is a metalinter combining Pyflakes, pycodestyle, and mccabe
+      - id: flake8
         name: flake8
         entry: poetry run flake8 src/vunnel
         pass_filenames: false
         language: system
 
-      - id: system
+      - id: mypy
         name: mypy
         entry: poetry run mypy --config-file ./pyproject.toml src/vunnel
         pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,9 +168,3 @@ exclude_dirs = ["tests",]
 [tool.autoflake]
 # note: these options may not play nicely with __init__ imports
 remove-unused-variables = true
-
-[tool.unimport]
-sources = ["src/vunnel"]
-exclude = 'tests/'
-remove = true
-gitignore = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,9 @@ import json
 import os
 import subprocess
 import uuid
-from datetime import datetime
 
 import jsonschema
 import pytest
-
-from vunnel import provider, workspace
 
 
 class WorkspaceHelper:

--- a/tests/unit/providers/sles/test_sles.py
+++ b/tests/unit/providers/sles/test_sles.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 import defusedxml.ElementTree as ET

--- a/tests/unit/providers/ubuntu/test_ubuntu.py
+++ b/tests/unit/providers/ubuntu/test_ubuntu.py
@@ -4,8 +4,6 @@ import shlex
 import shutil
 import subprocess
 import sys
-import tempfile
-import unittest
 
 import pytest
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,7 +1,5 @@
 import json
 import os
-import uuid
-from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1,11 +1,6 @@
-import json
 import os
-import uuid
-from datetime import datetime
 
-import pytest
-
-from vunnel import provider, schema, workspace
+from vunnel import schema, workspace
 
 
 def assert_directory(path: str, exists: bool = True, empty: bool = False):


### PR DESCRIPTION
Currently the unimports linter is ignoring the configuration in the pyproject.toml. I've updated the command to include all necessary switches instead of using a config. This now runs much faster (if there is a full data directory locally)