### PR TITLE
fix: detect updated ubuntu eol labels

### DIFF
--- a/.github/scripts/update-dev-db.sh
+++ b/.github/scripts/update-dev-db.sh
@@ -27,7 +27,7 @@ ${GRYPE_DB} pull -v
 rm -rf build
 
 step "Building grype-db"
-${GRYPE_DB} build
+${GRYPE_DB} build -vvv
 
 step "Packaging grype-db"
 ${GRYPE_DB} package

--- a/tests/unit/providers/ubuntu/test_ubuntu.py
+++ b/tests/unit/providers/ubuntu/test_ubuntu.py
@@ -311,12 +311,18 @@ class TestUbuntuParser:
             (Patch(distro="foo", package="bar", status="ignored ftw", version="end-of-life now but something else before"), True),
             (Patch(distro="foo", package="bar", status="ignored", version="reached end-of-life"), True),
             (Patch(distro="foo", package="bar", status="ignored", version="end-of-life"), True),
+            (Patch(distro="foo", package="bar", status="ignored", version="end-of-life, was needed"), True),
             (Patch(distro="foo", package="bar", status="ignored", version="was pending now end-of-life"), True),
             (Patch(distro="foo", package="bar", status="ignored", version="end_of_life"), False),
             (Patch(distro="foo", package="bar", status="ignored", version="bleddyend-of-lifeas we know"), False),
             (Patch(distro="foo", package="bar", status="ignored", version="end times of all life"), False),
             (Patch(distro="foo", package="bar", status="some-invalid-state", version="end-of-life"), False),
             (Patch(distro="foo", package="bar", status="ignored", version="oh so end-of-lifed"), False),
+            (Patch(distro="foo", package="bar", status="ignored", version="end of standard support"), True),
+            (Patch(distro="foo", package="bar", status="ignored", version="out of standard support"), True),
+            (Patch(distro="foo", package="bar", status="ignored", version="end-of-standard-support"), True),
+            (Patch(distro="foo", package="bar", status="ignored", version="out-of-standard-support"), True),
+            (Patch(distro="foo", package="bar", status="ignored", version="end of standard support, was needed"), True),
         ],
     )
     def test_check_merge(self, patch: Patch, expected: bool):


### PR DESCRIPTION
The Ubuntu CVE Tracker repo made updates to the labelling used to indicate end of life so that unfixed vulnerabilities for older distros were no longer getting detected properly.  This updates the regex used to catch more of the existing (and additional historical labels) that were being missed.  This will require a full purge of existing workspace in order to pick up these historical vulns again