### PR TITLE
fix: re-enable --follow on ubuntu provider

### DIFF
--- a/src/vunnel/providers/ubuntu/git.py
+++ b/src/vunnel/providers/ubuntu/git.py
@@ -28,7 +28,7 @@ class GitWrapper:
     _reset_head_cmd_ = "git reset --hard origin/master"
     _write_graph_ = "git commit-graph write --reachable --changed-paths"
     _change_set_cmd_ = "git log --no-renames --no-merges --name-status --format=oneline {from_rev}..{to_rev}"
-    _rev_history_cmd_ = "git log --no-merges --name-status --format=oneline {from_rev} -- {file}"
+    _rev_history_cmd_ = "git log --no-merges --follow --name-status --format=oneline {from_rev} -- {file}"
     _get_rev_content_cmd_ = "git show {sha}:{file}"
     _head_rev_cmd_ = "git rev-parse HEAD"
 


### PR DESCRIPTION
re-enabling `--follow` for the ubuntu provider as it seems to be required in order to get equivalent results to the legacy driver