### PR TITLE
feat: preserve prior results longer with sqlite writer

### DIFF
--- a/src/vunnel/provider.py
+++ b/src/vunnel/provider.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from . import result, workspace
+from .result import ResultStatePolicy
 
 
 class OnErrorAction(str, enum.Enum):
@@ -23,15 +24,6 @@ class OnErrorAction(str, enum.Enum):
 class InputStatePolicy(str, enum.Enum):
     KEEP = "keep"
     DELETE = "delete"
-
-    def __repr__(self) -> str:
-        return self.value
-
-
-class ResultStatePolicy(str, enum.Enum):
-    KEEP = "keep"
-    DELETE = "delete"
-    DELETE_BEFORE_WRITE = "delete-before-write"  # treat like "KEEP" in error cases
 
     def __repr__(self) -> str:
         return self.value
@@ -215,8 +207,8 @@ class Provider(abc.ABC):
     def results_writer(self, **kwargs: Any) -> result.Writer:
         return result.Writer(
             workspace=self.workspace,
+            result_state_policy=self.runtime_cfg.existing_results,
             logger=self.logger,
             store_strategy=self.runtime_cfg.result_store,
-            clear_results_before_writing=self.runtime_cfg.existing_results == ResultStatePolicy.DELETE_BEFORE_WRITE,
             **kwargs,
         )

--- a/src/vunnel/providers/alpine/__init__.py
+++ b/src/vunnel/providers/alpine/__init__.py
@@ -17,7 +17,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/amazon/__init__.py
+++ b/src/vunnel/providers/amazon/__init__.py
@@ -18,7 +18,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/chainguard/__init__.py
+++ b/src/vunnel/providers/chainguard/__init__.py
@@ -16,7 +16,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/debian/__init__.py
+++ b/src/vunnel/providers/debian/__init__.py
@@ -18,7 +18,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/github/__init__.py
+++ b/src/vunnel/providers/github/__init__.py
@@ -20,7 +20,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/mariner/__init__.py
+++ b/src/vunnel/providers/mariner/__init__.py
@@ -16,7 +16,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.KEEP,
+            existing_results=result.ResultStatePolicy.KEEP,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -16,7 +16,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.KEEP,
+            existing_results=result.ResultStatePolicy.KEEP,
         ),
     )
     request_timeout: int = 125
