### PR TITLE
Move away from asset promotion

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,9 +66,42 @@ jobs:
           echo "Nightly Quality Gate Status: ${{ steps.nightly-quality-gate.conclusion }}"
           false
 
-  tag:
+  publish-to-pre-prod:
+    runs-on: ubuntu-22.04
     needs:
       - quality-gate
+    permissions:
+      contents: read
+      # package write permission is needed for publishing commit images
+      packages: write
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          # in order to properly resolve the version from git
+          fetch-depth: 0
+
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
+
+      - name: Login to ghcr.io
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+
+      - name: Build assets
+        run: poetry run make build
+
+      - name: Publish commit image
+        run: make ci-publish-commit
+
+      - name: Publish to test PyPI
+        run: make ci-publish-testpypi
+        env:
+          # note: "..._TESTPYPI" suffix should match the name of the testpypi repository (see the Makefile target)
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_TOKEN }}
+
+  tag:
+    needs:
+      - publish-to-pre-prod
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -81,36 +81,3 @@ jobs:
           else
             exit 1
           fi
-
-  Publish-PreProd:
-    runs-on: ubuntu-22.04
-    needs: [Static-Analysis, Test]
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      # package write permission is needed for publishing commit images
-      packages: write
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
-        with:
-          # in order to properly resolve the version from git
-          fetch-depth: 0
-
-      - name: Bootstrap environment
-        uses: ./.github/actions/bootstrap
-
-      - name: Login to ghcr.io
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-
-      - name: Build assets
-        run: poetry run make build
-
-      - name: Publish commit image
-        run: make ci-publish-commit
-
-      - name: Publish to test PyPI
-        run: make ci-publish-testpypi
-        env:
-          # note: "..._TESTPYPI" suffix should match the name of the testpypi repository (see the Makefile target)
-          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,14 +3,13 @@
 Vunnel is published as:
 - a git tag in the repo
 - a `ghcr.io/anchore/vunnel` docker image
+- a new release in the [pypi project](https://pypi.org/project/vunnel/)
 
-There are two times when assets are released:
-
-- when a new commit reaches main:
+When a release a triggered then the following actions are taken:
     - a new `ghcr.io/anchore/vunnel:[GIT-COMMIT]` docker image is published
     - a build is published to the [testpypi project](https://test.pypi.org/project/vunnel/)
 
-- when a release is triggered:
+If the actions succeeds, then the release continues:
     - the commit on main is tagged with the given version
     - the existing commit-based image is additionally tagged as `ghcr.io/anchore/vunnel:[VERSION]` and `ghcr.io/anchore/vunnel:latest`
     - a build is published to the [pypi project](https://pypi.org/project/vunnel/)


### PR DESCRIPTION
One consequence of auto merging dependabot PRs is that releases cannot depend on workflows always being run on main. This is because when dependabot merges a PR any "recursive" workflows are not kicked off since the default GITHUB_TOKEN was used (a security feature of github actions). We still want the benefit of not adding our own token and still getting dependabot PRs merged automatically, so the next choice we have is to move away from asset promotion and instead create all assets at release.