### PR TITLE
fix: consider non-exact renames as modifications

### DIFF
--- a/src/vunnel/providers/ubuntu/git.py
+++ b/src/vunnel/providers/ubuntu/git.py
@@ -22,7 +22,6 @@ class GitCommitSummary:
 @dataclass
 class GitRevision:
     sha: str
-    # status: str
     file: str
 
 
@@ -39,7 +38,6 @@ class GitWrapper:
     _reset_head_cmd_ = "git reset --hard origin/master"
     _write_graph_ = "git commit-graph write --reachable --changed-paths"
     _change_set_cmd_ = "git log --no-renames --no-merges --name-status --format=oneline {from_rev}..{to_rev}"
-    _rev_history_cmd_ = "git log --no-merges --name-status --format=oneline {from_rev} -- {file}"
     _get_rev_content_cmd_ = "git show {sha}:{file}"
     _head_rev_cmd_ = "git rev-parse HEAD"
 
@@ -322,6 +320,9 @@ class GitWrapper:
                     # CVE deleted from active or retired directory
                     # D       active/CVE-2009-1553
                     deleted[cve_id] = components[1]
+                elif components[0].startswith("R"):
+                    if components[0] != "R100" and len(components) > 2:
+                        updated[cve_id] = components[2]
                 else:
                     # either not a commit line or an irrelevant file, ignore it
                     self.logger.warning("encountered unknown change symbol {}".format(components[0]))


### PR DESCRIPTION
Consider renames where the renamed file content isn't an exact match as a modified commit when evaluating change history