### PR TITLE
Fix github timestamp creation

### DIFF
--- a/tests/unit/providers/github/test_github.py
+++ b/tests/unit/providers/github/test_github.py
@@ -343,7 +343,7 @@ class TestParser:
         metadata = database.get_metadata()
         timestamp = metadata.data["timestamp"]
         assert isinstance(timestamp, str)
-        assert timestamp.endswith("Z")
+        assert timestamp.endswith("Z") or timestamp.endswith("+00:00")
 
     def test_get_commits_timestamp_with_cursors(self, advisories, fake_get_query, tmpdir, empty_response):
         fake_get_query([empty_response, advisories(has_next_page=True)])
@@ -355,7 +355,7 @@ class TestParser:
         metadata = database.get_metadata()
         timestamp = metadata.data["timestamp"]
         assert isinstance(timestamp, str)
-        assert timestamp.endswith("Z")
+        assert timestamp.endswith("Z") or timestamp.endswith("+00:00")
 
     def test_has_next_page(self, advisories, fake_get_query, tmpdir, empty_response):
         fake_get_query([empty_response, advisories(has_next_page=True)])


### PR DESCRIPTION
After replacing the timestamp creation method for the github provider, it began to fail:
```
error during update: Error downloading advisories: [{'path': ['query', 'securityAdvisories', 'updatedSince'], 'extensions': {'code': 'argumentLiteralsIncompatible', 'typeName': 'Field', 'argumentName': 'updatedSince'}, 'locations': [{'line': 3, 'column': 7}], 'message': 'Argument \'updatedSince\' on Field \'securityAdvisories\' has an invalid value ("2023-03-11T01:28:29.190023+00:00Z"). Expected type \'DateTime\'.'}]
```
The code had been manually adding the `Z` to the timestamp, which is incorrect. The value is cached for the next run to calculate the incremental diff on. This means that the new code does not account for all values passed to the API, so cached values need to have the Z stripped. This should be removed in future releases.

Fun question -- why didn't the quality gate catch this? It's because this issue only arises when there is pull cache used, which they quality gates don't use (unless they have to, and for the github provider this is disabled).