### PR TITLE
chore: change dependabot to auto-approve only

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -1,0 +1,10 @@
+name: Dependabot Automation
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  run:
+    uses: anchore/workflows/.github/workflows/dependabot-automation.yaml@main


### PR DESCRIPTION
When dependabot PRs are automatically merged, the resulting commit doesn't run workflows on main if the default GitHub token is used. Rather than generate a more potent token, or live with some commits not running workflows on main, scale back dependabot automation to only approve the PRs but not merge them. This still reduces toil by saving several clicks in the UI.

Copied from anchore/grype-db#222