### PR TITLE
feat: add mappings for ubuntu 23.04, 23.10

### DIFF
--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -81,6 +81,8 @@ ubuntu_version_names = {
     "impish": "21.10",
     "jammy": "22.04",
     "kinetic": "22.10",
+    "lunar": "23.04",
+    "mantic": "23.10",
 }
 
 # driver workspace


### PR DESCRIPTION
Adds the necessary mappings for Ubuntu 23.04 (Lunar Lobster), and Ubuntu 23.10 (Mantic Minotaur)