### PR TITLE
Fix release script to produce release version with changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 /.tmp/
 CHANGELOG.md
+VERSION
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ ci-promote-release: ci-check
 
 .PHONY: changelog
 changelog:
-	@$(CHRONICLE) -vvv -n . > CHANGELOG.md
+	@$(CHRONICLE) -vvv -n . --version-file VERSION > CHANGELOG.md
 	@$(GLOW) CHANGELOG.md
 
 .PHONY: release


### PR DESCRIPTION
This switches the chronicle options to output the speculated next release version into a separate `VERSION` file when kicking off the release workflow.