### PR TITLE
fix: add retry on alpine and mariner url fetches

### DIFF
--- a/src/vunnel/providers/mariner/parser.py
+++ b/src/vunnel/providers/mariner/parser.py
@@ -9,6 +9,7 @@ from xsdata.formats.dataclass.parsers import XmlParser
 from xsdata.formats.dataclass.parsers.config import ParserConfig
 
 from vunnel.providers.mariner.model import Definition, RpminfoObject, RpminfoState, RpminfoTest
+from vunnel.utils import retry_with_backoff
 from vunnel.utils.vulnerability import FixedIn, Vulnerability
 
 if TYPE_CHECKING:
@@ -184,6 +185,7 @@ class Parser:
     def _download(self) -> list[str]:
         return [self._download_version(v) for v in self.allow_versions]
 
+    @retry_with_backoff()
     def _download_version(self, version: str) -> str:
         filename = MARINER_URL_FILENAME.format(version)
         url = MARINER_URL_BASE.format(filename)


### PR DESCRIPTION
Adds additional retry with backoff logic on url fetches for the `alpine` and `mariner` providers

There was already a retry on parsing the alpine security db for a specific release, but there wasn't a retry on fetching the landing page to parse the release-specific links from.