### PR TITLE
feat: add ubuntu provider git config options

### DIFF
--- a/src/vunnel/providers/ubuntu/__init__.py
+++ b/src/vunnel/providers/ubuntu/__init__.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 
 from vunnel import provider, result, schema
 
-from .parser import Parser, default_max_workers
+from .parser import Parser, default_git_branch, default_git_url, default_max_workers
 
 
 @dataclass
@@ -21,6 +21,8 @@ class Config:
     additional_versions: dict[str, str] = field(default_factory=lambda: {})
     enable_rev_history: bool = True
     max_workers: int = default_max_workers
+    git_url: str = default_git_url
+    git_branch: str = default_git_branch
 
 
 class Provider(provider.Provider):
@@ -37,6 +39,8 @@ class Provider(provider.Provider):
             additional_versions=self.config.additional_versions,
             enable_rev_history=self.config.enable_rev_history,
             max_workers=self.config.max_workers,
+            git_url=self.config.git_url,
+            git_branch=self.config.git_branch,
         )
 
     @classmethod

--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -21,6 +21,8 @@ from .git import GitWrapper
 namespace = "ubuntu"
 
 default_max_workers = 8
+default_git_url = "git://git.launchpad.net/ubuntu-cve-tracker"
+default_git_branch = "master"
 
 ubuntu_pkg_version_format = "dpkg"
 ubuntu_cve_url = "http://people.ubuntu.com/~ubuntu-security/cve/{}"
@@ -580,8 +582,7 @@ class Parser:
     __payload__ = Vulnerability
 
     _bzr_src = "https://launchpad.net/ubuntu-cve-tracker"
-    _git_https = "https://git.launchpad.net/ubuntu-cve-tracker"
-    _git_src = "git://git.launchpad.net/ubuntu-cve-tracker"
+    _git_src_url = "git://git.launchpad.net/ubuntu-cve-tracker"
     _bzr_to_git_transition_commit = "dc3f64a0dfe6b1780240ff115d8a0a1b23fd00b4"
 
     _active_cve_dir = "active"
@@ -605,6 +606,8 @@ class Parser:
         additional_versions: dict[str, str] | None = None,
         enable_rev_history: bool = True,
         max_workers: int = default_max_workers,
+        git_url: str = default_git_url,
+        git_branch: str = default_git_branch,
     ):
         self.vc_workspace = os.path.join(workspace.input_path, self._vc_working_dir)
         # TODO: tech debt: this should use the results workspace with the correct schema-aware envelope
@@ -612,9 +615,10 @@ class Parser:
         if not logger:
             logger = logging.getLogger(self.__class__.__name__)
         self.logger = logger
-        self.urls = [self._git_https]
-
-        self.git_wrapper = GitWrapper(source=self._git_src, checkout_dest=self.vc_workspace, logger=logger)
+        self.git_url = git_url
+        self.git_branch = git_branch
+        self.urls = [self.git_url]
+        self.git_wrapper = GitWrapper(source=self.git_url, branch=self.git_branch, checkout_dest=self.vc_workspace, logger=logger)
 
         if additional_versions:
             ubuntu_version_names.update(additional_versions)

--- a/tests/unit/cli/test-fixtures/full.yaml
+++ b/tests/unit/cli/test-fixtures/full.yaml
@@ -52,6 +52,15 @@ providers:
     request_timeout: 20
     allow_versions:
       - 13
+  ubuntu:
+    runtime: *runtime
+    request_timeout: 20
+    additional_versions:
+      "zzz": "24.24"
+    enable_rev_history: true
+    max_workers: 25
+    git_url: "https://xyz.abc"
+    git_branch: "yoda"
   wolfi:
     runtime: *runtime
     request_timeout: 20

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -257,6 +257,8 @@ providers:
   ubuntu:
     additional_versions: {}
     enable_rev_history: true
+    git_branch: master
+    git_url: git://git.launchpad.net/ubuntu-cve-tracker
     max_workers: 8
     request_timeout: 125
     runtime:

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -79,6 +79,15 @@ def test_full_config(helpers):
                 request_timeout=20,
                 allow_versions=[13],
             ),
+            ubuntu=providers.ubuntu.Config(
+                runtime=runtime_cfg,
+                request_timeout=20,
+                additional_versions={"zzz": "24.24"},
+                enable_rev_history=True,
+                max_workers=25,
+                git_url="https://xyz.abc",
+                git_branch="yoda",
+            ),
             wolfi=providers.wolfi.Config(
                 runtime=runtime_cfg,
                 request_timeout=20,

--- a/tests/unit/providers/ubuntu/test_git_wrapper.py
+++ b/tests/unit/providers/ubuntu/test_git_wrapper.py
@@ -133,7 +133,7 @@ class TestGitWrapper(unittest.TestCase):
         with open(self._git_change_log_file_) as f:
             git_commit_log = f.read()
 
-        wrapper = GitWrapper(self._workspace_, self._workspace_)
+        wrapper = GitWrapper(self._workspace_, "master", self._workspace_)
 
         commits = wrapper._parse_log(git_commit_log)
 
@@ -149,7 +149,7 @@ class TestGitWrapper(unittest.TestCase):
         with open(self._git_change_log_file_) as f:
             git_commit_log = f.read()
 
-        wrapper = GitWrapper(self._workspace_, self._workspace_)
+        wrapper = GitWrapper(self._workspace_, "master", self._workspace_)
 
         commits = wrapper._parse_log(git_commit_log)
 
@@ -195,4 +195,4 @@ A       active/CVE-2013-4348
     ],
 )
 def test_parse_full_cve_revision_history(git_log_output: str, expected: dict[str, list[GitRevision]]):
-    assert GitWrapper("", "").parse_full_cve_revision_history(git_log_output) == expected
+    assert GitWrapper("", "master", "").parse_full_cve_revision_history(git_log_output) == expected


### PR DESCRIPTION
Adds configuration options to the ubuntu driver to specify the `git_url` and `git_branch` to use for the ubuntu-cve-tracker repository

Closes #48 