### PR TITLE
chore: improve unit tests in debian provider

### DIFF
--- a/tests/unit/providers/debian/test_debian.py
+++ b/tests/unit/providers/debian/test_debian.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os.path
 import shutil
+from unittest.mock import MagicMock
 
 import pytest
 from vunnel import result, workspace
@@ -68,6 +69,7 @@ class TestParser:
 
     def test_normalize_json(self, tmpdir, helpers, disable_get_requests):
         subject = parser.Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
+        subject.logger = MagicMock()
 
         dsa_mock_data_path = helpers.local_dir(self._sample_dsa_data_)
         json_mock_data_path = helpers.local_dir(self._sample_json_data_)
@@ -88,6 +90,7 @@ class TestParser:
             assert all(x.get("Vulnerability", {}).get("Name") for x in vuln_dict.values())
 
             assert all(x.get("Vulnerability", {}).get("Description") is not None for x in vuln_dict.values())
+        assert not subject.logger.exception.called, "no exceptions should be logged"
 
     def test_get_legacy_records(self, tmpdir, helpers, disable_get_requests):
         subject = parser.Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))


### PR DESCRIPTION
The provider is intentionally resilient to malformed records, and implements this resilience by logging and continuing on when any exception is thrown. However, this prevents the unit tests from many errors in the implementation of the provider. Therefore, spy on the provider and fail unit tests if it is logging exceptions.

Part of https://github.com/anchore/vunnel/issues/309, but doesn't resolve it.