### PR TITLE
Fix grype-db install within quality gate

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -26,6 +26,7 @@ yardstick:
       #  - "latest" to use the latest released grype
       #  - a released version name (e.g. "v0.52.1")
       #  - a branch name (e.g. "dev-fix-foo")
+      #  - a repo reference and optional "@branch" (e.g. "my-user-fork/grype@dev-fix-foo")
       # Note:
       #  - this version should ALWAYS match that of the other "grype" tool above
       version: latest
@@ -37,6 +38,7 @@ grype-db:
   #  - a released version name (e.g. "v0.15.2")
   #  - a branch name (e.g. "dev-fix-foo")
   #  - a repo reference and optional "@branch" (e.g. "my-user-fork/grype-db@dev-fix-foo")
+  #  - a local file path (e.g. "file://~/code/grype-db")
   version: latest
 
 tests:


### PR DESCRIPTION
Currently it isn't possible to install grype-db from a fork. This PR refactors the grype-db install code to be a little more modular and adds install capability for forks and local user paths (e.g. `file://~/code/grype-db`).