### PR TITLE
refactor: http.get wrapper in wolfi provider

### DIFF
--- a/src/vunnel/providers/wolfi/parser.py
+++ b/src/vunnel/providers/wolfi/parser.py
@@ -7,10 +7,7 @@ import os
 import re
 from urllib.parse import urlparse
 
-import requests
-
-from vunnel import utils
-from vunnel.utils import vulnerability
+from vunnel.utils import http, vulnerability
 
 
 class Parser:
@@ -40,7 +37,6 @@ class Parser:
     def _extract_filename_from_url(url):
         return os.path.basename(urlparse(url).path)
 
-    @utils.retry_with_backoff()
     def _download(self):
         """
         Downloads wolfi sec db files
@@ -51,14 +47,11 @@ class Parser:
 
         try:
             self.logger.info(f"downloading {self.namespace} secdb {self.url}")
-            r = requests.get(self.url, stream=True, timeout=self.download_timeout)
-            if r.status_code == 200:
-                file_path = os.path.join(self.secdb_dir_path, self._db_filename)
-                with open(file_path, "wb") as fp:
-                    for chunk in r.iter_content():
-                        fp.write(chunk)
-            else:
-                r.raise_for_status()
+            r = http.get(self.url, self.logger, stream=True, timeout=self.download_timeout)
+            file_path = os.path.join(self.secdb_dir_path, self._db_filename)
+            with open(file_path, "wb") as fp:
+                for chunk in r.iter_content():
+                    fp.write(chunk)
         except Exception:
             self.logger.exception(f"ignoring error processing secdb for {self.url}")
 

--- a/tests/unit/providers/chainguard/test_chainguard.py
+++ b/tests/unit/providers/chainguard/test_chainguard.py
@@ -10,14 +10,6 @@ from vunnel.providers.chainguard import Config, Provider
 from vunnel.providers.wolfi import parser
 
 
-@pytest.fixture()
-def disable_get_requests(monkeypatch):
-    def disabled(*args, **kwargs):
-        raise RuntimeError("requests disabled but HTTP GET attempted")
-
-    monkeypatch.setattr(parser.requests, "get", disabled)
-
-
 def test_provider_schema(helpers, disable_get_requests):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 

--- a/tests/unit/providers/wolfi/test_wolfi.py
+++ b/tests/unit/providers/wolfi/test_wolfi.py
@@ -179,14 +179,6 @@ class TestParser:
         )
 
 
-@pytest.fixture()
-def disable_get_requests(monkeypatch):
-    def disabled(*args, **kwargs):
-        raise RuntimeError("requests disabled but HTTP GET attempted")
-
-    monkeypatch.setattr(parser.requests, "get", disabled)
-
-
 def test_provider_schema(helpers, disable_get_requests):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),


### PR DESCRIPTION
Also change chainguard unit tests, since chainguard uses the wolfi provider.