### PR TITLE
chore: fix false positive in detecting that yardstick changed

### DIFF
--- a/tests/quality/configure.py
+++ b/tests/quality/configure.py
@@ -338,6 +338,10 @@ def yardstick_version_changed():
     # get list of files changed with git diff
     changes = subprocess.check_output(["git", "diff", base_ref]).decode("utf-8").splitlines()
     for line in changes:
+        if not line.strip().startswith(("-", "+")):
+            # this line is in the output of `git diff`, but is just context, not a change
+            continue
+
         if 'git = "https://github.com/anchore/yardstick"' in line:
             return True
 


### PR DESCRIPTION
Previously, if "git diff" included the yardstick dependency declaration in one of the context/unchanged lines, configure.py would request running the quality gate on every provider. Fix this false positive by only considering lines with changes in them in the output.

Basically, [this check](https://github.com/anchore/vunnel/pull/374/files#diff-70418a48df4fa132049398d4aba7e5c863decf012a8242eebf9b8adc888f59e7R342) could false positive, as evident in https://github.com/anchore/vunnel/pull/387 trying to run all the providers even though it doesn't change anything that should necessitate that.