### PR TITLE
chore: remove file noqa for utils oval parser

### DIFF
--- a/src/vunnel/utils/oval_parser.py
+++ b/src/vunnel/utils/oval_parser.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from __future__ import annotations
 
 import copy
@@ -47,7 +46,7 @@ class Config:
     ns_format = None
 
 
-def parse(dest_file: str, config: Config, vuln_dict: dict | None = None):
+def parse(dest_file: str, config: Config, vuln_dict: dict | None = None):  # noqa: C901
     """
     Parse the oval file and return a dictionary with tuple (ID, namespace) as the key
     and tuple (version, vulnerability-dictionary) as the value
@@ -61,7 +60,7 @@ def parse(dest_file: str, config: Config, vuln_dict: dict | None = None):
         logger.warning("Invalid config found, expected an instance of Config class")
         raise TypeError("Invalid config")
 
-    logger.debug("Parsing {}".format(dest_file))
+    logger.debug("Parsing {}".format(dest_file))  # noqa: UP032, G001
 
     if not vuln_dict:
         vuln_dict = {}
@@ -73,7 +72,7 @@ def parse(dest_file: str, config: Config, vuln_dict: dict | None = None):
         if dest_file.endswith(".gz"):
             opener = gzip.open
 
-        with opener(dest_file, "rb") as f:
+        with opener(dest_file, "rb") as f:  # noqa: F841
             for event, element in ET.iterparse(dest_file, events=("start", "end")):
                 # gather definition
                 if event == "start" and re.search(config.tag_pattern, element.tag).group(1) == "definition":
@@ -100,7 +99,7 @@ def parse(dest_file: str, config: Config, vuln_dict: dict | None = None):
     return vuln_dict
 
 
-def _process_definition(def_element, vuln_dict, config: Config):
+def _process_definition(def_element, vuln_dict, config: Config):  # noqa: PLR0912
     logger = logging.getLogger("oval-parser")
     oval_ns = re.search(config.ns_pattern, def_element.tag).group(1)
 
@@ -114,7 +113,7 @@ def _process_definition(def_element, vuln_dict, config: Config):
         severity = "Unknown"
     issued = def_element.find(config.date_issued_xpath_query.format(oval_ns)).attrib["date"]
     # check for xpath query first since oracle does not provide this and its not initialized in the config
-    if config.date_updated_xpath_query:
+    if config.date_updated_xpath_query:  # noqa: SIM108
         updated = def_element.find(config.date_updated_xpath_query.format(oval_ns)).attrib["date"]
     else:
         updated = None
@@ -130,7 +129,7 @@ def _process_definition(def_element, vuln_dict, config: Config):
                     "Name": cve.text,
                     "Link": cve.attrib["href"],
                     "cvss2": cve.attrib["cvss2"],
-                }
+                },
             )
         else:
             cves.append({"Name": cve.text, "Link": cve.attrib["href"]})
@@ -170,9 +169,12 @@ def _process_definition(def_element, vuln_dict, config: Config):
         if (name, ns_name) in vuln_dict:
             existing_version, _ = vuln_dict[(name, ns_name)]
             logger.debug(
-                "Found an existing record for {} under {}. Version attribute of definition oval element: existing: {}, new: {}".format(
-                    name, ns_name, existing_version, def_version
-                )
+                "Found an existing record for {} under {}. Version attribute of definition oval element: existing: {}, new: {}".format(  # noqa: G001
+                    name,
+                    ns_name,
+                    existing_version,
+                    def_version,
+                ),
             )
             # lexicographic comparison of versions to choose which vulnerability record wins
             if def_version > existing_version:
@@ -212,7 +214,7 @@ def _process_criteria(element_a, oval_ns, config: Config):
 
         if ns_name:  # proceed only if a platform is found
             # Filter out duplicate (package, version) tuples
-            ns_pkgs_dict[ns_name] = {tuple(list(x) + [ns_module]) for x in group if isinstance(x, tuple)}
+            ns_pkgs_dict[ns_name] = {tuple(list(x) + [ns_module]) for x in group if isinstance(x, tuple)}  # noqa: RUF005
         else:
             # logger.debug('Namespace for the criteria not found, ignoring criteria')
             continue  # ignore this group of conditions if namespace is not found

--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -155,6 +155,8 @@ tests:
       - nvd:cpe
 
   - provider: oracle
+    additional_trigger_globs:
+      - src/vunnel/utils/oval_parser.py
     images:
       - docker.io/oraclelinux:6@sha256:a06327c0f1d18d753f2a60bb17864c84a850bb6dcbcf5946dd1a8123f6e75495
       - docker.io/anchore/test_images:appstreams-oraclelinux-8-1a287dd@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1
@@ -168,6 +170,8 @@ tests:
   - provider: rhel
     # ideally we would not use cache, however, the ubuntu provider is currently very expensive to run.
     # This will still test incremental updates relative to the nightly cache that is populated.
+    additional_trigger_globs:
+      - src/vunnel/utils/oval_parser.py
     use_cache: true
     images:
       - registry.access.redhat.com/ubi8@sha256:68fecea0d255ee253acbf0c860eaebb7017ef5ef007c25bee9eeffd29ce85b29


### PR DESCRIPTION
This way, the set of lints suppressed in the file cannot grow unnoticed.

See #310 