### PR TITLE
Status command does not read records from DB

### DIFF
--- a/src/vunnel/cli/cli.py
+++ b/src/vunnel/cli/cli.py
@@ -132,8 +132,8 @@ def status_provider(cfg: config.Application, provider_names: str) -> None:
             if not state:
                 raise FileNotFoundError("no state found")
             node = f"""
-{fill}      {len(list(state.result_files(provider.workspace.path)))} result files
-{fill}      {state.timestamp}"""
+{fill}      results: {state.result_count(provider.workspace.path)}
+{fill}      from:    {state.timestamp.strftime("%Y-%m-%d %H:%M:%S")}"""
         except FileNotFoundError:
             node = f"""
 {fill}      (no state found)"""


### PR DESCRIPTION
After allowing for additional storage strategies, many of the drivers now prefer the SQLite storage approach. This PR enhances the status command to read records from the DB when the DB strategy is used (instead of reporting a single record).