### PR TITLE
chore(deps-dev): bump yardstick to v0.9.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -646,13 +646,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.11.0"
+version = "7.0.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-6.11.0-py3-none-any.whl", hash = "sha256:f0afba6205ad8f8947c7d338b5342d5db2afbfd82f9cbef7879a9539cc12eb9b"},
-    {file = "importlib_metadata-6.11.0.tar.gz", hash = "sha256:1231cf92d825c9e03cfc4da076a16de6422c863558229ea0b22b675657463443"},
+    {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
+    {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
 ]
 
 [package.dependencies]
@@ -2166,14 +2166,14 @@ develop = false
 [package.dependencies]
 click = "^8"
 Colr = "^0.9.1"
-dataclass-wizard = "^0.22.2"
-dataclasses-json = "^0.6.1"
-GitPython = "^3.1.40"
-importlib-metadata = "^6.8.0"
+dataclass-wizard = "^0.22.3"
+dataclasses-json = "^0.6.4"
+GitPython = "^3.1.41"
+importlib-metadata = "^7.0.1"
 mergedeep = "^1.3.4"
 omitempty = "^0.1.1"
-prompt-toolkit = "^3.0.18"
-Pygments = "^2.16.1"
+prompt-toolkit = "^3.0.43"
+Pygments = "^2.17.2"
 PyYAML = ">= 6.0.0, < 7.0"
 requests = "^2.31.0"
 rfc3339 = "^6.2"
@@ -2182,8 +2182,8 @@ tabulate = "^0.9.0"
 [package.source]
 type = "git"
 url = "https://github.com/anchore/yardstick"
-reference = "v0.9.1"
-resolved_reference = "9f9a3ea47c90f5dd4bce89951531746e4bed854f"
+reference = "v0.9.2"
+resolved_reference = "90aed9fcf125dde688674874a32f6a0af9767cbf"
 
 [[package]]
 name = "zipp"
@@ -2203,4 +2203,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8e9d70e2723e3565575f02639ad73ef6bf610da33e85762cb5dce68480b0eb59"
+content-hash = "3645dc5afbdc1f605b4dc4f83307a584df027d31d4cfc99542d0cccb2947cd18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ orjson = "^3.8.6"
 SQLAlchemy = ">= 1.4.46, < 2.0"  # note: 1.4.x currently required for enterprise
 mergedeep = "^1.3.4"
 future = "^0.18.3"
-importlib-metadata = "^6.1.0"
+importlib-metadata = "^7.0.1"
 xsdata = {extras = ["cli", "lxml", "soap"], version = ">=22.12,<25.0"}
 pytest-snapshot = "^0.9.0"
 mashumaro = "^3.10"
@@ -77,7 +77,7 @@ mypy = "^1.1"
 radon = ">=5.1,<7.0"
 dunamai = "^1.15.0"
 ruff = ">=0.0.254,<0.2.2"
-yardstick = {git = "https://github.com/anchore/yardstick", rev = "v0.9.1"}
+yardstick = {git = "https://github.com/anchore/yardstick", rev = "v0.9.2"}
 tabulate = "0.9.0"
 tox = "^4.11.3"
 


### PR DESCRIPTION
To bring in the ALAS filtering fixes from https://github.com/anchore/yardstick/pull/239