### PR TITLE
Load all schema url refs for offline validation

### DIFF
--- a/schema/vulnerability/nvd/README.md
+++ b/schema/vulnerability/nvd/README.md
@@ -2,6 +2,8 @@
 
 This schema governs the data shape for a single NVD vulnerability record.
 
+Derived from schemas located on the [NVD website](https://nvd.nist.gov/developers/vulnerabilities).
+
 ## Updating the schema
 
 Versioning the JSON schema must be done manually by copying the existing JSON schema into a new `schema-x.y.z.json` file and manually making the necessary updates (or by using an online tool such as https://www.liquid-technologies.com/online-json-to-schema-converter).

--- a/schema/vulnerability/nvd/cvss/README.md
+++ b/schema/vulnerability/nvd/cvss/README.md
@@ -1,0 +1,5 @@
+These are cvss schemas found [here](https://nvd.nist.gov/developers/vulnerabilities) that are referenced in the main NVD schema.
+
+Local copies have been made to ensure that schema valiations can be performed without network access being required.
+
+This is facilitated by loading the file-to-url mapping in the test fixture (in conftest.py) that is responsible for json schema validation.

--- a/schema/vulnerability/nvd/cvss/schema-v2.0.json
+++ b/schema/vulnerability/nvd/cvss/schema-v2.0.json
@@ -1,0 +1,103 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 2.0",
+    "type": "object",
+    "definitions": {
+        "accessVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL" ]
+        },
+        "accessComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "MEDIUM", "LOW" ]
+        },
+        "authenticationType": {
+            "type": "string",
+            "enum": [ "MULTIPLE", "SINGLE", "NONE" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "PARTIAL", "COMPLETE" ]
+        },
+        "exploitabilityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "reportConfidenceType": {
+            "type": "string",
+            "enum": [ "UNCONFIRMED", "UNCORROBORATED", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "collateralDamagePotentialType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "LOW_MEDIUM", "MEDIUM_HIGH", "HIGH", "NOT_DEFINED" ]
+        },
+        "targetDistributionType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "2.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+        },
+        "accessVector":                   { "$ref": "#/definitions/accessVectorType" },
+        "accessComplexity":               { "$ref": "#/definitions/accessComplexityType" },
+        "authentication":                 { "$ref": "#/definitions/authenticationType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "exploitability":                 { "$ref": "#/definitions/exploitabilityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/reportConfidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "collateralDamagePotential":      { "$ref": "#/definitions/collateralDamagePotentialType" },
+        "targetDistribution":             { "$ref": "#/definitions/targetDistributionType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" }
+    },
+    "required": [ "version", "vectorString", "baseScore" ]
+}

--- a/schema/vulnerability/nvd/cvss/schema-v3.0.json
+++ b/schema/vulnerability/nvd/cvss/schema-v3.0.json
@@ -1,0 +1,142 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.0",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3[.]0/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/schema/vulnerability/nvd/cvss/schema-v3.1.json
+++ b/schema/vulnerability/nvd/cvss/schema-v3.1.json
@@ -1,0 +1,142 @@
+{
+    "license": [
+        "Copyright (c) 2021, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.1",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.1" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3[.]1/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}


### PR DESCRIPTION
This adds all schemas that are referenced by URL within other already-captured schemas to a location within the repo. Additionally, the test fixture responsible for schema validation has been updated to manually map URLs to paths within the repo to use such that no network calls are used. Without this update you tend to see [flaky behavior in CI](https://github.com/anchore/vunnel/actions/runs/7324485690/job/19948100788):

```
tests/unit/providers/nvd/test_nvd.py:52: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/conftest.py:59: in result_schemas_valid
    jsonschema.validate(instance=envelope["item"], schema=schema_dict)
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:1306: in validate
    error = exceptions.best_match(validator.iter_errors(instance))
.tox/py310/lib/python3.10/site-packages/jsonschema/exceptions.py:456: in best_match
    best = next(errors, None)
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:368: in iter_errors
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_keywords.py:295: in properties
    yield from validator.descend(
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:416: in descend
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_keywords.py:274: in ref
    yield from validator._validate_reference(ref=ref, instance=instance)
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:416: in descend
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_keywords.py:295: in properties
    yield from validator.descend(
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:416: in descend
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_keywords.py:295: in properties
    yield from validator.descend(
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:416: in descend
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_legacy_keywords.py:135: in items_draft6_draft7_draft201909
    yield from validator.descend(item, items, path=index)
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:416: in descend
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_keywords.py:274: in ref
    yield from validator._validate_reference(ref=ref, instance=instance)
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:416: in descend
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_keywords.py:295: in properties
    yield from validator.descend(
.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:416: in descend
    for error in errors:
.tox/py310/lib/python3.10/site-packages/jsonschema/_keywords.py:274: in ref
    yield from validator._validate_reference(ref=ref, instance=instance)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Draft7Validator(schema={'$ref': 'https://csrc...vss-v2.0.json/'}, format_checker=None)
ref = 'https://csrc.nist.gov/schema/nvd/api/2.0/external/cvss-v2.0.json'
instance = {'accessComplexity': 'MEDIUM', 'accessVector': 'LOCAL', 'authentication': 'NONE', 'availabilityImpact': 'COMPLETE', ...}

    def _validate_reference(self, ref, instance):
        if self._ref_resolver is None:
            try:
                resolved = self._resolver.lookup(ref)
            except referencing.exceptions.Unresolvable as err:
>               raise exceptions._WrappedReferencingError(err)
E               jsonschema.exceptions._WrappedReferencingError: Unresolvable: https://csrc.nist.gov/schema/nvd/api/2.0/external/cvss-v2.0.json

.tox/py310/lib/python3.10/site-packages/jsonschema/validators.py:448: _WrappedReferencingError

---------- coverage: platform linux, python 3.10.13-final-0 ----------
Coverage HTML written to dir htmlcov

Required test coverage of 75.0% reached. Total coverage: 79.78%
=========================== short test summary info ============================
FAILED tests/unit/providers/nvd/test_nvd.py::test_provider_schema[test-fixtures/single-entry.json-1] - jsonschema.exceptions._WrappedReferencingError: Unresolvable: https://csrc..../
================== 1 failed, 288 passed in 139.09s (0:02:19) ===================
```