@@ -44,7 +44,7 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        if self.config.runtime.skip_if_exists and config.runtime.existing_results != provider.ResultStatePolicy.KEEP:
+        if self.config.runtime.skip_if_exists and config.runtime.existing_results != result.ResultStatePolicy.KEEP:
             raise ValueError(
                 "if 'skip_if_exists' is set then 'runtime.existing_results' must be 'keep' "
                 "(otherwise incremental updates will fail)",

--- a/src/vunnel/providers/oracle/__init__.py
+++ b/src/vunnel/providers/oracle/__init__.py
@@ -17,7 +17,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -17,7 +17,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.KEEP,
+            existing_results=result.ResultStatePolicy.KEEP,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/sles/__init__.py
+++ b/src/vunnel/providers/sles/__init__.py
@@ -17,7 +17,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/wolfi/__init__.py
+++ b/src/vunnel/providers/wolfi/__init__.py
@@ -17,7 +17,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=provider.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/tests/unit/test_result.py
+++ b/tests/unit/test_result.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
 import datetime
+import pytest
+import os
+import shutil
 
 from vunnel import result, schema, workspace
 
 
-def test_result_writer_flat_file(tmpdir):
-    root = tmpdir
-    ws = workspace.Workspace(root=root, name="nvd", create=True)
+@pytest.fixture()
+def ws(tmpdir) -> workspace.Workspace:
+    return workspace.Workspace(root=tmpdir, name="nvd", create=True)
+
+
+@pytest.fixture()
+def flat_file_existing_workspace(ws: workspace.Workspace) -> workspace.Workspace:
     store_strategy = result.StoreStrategy.FLAT_FILE
-    with result.Writer(ws, store_strategy=store_strategy) as writer:
+    with result.Writer(ws, result_state_policy=result.ResultStatePolicy.DELETE, store_strategy=store_strategy) as writer:
         writer.write(
             identifier="dummy-result-1",
             schema=schema.OSSchema(),
@@ -20,40 +27,200 @@ def test_result_writer_flat_file(tmpdir):
             identifier="dummy-result-2",
             schema=schema.OSSchema(),
             payload={"Vulnerability": {"dummy": "result-2"}},
+        )
+
+    ws.record_state(timestamp=datetime.datetime.now(), urls=[], store=store_strategy, version=1)
+    return ws
+
+
+@pytest.fixture()
+def sqlite_existing_workspace(ws: workspace.Workspace) -> workspace.Workspace:
+    store_strategy = result.StoreStrategy.SQLITE
+    with result.Writer(
+        ws, result_state_policy=result.ResultStatePolicy.DELETE_BEFORE_WRITE, store_strategy=store_strategy
+    ) as writer:
+        writer.write(
+            identifier="dummy-result-1",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-1"}},
+        )
+
+        writer.write(
+            identifier="dummy-result-2",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-2"}},
+        )
+
+    ws.record_state(timestamp=datetime.datetime.now(), urls=[], store=store_strategy, version=1)
+    return ws
+
+
+@pytest.fixture()
+def sqlite_existing_workspace_with_partial_results(sqlite_existing_workspace: workspace.Workspace) -> workspace.Workspace:
+    shutil.copy2(
+        os.path.join(sqlite_existing_workspace.results_path, "results.db"),
+        os.path.join(sqlite_existing_workspace.results_path, "results.db.tmp"),
+    )
+    sqlite_existing_workspace.record_state(
+        timestamp=datetime.datetime.now(), urls=[], store=result.StoreStrategy.SQLITE, version=1
+    )
+    assert len(list(sqlite_existing_workspace.state().result_files(sqlite_existing_workspace.path))) == 2
+    return sqlite_existing_workspace
+
+
+@pytest.mark.parametrize(
+    "result_state_policy,expected_files,expected_result_count",
+    [
+        (
+            result.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            [
+                workspace.File(digest="ed801e4317631f7e", path="results/dummy-result-3.json", algorithm="xxh64"),
+                workspace.File(digest="9838099ec6ec3d2f", path="results/dummy-result-4.json", algorithm="xxh64"),
+            ],
+            2,
+        ),
+        (
+            result.ResultStatePolicy.KEEP,
+            [
+                workspace.File(digest="15a391c356b028bd", path="results/dummy-result-1.json", algorithm="xxh64"),
+                workspace.File(digest="773ff3e88c39e9db", path="results/dummy-result-2.json", algorithm="xxh64"),
+                workspace.File(digest="ed801e4317631f7e", path="results/dummy-result-3.json", algorithm="xxh64"),
+                workspace.File(digest="9838099ec6ec3d2f", path="results/dummy-result-4.json", algorithm="xxh64"),
+            ],
+            4,
+        ),
+    ],
+)
+def test_result_writer_flat_file(
+    flat_file_existing_workspace: workspace.Workspace,
+    result_state_policy: result.ResultStatePolicy,
+    expected_files: list[workspace.File],
+    expected_result_count: int,
+):
+    ws = flat_file_existing_workspace
+    store_strategy = result.StoreStrategy.FLAT_FILE
+    with result.Writer(ws, result_state_policy=result_state_policy, store_strategy=store_strategy) as writer:
+        writer.write(
+            identifier="dummy-result-3",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-3"}},
+        )
+
+        writer.write(
+            identifier="dummy-result-4",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-4"}},
+        )
+
+        writer.write(
+            identifier="dummy-result-4",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-4"}},
         )
 
     ws.record_state(timestamp=datetime.datetime.now(), urls=[], store=store_strategy, version=1)
 
     state = ws.state()
 
-    assert list(state.result_files(ws.path)) == [
-        workspace.File(digest="15a391c356b028bd", path="results/dummy-result-1.json", algorithm="xxh64"),
-        workspace.File(digest="773ff3e88c39e9db", path="results/dummy-result-2.json", algorithm="xxh64"),
-    ]
-    assert state.result_count(ws.path) == 2
+    assert list(state.result_files(ws.path)) == expected_files
+    assert state.result_count(ws.path) == expected_result_count
 
 
-def test_result_writer_sqlite(tmpdir):
-    root = tmpdir
-    ws = workspace.Workspace(root=root, name="nvd", create=True)
+@pytest.mark.parametrize(
+    "result_state_policy,expected_file_count,expected_result_count",
+    [
+        (
+            result.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            1,
+            2,
+        ),
+        (
+            result.ResultStatePolicy.KEEP,
+            1,
+            4,
+        ),
+    ],
+)
+def test_result_writer_sqlite(
+    sqlite_existing_workspace: workspace.Workspace,
+    result_state_policy: result.ResultStatePolicy,
+    expected_file_count: int,
+    expected_result_count: int,
+):
+    ws = sqlite_existing_workspace
     store_strategy = result.StoreStrategy.SQLITE
-    with result.Writer(ws, store_strategy=store_strategy) as writer:
+    with result.Writer(ws, result_state_policy=result_state_policy, store_strategy=store_strategy) as writer:
         writer.write(
-            identifier="dummy-result-1",
+            identifier="dummy-result-3",
             schema=schema.OSSchema(),
-            payload={"Vulnerability": {"dummy": "result-1"}},
+            payload={"Vulnerability": {"dummy": "result-3"}},
         )
 
         writer.write(
-            identifier="dummy-result-2",
+            identifier="dummy-result-4",
             schema=schema.OSSchema(),
-            payload={"Vulnerability": {"dummy": "result-2"}},
+            payload={"Vulnerability": {"dummy": "result-4"}},
+        )
+
+        writer.write(
+            identifier="dummy-result-4",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-4"}},
         )
 
     ws.record_state(timestamp=datetime.datetime.now(), urls=[], store=store_strategy, version=1)
-
     state = ws.state()
 
     # note: since the hash changes on each test run, just confirm the result file count, not the extra metadata
-    assert len(list(state.result_files(ws.path))) == 1
-    assert state.result_count(ws.path) == 2
+    assert len(list(state.result_files(ws.path))) == expected_file_count
+    assert state.result_count(ws.path) == expected_result_count
+
+
+@pytest.mark.parametrize(
+    "result_state_policy,expected_file_count,expected_result_count",
+    [
+        (
+            result.ResultStatePolicy.DELETE_BEFORE_WRITE,
+            1,
+            2,
+        ),
+        (
+            result.ResultStatePolicy.KEEP,
+            1,
+            4,
+        ),
+    ],
+)
+def test_result_writer_sqlite_with_partial_result(
+    sqlite_existing_workspace_with_partial_results: workspace.Workspace,
+    result_state_policy: result.ResultStatePolicy,
+    expected_file_count: int,
+    expected_result_count: int,
+):
+    ws = sqlite_existing_workspace_with_partial_results
+    store_strategy = result.StoreStrategy.SQLITE
+    with result.Writer(ws, result_state_policy=result_state_policy, store_strategy=store_strategy) as writer:
+        writer.write(
+            identifier="dummy-result-3",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-3"}},
+        )
+
+        writer.write(
+            identifier="dummy-result-4",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-4"}},
+        )
+
+        writer.write(
+            identifier="dummy-result-4",
+            schema=schema.OSSchema(),
+            payload={"Vulnerability": {"dummy": "result-4"}},
+        )
+
+    ws.record_state(timestamp=datetime.datetime.now(), urls=[], store=store_strategy, version=1)
+    state = ws.state()
+
+    # note: since the hash changes on each test run, just confirm the result file count, not the extra metadata
+    assert len(list(state.result_files(ws.path))) == expected_file_count
+    assert state.result_count(ws.path) == expected_result_count


### PR DESCRIPTION
When using the sqlite writer, preserve the prior results as long as possible by writing the new results to a temp file and then renaming it after everything is successful.