### PR TITLE
chore: add alpine:distro:alpine:3.19 namespace to quality gate

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -68,6 +68,7 @@ tests:
       - alpine:distro:alpine:3.16
       - alpine:distro:alpine:3.17
       - alpine:distro:alpine:3.18
+      - alpine:distro:alpine:3.19
       - alpine:distro:alpine:edge
 
   - provider: amazon


### PR DESCRIPTION
Alpine Linux 3.19 has been released, so adding the relevant namespace to the vunnel quality gate config