### PR TITLE
Update vunnel list output in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ $ vunnel list
 
 alpine
 amazon
-centos
+chainguard
 debian
 github
+mariner
 nvd
 oracle
 rhel


### PR DESCRIPTION
I found centos being listed in the readme but not in my output a bit confusing, so updated the list to match what I got today.