### PR TITLE
chore: update AdvisorySummary and VendorAdvisory with FixedIn info

### DIFF
--- a/src/vunnel/providers/mariner/parser.py
+++ b/src/vunnel/providers/mariner/parser.py
@@ -122,7 +122,14 @@ class MarinerXmlFile:
         # mariner data might have "versions <= 3.2.1" is vulnerable.
         if state.evr.operation == LESS_THAN_OR_EQUAL_TO:
             version = "None"  # legacy API needs the string "None" instead of None
-        return FixedIn(Name=obj.name, NamespaceName=self.namespace_name(), VersionFormat="rpm", Version=version)
+        return FixedIn(
+            Name=obj.name,
+            NamespaceName=self.namespace_name(),
+            VersionFormat="rpm",
+            Version=version,
+            Module=None,
+            VendorAdvisory=None,
+        )
 
     def vulnerability_id(self, definition: Definition) -> str | None:
         if definition.metadata is None or definition.metadata.reference is None or definition.metadata.reference.ref_id is None:

--- a/src/vunnel/providers/sles/parser.py
+++ b/src/vunnel/providers/sles/parser.py
@@ -295,6 +295,8 @@ class Parser:
                             NamespaceName=feed_ns,
                             VersionFormat="rpm",
                             Version=pkg_version,
+                            Module=None,
+                            VendorAdvisory=None,
                         )
                     )
 

--- a/src/vunnel/utils/vulnerability.py
+++ b/src/vunnel/utils/vulnerability.py
@@ -49,6 +49,22 @@ def order_payload(payload, feed_type):
 
 
 @dataclass
+class AdvisorySummary:
+    ID: str
+    Link: str
+
+
+@dataclass
+class VendorAdvisory:
+    NoAdvisory: bool
+    AdvisorySummary: list[AdvisorySummary] | None
+
+    def __post_init__(self):
+        if self.AdvisorySummary is None:
+            self.AdvisorySummary = []
+
+
+@dataclass
 class FixedIn:
     """
     Class representing a fix record for return back to the service from the driver. The semantics of the version are:
@@ -61,6 +77,14 @@ class FixedIn:
     NamespaceName: str
     VersionFormat: str
     Version: str
+    Module: str | None
+    VendorAdvisory: VendorAdvisory | None
+
+    def __post_init__(self):
+        if self.Module is None:
+            self.Module = ""
+        if self.VendorAdvisory is None:
+            self.VendorAdvisory = VendorAdvisory(NoAdvisory=False, AdvisorySummary=None)
 
 
 @dataclass

--- a/tests/unit/providers/mariner/test_mariner.py
+++ b/tests/unit/providers/mariner/test_mariner.py
@@ -24,7 +24,16 @@ from vunnel.utils.vulnerability import Vulnerability, FixedIn
                     Severity="High",
                     Link="https://nvd.nist.gov/vuln/detail/CVE-2023-21980",
                     CVSS=[],
-                    FixedIn=[FixedIn(Name="mysql", NamespaceName="mariner:2.0", VersionFormat="rpm", Version="0:8.0.33-1.cm2")],
+                    FixedIn=[
+                        FixedIn(
+                            Name="mysql",
+                            NamespaceName="mariner:2.0",
+                            VersionFormat="rpm",
+                            Version="0:8.0.33-1.cm2",
+                            Module=None,
+                            VendorAdvisory=None,
+                        )
+                    ],
                     Metadata={},
                 ),
                 Vulnerability(
@@ -34,7 +43,16 @@ from vunnel.utils.vulnerability import Vulnerability, FixedIn
                     Severity="Medium",
                     Link="https://nvd.nist.gov/vuln/detail/CVE-2023-21977",
                     CVSS=[],
-                    FixedIn=[FixedIn(Name="mysql", NamespaceName="mariner:2.0", VersionFormat="rpm", Version="0:8.0.33-1.cm2")],
+                    FixedIn=[
+                        FixedIn(
+                            Name="mysql",
+                            NamespaceName="mariner:2.0",
+                            VersionFormat="rpm",
+                            Version="0:8.0.33-1.cm2",
+                            Module=None,
+                            VendorAdvisory=None,
+                        )
+                    ],
                     Metadata={},
                 ),
                 Vulnerability(
@@ -45,7 +63,14 @@ from vunnel.utils.vulnerability import Vulnerability, FixedIn
                     Link="https://nvd.nist.gov/vuln/detail/CVE-2022-3736",
                     CVSS=[],
                     FixedIn=[
-                        FixedIn(Name="bind", NamespaceName="mariner:2.0", VersionFormat="rpm", Version="None"),
+                        FixedIn(
+                            Name="bind",
+                            NamespaceName="mariner:2.0",
+                            VersionFormat="rpm",
+                            Version="None",
+                            Module=None,
+                            VendorAdvisory=None,
+                        ),
                     ],
                 ),
             ],

--- a/tests/unit/providers/sles/test_sles.py
+++ b/tests/unit/providers/sles/test_sles.py
@@ -148,6 +148,8 @@ class TestSLESParser:
                         NamespaceName="sles:15",
                         VersionFormat="rpm",
                         Version="0:4.12.14-150.72.1",
+                        Module=None,
+                        VendorAdvisory=None,
                     )
                 ],
                 Metadata={},
@@ -177,6 +179,8 @@ class TestSLESParser:
                         NamespaceName="sles:15.1",
                         VersionFormat="rpm",
                         Version="0:4.12.14-197.89.2",
+                        Module=None,
+                        VendorAdvisory=None,
                     )
                 ],
                 Metadata={},


### PR DESCRIPTION
Update dataclass representations for AdvisorySummary and VendorAdvisory so that Module and VendorAdvisory (both optional) could be added to the FixedIn dataclass specification.