### PR TITLE
feat(deps): drop python-future

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -487,16 +487,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pyt
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
-name = "future"
-version = "0.18.3"
-description = "Clean single-source support for Python 3 and 2"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "future-0.18.3.tar.gz", hash = "sha256:34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307"},
-]
-
-[[package]]
 name = "gitdb"
 version = "4.0.11"
 description = "Git Object Database"
@@ -2203,4 +2193,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "85f25902664e22d4cbd75592331906ffdc96b9d6438c103d1bbfe40e085294cc"
+content-hash = "1761e2e2c0b2dec02c092bb519b3d07d2d658f0b03399d257cd428f75cf2d8a1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ defusedxml = "^0.7.1"
 orjson = "^3.8.6"
 SQLAlchemy = ">= 1.4.46, < 2.0"  # note: 1.4.x currently required for enterprise
 mergedeep = "^1.3.4"
-future = "^0.18.3"
 importlib-metadata = "^7.0.1"
 xsdata = {extras = ["cli", "lxml", "soap"], version = ">=22.12,<25.0"}
 pytest-snapshot = "^0.9.0"


### PR DESCRIPTION
It seems like python-future is no longer needed here and according to the [1.0.0 release notes](https://github.com/PythonCharmers/python-future/releases/tag/v1.0.0)

> The new version number of 1.0.0 indicates that the python-future project, like
Python 2, is now done.