### PR TITLE
Disallow existing input to be deleted via configuration

### DIFF
--- a/src/vunnel/provider.py
+++ b/src/vunnel/provider.py
@@ -76,6 +76,13 @@ class RuntimeConfig:
         return self.existing_input == InputStatePolicy.KEEP
 
 
+def disallow_existing_input_policy(cfg: RuntimeConfig) -> None:
+    if cfg.existing_input != InputStatePolicy.KEEP:
+        raise ValueError(
+            f"existing_input policy is '{cfg.existing_input}' but only a value of 'keep' is allowed for this provider",
+        )
+
+
 class Provider(abc.ABC):
     def __init__(self, root: str, runtime_cfg: RuntimeConfig = RuntimeConfig()):  # noqa: B008
         self.logger = logging.getLogger(self.name())

--- a/src/vunnel/providers/alpine/__init__.py
+++ b/src/vunnel/providers/alpine/__init__.py
@@ -36,6 +36,9 @@ class Provider(provider.Provider):
             logger=self.logger,
         )
 
+        # this provider requires the previous state from former runs
+        provider.disallow_existing_input_policy(config.runtime)
+
     @classmethod
     def name(cls) -> str:
         return "alpine"

--- a/src/vunnel/providers/centos/__init__.py
+++ b/src/vunnel/providers/centos/__init__.py
@@ -38,6 +38,9 @@ class Provider(provider.Provider):
             logger=self.logger,
         )
 
+        # this provider requires the previous state from former runs
+        provider.disallow_existing_input_policy(config.runtime)
+
     @classmethod
     def name(cls) -> str:
         return "centos"

--- a/src/vunnel/providers/debian/__init__.py
+++ b/src/vunnel/providers/debian/__init__.py
@@ -42,6 +42,9 @@ class Provider(provider.Provider):
             logger=self.logger,
         )
 
+        # this provider requires the previous state from former runs
+        provider.disallow_existing_input_policy(config.runtime)
+
     @classmethod
     def name(cls) -> str:
         return "debian"

--- a/src/vunnel/providers/oracle/__init__.py
+++ b/src/vunnel/providers/oracle/__init__.py
@@ -38,6 +38,9 @@ class Provider(provider.Provider):
             logger=self.logger,
         )
 
+        # this provider requires the previous state from former runs
+        provider.disallow_existing_input_policy(config.runtime)
+
     @classmethod
     def name(cls) -> str:
         return "oracle"

--- a/src/vunnel/providers/sles/__init__.py
+++ b/src/vunnel/providers/sles/__init__.py
@@ -42,6 +42,9 @@ class Provider(provider.Provider):
             logger=self.logger,
         )
 
+        # this provider requires the previous state from former runs
+        provider.disallow_existing_input_policy(config.runtime)
+
     @classmethod
     def name(cls) -> str:
         return "sles"

--- a/src/vunnel/providers/wolfi/__init__.py
+++ b/src/vunnel/providers/wolfi/__init__.py
@@ -37,6 +37,9 @@ class Provider(provider.Provider):
             logger=self.logger,
         )
 
+        # this provider requires the previous state from former runs
+        provider.disallow_existing_input_policy(config.runtime)
+
     @classmethod
     def name(cls) -> str:
         return "wolfi"


### PR DESCRIPTION
This is a follow up to #53  and #54 to ensure that the provider will exit with 1 when misconfigured. The only supported configuration is checking the runtime config options that drive skip_if_exists.