### PR TITLE
Revert github namespace selection

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -114,6 +114,11 @@ tests:
       # we need to convert GHSAs to CVEs so that we can filter based on date
       - name: nvd
         use_cache: true
+      # note: the base images for most of the github test images are alpine and we are including the NVD namespace.
+      - name: alpine
+        use_cache: true
+      - name: wolfi
+        use_cache: true
     images:
       - docker.io/anchore/test_images:java-56d52bc@sha256:10008791acbc5866de04108746a02a0c4029ce3a4400a9b3dad45d7f2245f9da
       - docker.io/anchore/test_images:npm-56d52bc@sha256:ba42ded8613fc643d407a050faf5ab48cfb405ad3ef2015bf6feeb5dff44738d


### PR DESCRIPTION
Reverts #354 and adds additional quality gate triggers, so if the quality gate code changes then all providers must be tested.

Investigating this also lead to a conclusion about how we measure results, captured in https://github.com/anchore/vunnel/issues/359
