### PR TITLE
chore: bump crane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PUBLISH_CMD = poetry publish --build -n
 # Tool versions #################################
 CHRONICLE_VERSION = v0.6.0
 GLOW_VERSION = v1.4.1
-CRANE_VERSION = v0.12.1
+CRANE_VERSION = v0.16.1
 
 # Formatting variables #################################
 BOLD := $(shell tput -T linux bold)


### PR DESCRIPTION
Previous crane version say installation errors when installed with go 1.20.7:

```
$ go version
go version go1.20.7 darwin/arm64
$ make bootstrap
mkdir -p ./.tmp
curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b ./.tmp/ v0.6.0
anchore/chronicle info checking GitHub for tag 'v0.6.0'
anchore/chronicle info found version: 0.6.0 for v0.6.0/Darwin/all
anchore/chronicle info installed ./.tmp//chronicle
GOBIN="/Users/willmurphy/work/vunnel-clean/.tmp" go install github.com/charmbracelet/glow@v1.4.1
GOBIN="/Users/willmurphy/work/vunnel-clean/.tmp" go install github.com/google/go-containerregistry/cmd/crane@v0.12.1
# golang.org/x/sys/unix
../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/ioctl.go:11:2: "os" imported and not used
make: *** [bootstrap] Error 1
```