### PR TITLE
fix: prevent git dubious ownership errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,15 @@ RUN apt update && apt install -y git && rm -rf /var/lib/apt/lists/*
 
 COPY dist dist
 RUN pip install ./dist/vunnel-*.whl
+
+# This is needed to prevent newer versions of git raising dubious ownership
+# errors if the repo directory or .git sub-directory are not owned by the
+# current user.
+#
+# https://medium.com/@thecodinganalyst/git-detect-dubious-ownership-in-repository-e7f33037a8f
+# https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
+RUN git config --system safe.directory '*'
+
 ENTRYPOINT ["vunnel"]
 
 LABEL org.opencontainers.image.source https://github.com/anchore/vunnel


### PR DESCRIPTION
This is needed to prevent newer versions of git raising dubious ownership errors if the repo directory or .git sub-directory are not owned by the current user.

- https://medium.com/@thecodinganalyst/git-detect-dubious-ownership-in-repository-e7f33037a8f
- https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>