### PR TITLE
Fix selecting providers to test by additional trigger globs

### DIFF
--- a/tests/quality/configure.py
+++ b/tests/quality/configure.py
@@ -338,6 +338,9 @@ def select_providers(cfg: Config, output_json: bool):
         for additional_provider in test.additional_providers:
             search_globs.append(f"src/vunnel/providers/{additional_provider.name}/**")
 
+        for g in test.additional_trigger_globs:
+            search_globs.append(g)
+
         for search_glob in search_globs:
             for changed_file in changed_files:
                 if fnmatch.fnmatch(changed_file, search_glob):


### PR DESCRIPTION
Currently only the standard provider globs are being considered for test detection of the quality gate, this PR fixes this behavior to additional consider the `additional-trigger-globs` configuration value.