### PR TITLE
chore: add ubuntu 23.10 to expected vuln namespaces

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -241,6 +241,7 @@ tests:
       - ubuntu:distro:ubuntu:22.04
       - ubuntu:distro:ubuntu:22.10
       - ubuntu:distro:ubuntu:23.04
+      - ubuntu:distro:ubuntu:23.10
 
   - provider: wolfi
     additional_providers:


### PR DESCRIPTION
Looks like we've finally got some vuln data flowing in for ubuntu 23.10, so we need to get it added to the expected vuln namespaces for the ubuntu provider