### PR TITLE
fix: avoid ubuntu git repo check exception on missing directory

### DIFF
--- a/src/vunnel/providers/ubuntu/git.py
+++ b/src/vunnel/providers/ubuntu/git.py
@@ -65,6 +65,10 @@ class GitWrapper:
 
     def _check(self, destination):
         try:
+            if not os.path.exists(destination):
+                self.logger.debug(f"git working tree not found at {destination}")
+                return False
+
             cmd = self._is_git_repo_cmd_
             out = self._exec_cmd(cmd, cwd=destination)
             self.logger.debug("check for git repository, cmd: {}, output: {}".format(cmd, out.decode()))


### PR DESCRIPTION
If the directory doesn't exist, there is no need to execute the `git rev-parse --is-inside-work-tree` command, we can just return false from the check command.  This silences an exception being thrown and logged on every initial run, thereby reducing support questions.  

Also adds a bit more info-level logging for the ubuntu provider