### PR TITLE
fix: adjust retry timeout for NVD requests

### DIFF
--- a/src/vunnel/providers/nvd/api.py
+++ b/src/vunnel/providers/nvd/api.py
@@ -139,7 +139,9 @@ class NvdAPI:
 
             index += results_per_page
 
-    @utils.retry_with_backoff()
+    # NVD rate-limiting is detailed at https://nvd.nist.gov/developers/start-here and currently resets on a 30 second
+    # rolling window, so setting retry to start trying again after 30 seconds.
+    @utils.retry_with_backoff(backoff_in_seconds=30)
     def _request(self, url: str, parameters: dict[str, str], headers: dict[str, str]) -> requests.Response:
         # this is to prevent from encoding the ':' in any timestamps passed
         # (e.g. prevent pubStartDate=2002-01-01T00%3A00%3A00 , want pubStartDate=2002-01-01T00:00:00)


### PR DESCRIPTION
Adjusts the NVD retry timeout to align with the current 30 second rolling rate limit window

Current rate-limits from https://nvd.nist.gov/developers/start-here
```
NIST firewall rules put in place to prevent denial of service attacks can thwart your application if it exceeds a predetermined rate limit. The public rate limit (without an API key) is 5 requests in a rolling 30 second window; the rate limit with an API key is 50 requests in a rolling 30 second window. Requesting an API key significantly raises the number of requests that can be made in a given time frame. However, it is still recommended that your application sleeps for several seconds between requests so that legitimate requests are not denied, and all requests are responded to in sequence.
```