### PR TITLE
Fix grype1393

### DIFF
--- a/src/vunnel/providers/mariner/__init__.py
+++ b/src/vunnel/providers/mariner/__init__.py
@@ -16,7 +16,7 @@ class Config:
     runtime: provider.RuntimeConfig = field(
         default_factory=lambda: provider.RuntimeConfig(
             result_store=result.StoreStrategy.SQLITE,
-            existing_results=result.ResultStatePolicy.KEEP,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
     request_timeout: int = 125

--- a/src/vunnel/providers/mariner/parser.py
+++ b/src/vunnel/providers/mariner/parser.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 LESS_THAN_OR_EQUAL_TO = "less than or equal"
 
+IGNORED_PATCHABLE_VALUES = ["Not Applicable"]
 
 class MarinerXmlFile:
     def __init__(self, oval_file_path: str, logger: logging.Logger):
@@ -146,6 +147,8 @@ class MarinerXmlFile:
         for d in self.definitions:
             if d.metadata is None or d.metadata.severity is None:
                 self.logger.warning("skipping definition because severity could not be found")
+                continue
+            if d.metadata and d.metadata.patchable and d.metadata.patchable in IGNORED_PATCHABLE_VALUES:
                 continue
             if d.metadata.description:
                 pass

--- a/src/vunnel/providers/mariner/parser.py
+++ b/src/vunnel/providers/mariner/parser.py
@@ -22,6 +22,7 @@ LESS_THAN_OR_EQUAL_TO = "less than or equal"
 
 IGNORED_PATCHABLE_VALUES = ["Not Applicable"]
 
+
 class MarinerXmlFile:
     def __init__(self, oval_file_path: str, logger: logging.Logger):
         parser_config = ParserConfig(
@@ -150,8 +151,6 @@ class MarinerXmlFile:
                 continue
             if d.metadata and d.metadata.patchable and d.metadata.patchable in IGNORED_PATCHABLE_VALUES:
                 continue
-            if d.metadata.description:
-                pass
             link = ""
             if d.metadata.reference and d.metadata.reference.ref_url:
                 link = d.metadata.reference.ref_url

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -202,7 +202,7 @@ providers:
     request_timeout: 125
     runtime:
       existing_input: keep
-      existing_results: keep
+      existing_results: delete-before-write
       on_error:
         action: fail
         input: keep

--- a/tests/unit/providers/mariner/test-fixtures/mariner-truncated-2.0-oval.xml
+++ b/tests/unit/providers/mariner/test-fixtures/mariner-truncated-2.0-oval.xml
@@ -7,6 +7,22 @@
     <oval:content_version>1683806521</oval:content_version>
   </generator>
   <definitions>
+    <definition class="vulnerability" id="oval:com.microsoft.cbl-mariner:def:13348" version="0">
+      <metadata>
+        <title>CVE-2023-0687 affecting package glibc 2.35-4</title>
+        <affected family="unix">
+          <platform>CBL-Mariner</platform>
+        </affected>
+        <reference ref_id="CVE-2023-0687" ref_url="https://nvd.nist.gov/vuln/detail/CVE-2023-0687" source="CVE"/>
+          <patchable>Not Applicable</patchable>
+        <advisory_id>13348</advisory_id>
+        <severity>Critical</severity>
+        <description>CVE-2023-0687 affecting package glibc 2.35-4. This CVE either no longer is or was never applicable.</description>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="Package glibc is installed with version 2.35-4 or earlier" test_ref="oval:com.microsoft.cbl-mariner:tst:13348000"/>
+      </criteria>
+    </definition>
     <definition class="vulnerability" id="oval:com.microsoft.cbl-mariner:def:26220" version="1">
       <metadata>
         <title>CVE-2023-21980 affecting package mysql 8.0.32-1</title>
@@ -59,6 +75,10 @@
     </definition>
   </definitions>
   <tests>
+    <linux-def:rpminfo_test check="at least one" comment="Package glibc is installed with version 2.35-4 or earlier" id="oval:com.microsoft.cbl-mariner:tst:13348000" version="0">
+      <linux-def:object object_ref="oval:com.microsoft.cbl-mariner:obj:13348001"/>
+      <linux-def:state state_ref="oval:com.microsoft.cbl-mariner:ste:13348002"/>
+    </linux-def:rpminfo_test>
     <linux-def:rpminfo_test check="at least one" comment="Package mysql is earlier than 8.0.33-1, affected by CVE-2023-21977" id="oval:com.microsoft.cbl-mariner:tst:26178000" version="1">
       <linux-def:object object_ref="oval:com.microsoft.cbl-mariner:obj:26178001"/>
       <linux-def:state state_ref="oval:com.microsoft.cbl-mariner:ste:26178002"/>
@@ -73,7 +93,10 @@
     </linux-def:rpminfo_test>
   </tests>
   <objects>
-      <linux-def:rpminfo_object id="oval:com.microsoft.cbl-mariner:obj:26178001" version="1">
+    <linux-def:rpminfo_object id="oval:com.microsoft.cbl-mariner:obj:13348001" version="0">
+      <linux-def:name>glibc</linux-def:name>
+    </linux-def:rpminfo_object>
+    <linux-def:rpminfo_object id="oval:com.microsoft.cbl-mariner:obj:26178001" version="1">
       <linux-def:name>mysql</linux-def:name>
     </linux-def:rpminfo_object>
         <linux-def:rpminfo_object id="oval:com.microsoft.cbl-mariner:obj:26220001" version="1">
@@ -84,7 +107,10 @@
     </linux-def:rpminfo_object>
   </objects>
   <states>
-      <linux-def:rpminfo_state id="oval:com.microsoft.cbl-mariner:ste:26178002" version="1">
+    <linux-def:rpminfo_state id="oval:com.microsoft.cbl-mariner:ste:13348002" version="0">
+      <linux-def:evr datatype="evr_string" operation="less than or equal">0:2.35-4.cm2</linux-def:evr>
+    </linux-def:rpminfo_state>
+    <linux-def:rpminfo_state id="oval:com.microsoft.cbl-mariner:ste:26178002" version="1">
       <linux-def:evr datatype="evr_string" operation="less than">0:8.0.33-1.cm2</linux-def:evr>
     </linux-def:rpminfo_state>
         <linux-def:rpminfo_state id="oval:com.microsoft.cbl-mariner:ste:26220002" version="1">


### PR DESCRIPTION
Fixes https://github.com/anchore/grype/issues/1393

Fix Mariner provider to stop including CVEs that are "Not Applicable." Additionally, fix the data retention to regenerate the Mariner database, rather than appending to it, since we are downloading entire OVAL files every time.