### PR TITLE
Store quality gate state on failure

### DIFF
--- a/.github/actions/quality-gate/action.yaml
+++ b/.github/actions/quality-gate/action.yaml
@@ -15,7 +15,48 @@ runs:
       working-directory: tests/quality
       run: poetry run make capture provider=${{ inputs.provider }}
 
+
     - name: Validate provider results
       shell: bash
       working-directory: tests/quality
       run: poetry run make validate
+
+    - name: Archive the provider state (${{ inputs.provider }})
+      if: ${{ failure() }}
+      shell: bash
+      run: tar -czvf qg-capture-state-${{ inputs.provider }}.tar.gz -C tests/quality --exclude tools --exclude labels .yardstick.yaml .yardstick
+
+    - name: Upload the provider state archive (${{ inputs.provider }})
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: qg-capture-state-${{ inputs.provider }}
+        path: qg-capture-state-${{ inputs.provider }}.tar.gz
+
+    - name: Show instructions to debug
+      if: ${{ failure() }}
+      shell: bash
+      run: |
+        ARCHIVE_NAME=qg-capture-state-${{ inputs.provider }}.zip
+        WORKFLOW_RUN_LINK=https://github.com/anchore/vunnel/actions/runs/${{ github.run_id }}
+
+        cat << EOF >> $GITHUB_STEP_SUMMARY
+        ## Troubleshooting ${{ inputs.provider }} failed run
+
+        Download the archive from CI for the failed provider: $WORKFLOW_RUN_LINK
+        Specifically the artifact: $ARCHIVE_NAME
+
+        Then run the following commands to debug:
+        ```bash
+        # copy the archive to the tests/quality directory
+        cd tests/quality
+        tar -xzvf $ARCHIVE_NAME
+        ```
+
+        Now you can debug the provider with yardstick:
+        ```bash
+        poetry shell
+        yardstick result list
+        yardstick label explore
+        ```
+        EOF

--- a/.github/actions/quality-gate/action.yaml
+++ b/.github/actions/quality-gate/action.yaml
@@ -37,26 +37,25 @@ runs:
       if: ${{ failure() }}
       shell: bash
       run: |
-        ARCHIVE_NAME=qg-capture-state-${{ inputs.provider }}.zip
-        WORKFLOW_RUN_LINK=https://github.com/anchore/vunnel/actions/runs/${{ github.run_id }}
+        ARCHIVE_BASENAME=qg-capture-state-${{ inputs.provider }}
+        ARCHIVE_NAME=$ARCHIVE_BASENAME.zip
 
         cat << EOF >> $GITHUB_STEP_SUMMARY
-        ## Troubleshooting ${{ inputs.provider }} failed run
+        ## Troubleshooting '${{ inputs.provider }}' failed run
 
-        Download the archive from CI for the failed provider: $WORKFLOW_RUN_LINK
-        Specifically the artifact: $ARCHIVE_NAME
+        Download the artifact from this workflow run: \`$ARCHIVE_NAME\`
 
         Then run the following commands to debug:
-        ```bash
+        \`\`\`bash
         # copy the archive to the tests/quality directory
         cd tests/quality
-        tar -xzvf $ARCHIVE_NAME
-        ```
+        unzip $ARCHIVE_NAME && tar -xzf $ARCHIVE_BASENAME.tar.gz
+        \`\`\`
 
         Now you can debug the provider with yardstick:
-        ```bash
+        \`\`\`bash
         poetry shell
         yardstick result list
         yardstick label explore
-        ```
+        \`\`\`
         EOF

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .grype
 .grype-db
 *.tar.gz
+*.zip
 
 /bin
 /data/


### PR DESCRIPTION
When there is a quality gate failure it tends to take a lot of time to reproduce the state in CI locally to then go and introduce more labels or dive deeper into the raw data. With this PR the `.yardstick` and `.yardstick.yaml` data is captured as a CI artifact automatically on failure with instructions on how to use it:

Example run: https://github.com/anchore/vunnel/actions/runs/6657772557

<img width="773" alt="Screenshot 2023-10-26 at 1 56 26 PM" src="https://github.com/anchore/vunnel/assets/590471/07d00202-53f4-4751-80c1-f354cfd39060">

Fixes #360 