### PR TITLE
fix: always include rhel out of support entries when no other fix info available for any other releases

### DIFF
--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -662,6 +662,9 @@ class Parser:
                         break
             return merged
 
+        for oos in out_of_support:
+            affected.append(oos)
+
         return affected
 
     def _parse_cve(self, cve_id, content):

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -615,7 +615,15 @@ class TestParser:
                     version=None,
                 )
             ],
-            [],
+            [
+                FixedIn(
+                    module=None,
+                    platform="7",
+                    package="foobar",
+                    advisory=None,
+                    version=None,
+                )
+            ],
         ),
         (
             [],


### PR DESCRIPTION
Out of support entries from the RHEL provider should always be included as affected if there is no other fixed-in or affected information from other releases