### PR TITLE
refactor: use new http get wrapper in oracle provider

### DIFF
--- a/src/vunnel/providers/oracle/parser.py
+++ b/src/vunnel/providers/oracle/parser.py
@@ -5,10 +5,7 @@ import logging
 import os
 import re
 
-import requests
-
-from vunnel import utils
-from vunnel.utils import rpm
+from vunnel.utils import http, rpm
 from vunnel.utils.oval_parser import Config, parse
 
 # One time initialization of driver specific configuration
@@ -65,11 +62,10 @@ class Parser:
     def urls(self):
         return [self._url_]
 
-    @utils.retry_with_backoff()
     def _download(self):
         try:
             self.logger.info(f"downloading ELSA from {self._url_}")
-            r = requests.get(self._url_, stream=True, timeout=self.download_timeout)
+            r = http.get(self._url_, self.logger, stream=True, timeout=self.download_timeout)
             if r.status_code != 200:
                 raise Exception(f"GET {self._url_} failed with HTTP error {r.status_code}")
 

--- a/tests/unit/providers/oracle/test_oracle.py
+++ b/tests/unit/providers/oracle/test_oracle.py
@@ -361,14 +361,6 @@ class TestKspliceFilterer:
         assert f.filter(input_vulnerability) == expected_output
 
 
-@pytest.fixture()
-def disable_get_requests(monkeypatch):
-    def disabled(*args, **kwargs):
-        raise RuntimeError("requests disabled but HTTP GET attempted")
-
-    monkeypatch.setattr(parser.requests, "get", disabled)
-
-
 def test_provider_schema(helpers, disable_get_requests, monkeypatch):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 


### PR DESCRIPTION
Use the new http get wrapper introduced in #376 in the oracle provider.

See also #310.