### PR TITLE
Fix workspace schema to be correct relative to actual 1.0 datashape

### DIFF
--- a/schema/provider-workspace-state/schema-1.0.0.json
+++ b/schema/provider-workspace-state/schema-1.0.0.json
@@ -12,152 +12,32 @@
       "items": [
         {
           "type": "string"
-        },
-        {
-          "type": "string"
         }
       ]
     },
-    "input": {
+    "store": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "listing": {
       "type": "object",
       "properties": {
-        "files": {
-          "type": "array",
-          "items": [
-            {
-              "type": "object",
-              "properties": {
-                "path": {
-                  "type": "string"
-                },
-                "digests": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "modified": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "path",
-                "digests",
-                "modified"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "path": {
-                  "type": "string"
-                },
-                "digests": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "modified": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "path",
-                "digests",
-                "modified"
-              ]
-            }
-          ]
+        "digest": {
+          "type": "string"
         },
-        "timestamp": {
+        "path": {
+          "type": "string"
+        },
+        "algorithm": {
           "type": "string"
         }
       },
       "required": [
-        "files",
-        "timestamp"
-      ]
-    },
-    "results": {
-      "type": "object",
-      "properties": {
-        "files": {
-          "type": "array",
-          "items": [
-            {
-              "type": "object",
-              "properties": {
-                "path": {
-                  "type": "string"
-                },
-                "digests": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "modified": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "path",
-                "digests",
-                "modified"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "path": {
-                  "type": "string"
-                },
-                "digests": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "modified": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "path",
-                "digests",
-                "modified"
-              ]
-            }
-          ]
-        },
-        "timestamp": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "files",
-        "timestamp"
+        "digest",
+        "path",
+        "algorithm"
       ]
     },
     "schema": {
@@ -179,8 +59,9 @@
   "required": [
     "provider",
     "urls",
-    "input",
-    "results",
+    "store",
+    "timestamp",
+    "listing",
     "schema"
   ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ class WorkspaceHelper:
         self.name = name
 
     @property
+    def metadata_path(self):
+        return self.root / self.name / "metadata.json"
+
+    @property
     def input_dir(self):
         return self.root / self.name / "input"
 
@@ -45,6 +49,16 @@ class WorkspaceHelper:
 
         if require_entries and entries_validated == 0:
             raise ValueError("no entries were validated")
+
+        return True
+
+    def metadata_schema_valid(self) -> bool:
+        with open(self.metadata_path) as f:
+            item = json.load(f)
+            schema_url = item["schema"]["url"]
+
+            schema_dict = load_json_schema(get_schema_repo_path(schema_url))
+            jsonschema.validate(instance=item, schema=schema_dict)
 
         return True
 

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -127,3 +127,20 @@ def test_record_state_urls_persisted_across_runs(tmpdir, dummy_file):
     )
 
     assert current_state == expected_state
+
+
+def test_state_schema(tmpdir, dummy_file, helpers):
+    name = "dummy"
+    ws = workspace.Workspace(root=tmpdir, name=name, create=True)
+
+    # create a dummy files
+    dummy_file(ws.input_path, "dummt-input-1.json")
+    dummy_file(ws.results_path, "dummy-00000.json")
+
+    urls = ["http://localhost:8000/dummy-input-1.json"]
+    store = result.StoreStrategy.FLAT_FILE
+    ws.record_state(urls=urls, store=store.value, timestamp=datetime.datetime(2021, 1, 1))
+
+    ws_helper = helpers.provider_workspace_helper(name=name, create=False)
+
+    assert ws_helper.metadata_schema_valid()


### PR DESCRIPTION
The current json schema for the workplace state was not under test and the schema was incorrect relative to the data shape that was actually being output by vunnel. This PR fixes the schema to reflect the existing data shape (which is why this mutates the existing 1.0.0 schema instead of bumping it). 