### PR TITLE
Create ./bin if it's missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ bootstrap: $(TEMP_DIR)  ## Download and install all tooling dependencies
 $(TEMP_DIR):
 	mkdir -p $(TEMP_DIR)
 
+$(BIN_DIR):
+	mkdir -p $(BIN_DIR)
 
 ## Development targets #################################
 


### PR DESCRIPTION
Previously, when running "make dev" for the first time, the build-grype and build-grype-db recipes would fail because they depend on "$(BIN_DIR)", but nothing was creating it. Add a simple recipe that creates this directory if it's missing.