### PR TITLE
feat: bump ubuntu provider to v2 to ensure rebuild from clean workspace after upstream data changes

### DIFF
--- a/src/vunnel/providers/ubuntu/__init__.py
+++ b/src/vunnel/providers/ubuntu/__init__.py
@@ -29,6 +29,9 @@ class Config:
 
 
 class Provider(provider.Provider):
+    # Bumping to version 2 because upstream changed the values of some data which requires reprocessing all of the history
+    __version__ = 2
+
     def __init__(self, root: str, config: Config | None = None):
         if not config:
             config = Config()


### PR DESCRIPTION
This ensures that existing workspace state will not be considered so that all of history is reprocessed to pick up the necessary changes from https://github.com/anchore/vunnel/pull/222