### PR TITLE
Check PR author login, instead of actor

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' # not necessarily actor; needs to run on human push to dependabot PR
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
Otherwise, the workflow won't run on events where another user modified a dependabot PR.