### PR TITLE
Update os in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   quality-gate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -56,7 +56,7 @@ jobs:
   tag:
     needs:
       - quality-gate
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: release
     permissions:
       contents: write
@@ -79,7 +79,7 @@ jobs:
   release-pypi:
     needs:
       - tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: release
     permissions:
       contents: read
@@ -100,7 +100,7 @@ jobs:
   release-docker:
     needs:
       - tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: release
     permissions:
       contents: read
@@ -128,7 +128,7 @@ jobs:
   release-github:
     needs:
       - tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: release
     permissions:
       contents: write


### PR DESCRIPTION
This makes the OS version consistent in the validations and release pipelines (important when sharing a cache between workflows). I can't seem to find a way to get the `ubuntu-20.04` name/version info from the github runner context (seems to not exist https://github.com/actions/runner/issues/2527 ) but that would be ideal to bake into the cache key as well.