### PR TITLE
hack: hard-code severity for debian CVE-2023-44487

### DIFF
--- a/src/vunnel/providers/debian/parser.py
+++ b/src/vunnel/providers/debian/parser.py
@@ -354,7 +354,7 @@ class Parser:
                             # HACK: when we can represent per-package severity or have a good mechanism
                             # for overriding upstream data, we should take this out.
                             if vid == "CVE-2023-44487":
-                                vuln_record["Vulnerability"]["Severity"] = "High"
+                                vuln_record["Vulnerability"]["Severity"] = "Unknown"
 
                             # add fixedIn
                             skip_fixedin = False

--- a/src/vunnel/providers/debian/parser.py
+++ b/src/vunnel/providers/debian/parser.py
@@ -351,6 +351,11 @@ class Parser:
                             ):
                                 vuln_record["Vulnerability"]["Severity"] = sev
 
+                            # HACK: when we can represent per-package severity or have a good mechanism
+                            # for overriding upstream data, we should take this out.
+                            if vid == "CVE-2023-44487":
+                                vuln_record["Vulnerability"]["Severity"] = "High"
+
                             # add fixedIn
                             skip_fixedin = False
                             fixed_el = {

--- a/src/vunnel/providers/debian/parser.py
+++ b/src/vunnel/providers/debian/parser.py
@@ -354,6 +354,9 @@ class Parser:
                             # HACK: when we can represent per-package severity or have a good mechanism
                             # for overriding upstream data, we should take this out.
                             if vid == "CVE-2023-44487":
+                                self.logger.info(
+                                    "clearing severity on CVE-2023-44487, see https://github.com/anchore/grype-db/issues/108#issuecomment-1796301073",
+                                )
                                 vuln_record["Vulnerability"]["Severity"] = "Unknown"
 
                             # add fixedIn


### PR DESCRIPTION
The Debian feed contains per-package urgency for CVEs, which Vunnel translates into per-package severity, and the collapses into a single per-CVE serverity by having the most severe severity win. However, unknown severities always lose the comparison. This means that the particular CVE here, CVE-2023-44487, which has a single negligible package and a bunch of unknowns, is treated as negligible severity for every package, which is incorrect. Hard-code it to unknown severity (so that Grype-DB will take severity from NVD's data), while we figure out what schema changes and logic changes are needed put in a lasting fix.

See https://github.com/anchore/grype-db/issues/108#issuecomment-1796301073 for more info

## Manual testing done

```
$ make dev providers="debian nvd"
$ make update-db
$ sqlite3 --header --column .cache/grype/5/vulnerability.db \
"select id, severity, namespace from vulnerability_metadata where id = 'CVE-2023-44487' and namespace like '%debian%';"

id              severity  namespace
--------------  --------  -----------------------------
CVE-2023-44487  High      debian:distro:debian:10
CVE-2023-44487  High      debian:distro:debian:11
CVE-2023-44487  High      debian:distro:debian:12
CVE-2023-44487  High      debian:distro:debian:13
```

Note that these will still come through as high severity in Grype-DB, but it will be because Grype DB will fall back to using NVD to populate that bit of metadata.