### PR TITLE
Fix nightly quality gate notification

### DIFF
--- a/.github/workflows/nightly-quality-gate.yaml
+++ b/.github/workflows/nightly-quality-gate.yaml
@@ -69,10 +69,21 @@ jobs:
     needs: validate-provider
     if: ${{ always() && !cancelled() }}
     steps:
+      # based on https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+      # the valid result values are: success, failure, cancelled, skipped
       - run: |
           echo "Validations Status: ${{ needs.run-provider-validation.result }}"
-          if [ "${{ needs.run-provider-validation.result }}" == "failure" ]; then
-            echo "Quality gate failed!"
+          if [ "${{ needs.run-provider-validation.result }}" != "success" ]; then
+            echo "🔴 Quality gate FAILED! 😭"
             exit 1
           fi
-          echo "Quality gate passed!"
+          echo "🟢 Quality gate passed!"
+
+      - uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #v3.15.1
+        if: ${{ failure() }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow,action,eventName
+          text: "Vunnel nightly quality gate has failed: https://github.com/anchore/vunnel/actions/workflows/nightly-quality-gate.yaml"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}

--- a/.github/workflows/pr-quality-gate.yaml
+++ b/.github/workflows/pr-quality-gate.yaml
@@ -97,12 +97,3 @@ jobs:
             exit 1
           fi
           echo "🟢 Quality gate passed! (all tests passed)"
-
-      - uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #v3.15.1
-        if: ${{ failure() }}
-        with:
-          status: ${{ job.status }}
-          fields: repo,workflow,action,eventName
-          text: "Vunnel nightly quality gate has failed: https://github.com/anchore/vunnel/actions/workflows/nightly-quality-gate.yaml"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}


### PR DESCRIPTION
There are a couple problems:
- The gate logic was explicitly checking if there was a failure instead of checking explicitly for success (and failing otherwise)
- The notification was on the PR gate, not the nightly gate