### PR TITLE
Move nightly quality gate to be roughly after the latest DB build

### DIFF
--- a/.github/workflows/nightly-quality-gate.yaml
+++ b/.github/workflows/nightly-quality-gate.yaml
@@ -3,9 +3,9 @@ on:
   # allow for kicking off quality gate check manually
   workflow_dispatch:
 
-  # run 2 AM (UTC) daily
+  # run 5 AM (UTC) daily
   schedule:
-    - cron:  '0 2 * * *'
+    - cron:  '0 5 * * *'
 
 jobs:
 


### PR DESCRIPTION
This should help with non-cve IDs that can't easily be filtered from the results based on year (GHSAs) that cause false-positive quality gate failures. Comparing with data from 22 hours earlier isn't an apples-to-apples comparison, this change gets that to within an hour 🤞 .