### PR TITLE
fix: ignore trailing slash in GH CVSS strings

### DIFF
--- a/src/vunnel/providers/github/parser.py
+++ b/src/vunnel/providers/github/parser.py
@@ -548,6 +548,7 @@ class NodeParser(dict):
 
     def _make_cvss(self, cvss_vector: str, vulnerability_id: str) -> CVSS | None:
         try:
+            cvss_vector = cvss_vector.removesuffix("/")
             cvss3_obj = CVSS3(cvss_vector)
 
             cvss_object = CVSS(

--- a/tests/unit/providers/github/test_github.py
+++ b/tests/unit/providers/github/test_github.py
@@ -200,6 +200,19 @@ class TestNodeParser:
         assert result["CVSS"] == expected
         assert result.CVSS == expected
 
+    def test_trailing_slash_cvss(self, node):
+        node["cvss"]["vectorString"] = node["cvss"]["vectorString"] + "/"
+        result = parser.NodeParser(node).parse()
+        expected = CVSS(
+            version="3.0",
+            vector_string="CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            base_metrics=CVSSBaseMetrics(base_score=9.8, exploitability_score=3.9, impact_score=5.9, base_severity="Critical"),
+            status="N/A",
+        )
+
+        assert result["CVSS"] == expected
+        assert result.CVSS == expected
+
     def test_gets_published(self, node):
         result = parser.NodeParser(node).parse()
         result["published"] = "2020-02-04T03:07:31Z"


### PR DESCRIPTION
Sometimes these strings have a trailing slash; ignore the trailing slash rather than throwing away the entire CVSS info because of it.

I think that an otherwise well-formed CVSS that happens to have a `/` on the end shouldn't be thrown away just because of the `/`.

Previously, there were a lot of log entries like this:

``` log
[ERROR] error transforming CVSS vector CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:N/, skipping it for GHSA-gr4j-r575-g665
Traceback (most recent call last):
  File "/home/runner/work/vunnel/vunnel/src/vunnel/providers/github/parser.py", line 551, in _make_cvss
    cvss3_obj = CVSS3(cvss_vector)
  File "/home/runner/.virtualenvs/vunnel-A95CY2kd-py3.10/lib/python3.10/site-packages/cvss/cvss3.py", line 114, in __init__
    self.parse_vector()
  File "/home/runner/.virtualenvs/vunnel-A95CY2kd-py3.10/lib/python3.10/site-packages/cvss/cvss3.py", line 133, in parse_vector
```