### PR TITLE
Allows overriding CPE configurations on NVD records

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1443,7 +1443,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -21,6 +21,7 @@ class Config:
     )
     request_timeout: int = 125
     api_key: Optional[str] = "env:NVD_API_KEY"  # noqa: UP007
+    overrides_url: Optional[str] = "https://github.com/anchore/nvd-data-overrides/archive/refs/heads/main.tar.gz"
 
     def __post_init__(self) -> None:
         if self.api_key and self.api_key.startswith("env:"):
@@ -62,6 +63,7 @@ class Provider(provider.Provider):
             download_timeout=self.config.request_timeout,
             api_key=self.config.api_key,
             logger=self.logger,
+            overrides_url=self.config.overrides_url,
         )
 
     @classmethod

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -58,10 +58,10 @@ class Provider(provider.Provider):
         self.schema = schema.NVDSchema()
         self.manager = Manager(
             workspace=self.workspace,
+            schema=self.schema,
             download_timeout=self.config.request_timeout,
             api_key=self.config.api_key,
             logger=self.logger,
-            schema=self.schema,
         )
 
     @classmethod
@@ -69,23 +69,7 @@ class Provider(provider.Provider):
         return "nvd"
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
-        # with self.input_writer() as writer:
-        #     for id, record in self.manager.download_nvd_input(
-        #         last_updated=last_updated,
-        #         skip_if_exists=self.config.runtime.skip_if_exists,
-        #     ):
-        #         writer.write(
-        #             identifier=id.lower(),
-        #             schema=self.schema,
-        #             payload=record,
-        #         )
-
-        with self.results_writer() as writer, self.input_reader() as reader:
-            # TODO: get the reader and connection from the input writer and pass that in
-            # instead of the reader and connection from the results writer
-            # reader: result.SQLiteStore = nvd_writer.store
-            # conn, table = reader.connection()
-
+        with self.results_writer() as writer:
             for identifier, record in self.manager.get(
                 skip_if_exists=self.config.runtime.skip_if_exists,
                 last_updated=last_updated,

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -37,6 +37,8 @@ class Config:
 
 
 class Provider(provider.Provider):
+    __version__ = 2
+
     def __init__(self, root: str, config: Config | None = None):
         if not config:
             config = Config()

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -104,10 +104,8 @@ class Provider(provider.Provider):
             result_state_policy=self.runtime_cfg.existing_results,
             logger=self.logger,
             store_strategy=self.runtime_cfg.result_store,
-            write_location=os.path.join(self.workspace.input_path, 'nvd-input.db')
+            write_location=os.path.join(self.workspace.input_path, "nvd-input.db"),
         )
 
     def input_reader(self) -> result.SQLiteReader:
-        return result.SQLiteReader(
-            sqlite_db_path=os.path.join(self.workspace.input_path, 'nvd-input.db')
-        )
+        return result.SQLiteReader(sqlite_db_path=os.path.join(self.workspace.input_path, "nvd-input.db"))

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -79,10 +79,10 @@ class Provider(provider.Provider):
                     payload=record,
                 )
 
-        with self.results_writer() as writer:
+        with self.results_writer() as writer, self.input_writer() as nvd_writer:
             # TODO: get the reader and connection from the input writer and pass that in
             # instead of the reader and connection from the results writer
-            reader: result.SQLiteStore = writer.store
+            reader: result.SQLiteStore = nvd_writer.store
             conn, table = reader.connection()
 
             for identifier, record in self.manager.get(

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -50,6 +50,11 @@ class Provider(provider.Provider):
                 "(otherwise incremental updates will fail)",
             )
 
+        if self.config.runtime.result_store != result.StoreStrategy.SQLITE:
+            raise ValueError(
+                f"only 'SQLITE' is supported for 'runtime.result_store' but got '{self.config.runtime.result_store}'",
+            )
+
         self.schema = schema.NVDSchema()
         self.manager = Manager(
             workspace=self.workspace,
@@ -63,7 +68,23 @@ class Provider(provider.Provider):
         return "nvd"
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
+        with self.input_writer() as writer:
+            for id, record in self.manager.download_nvd_input(
+                last_updated=last_updated,
+                skip_if_exists=self.config.runtime.skip_if_exists,
+            ):
+                writer.write(
+                    identifier=id.lower(),
+                    schema=self.schema,
+                    payload=record,
+                )
+
         with self.results_writer() as writer:
+            # TODO: get the reader and connection from the input writer and pass that in
+            # instead of the reader and connection from the results writer
+            reader: result.SQLiteStore = writer.store
+            conn, table = reader.connection()
+
             for identifier, record in self.manager.get(
                 skip_if_exists=self.config.runtime.skip_if_exists,
                 last_updated=last_updated,
@@ -75,3 +96,12 @@ class Provider(provider.Provider):
                 )
 
         return self.manager.urls, len(writer)
+
+    def input_writer(self) -> result.Writer:
+        return result.Writer(
+            workspace=self.workspace,
+            result_state_policy=self.runtime_cfg.existing_results,
+            logger=self.logger,
+            store_strategy=self.runtime_cfg.result_store,
+            write_location=os.path.join(self.workspace.input_path, 'nvd-input.db')
+        )

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -5,8 +5,8 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-from .api import NvdAPI
 from ... import result, schema
+from .api import NvdAPI
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -40,7 +40,6 @@ class Manager:
     ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         yield from self.download_nvd_input(last_updated, skip_if_exists)
 
-
     def _can_update_incrementally(self, last_updated: datetime.datetime | None) -> bool:
         if not last_updated:
             return False
@@ -56,9 +55,11 @@ class Manager:
 
         return True
 
-    def download_nvd_input(self, last_updated: datetime.datetime | None,
-                           skip_if_exists: bool = False
-                           )-> Generator[tuple[str, dict[str, Any]], Any, None]:
+    def download_nvd_input(
+        self,
+        last_updated: datetime.datetime | None,
+        skip_if_exists: bool = False,
+    ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         with self.input_writer() as writer:
             if skip_if_exists and self._can_update_incrementally(last_updated):
                 yield from self._download_updates(last_updated, writer)  # type: ignore  # noqa: PGH003
@@ -73,7 +74,11 @@ class Manager:
         for response in self.api.cve():
             yield from self._unwrap_records(response, writer)
 
-    def _download_updates(self, last_updated: datetime.datetime, writer: result.Writer) -> Generator[tuple[str, dict[str, Any]], Any, None]:
+    def _download_updates(
+        self,
+        last_updated: datetime.datetime,
+        writer: result.Writer,
+    ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         self.logger.debug(f"downloading CVEs changed since {last_updated.isoformat()}")
 
         # get the list of CVEs that have been updated since the last sync
@@ -86,7 +91,11 @@ class Manager:
 
             yield from self._unwrap_records(response, writer)
 
-    def _unwrap_records(self, response: dict[str, Any], writer: result.Writer) -> Generator[tuple[str, dict[str, Any]], Any, None]:
+    def _unwrap_records(
+        self,
+        response: dict[str, Any],
+        writer: result.Writer,
+    ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         for vuln in response["vulnerabilities"]:
             cve_id = vuln["cve"]["id"]
             year = cve_id.split("-")[1]
@@ -101,5 +110,5 @@ class Manager:
             result_state_policy=result.ResultStatePolicy.KEEP,
             logger=self.logger,
             store_strategy=result.StoreStrategy.SQLITE,
-            write_location=os.path.join(self.workspace.input_path, 'nvd-input.db'),
+            write_location=os.path.join(self.workspace.input_path, "nvd-input.db"),
         )

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -35,10 +35,13 @@ class Manager:
         last_updated: datetime.datetime | None,
         skip_if_exists: bool = False,
     ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
-        if skip_if_exists and self._can_update_incrementally(last_updated):
-            yield from self._download_updates(last_updated)  # type: ignore  # noqa: PGH003
-        else:
-            yield from self._download_all()
+        # download and process NVD records in realtime (not persisted to the DB)
+        # TODO: instead yield from input db
+        # if skip_if_exists and self._can_update_incrementally(last_updated):
+        #     yield from self._download_updates(last_updated)  # type: ignore  # noqa: PGH003
+        # else:
+        #     yield from self._download_all()
+        yield from set()
 
     def _can_update_incrementally(self, last_updated: datetime.datetime | None) -> bool:
         if not last_updated:
@@ -54,6 +57,14 @@ class Manager:
             return False
 
         return True
+
+    def download_nvd_input(self, last_updated: datetime.datetime | None,
+                           skip_if_exists: bool = False
+                           )-> Generator[tuple[str, dict[str, Any]], Any, None]:
+        if skip_if_exists and self._can_update_incrementally(last_updated):
+            yield from self._download_updates(last_updated)  # type: ignore  # noqa: PGH003
+        else:
+            yield from self._download_all()
 
     def _download_all(self) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         self.logger.info("downloading all CVEs")

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -44,7 +44,7 @@ class Manager:
             download_timeout=download_timeout,
         )
 
-        self.urls = [self.api._cve_api_url_, self.overrides.url]  # noqa: SLF001
+        self.urls = [self.api._cve_api_url_]  # noqa: SLF001
         self.schema = schema
 
     def get(
@@ -60,6 +60,7 @@ class Manager:
             yield record_id, record
 
         if self.overrides.enabled:
+            self.urls.append(self.overrides.url)
             self.logger.debug("applying NVD data overrides...")
 
             override_cves = {cve.lower() for cve in self.overrides.cves()}
@@ -189,7 +190,7 @@ class Manager:
 
 def cve_to_id(cve: str) -> str:
     year = cve.split("-")[1]
-    return os.path.join(year, cve).lower()
+    return os.path.join(year, cve)
 
 
 def id_to_cve(cve_id: str) -> str:

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from ... import result, schema
 from .api import NvdAPI
+from .overrides import NVDOverrides
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -15,13 +16,15 @@ if TYPE_CHECKING:
 
 
 class Manager:
+    __nvd_input_db__ = "nvd-input.db"
+
     def __init__(
         self,
         workspace: Workspace,
+        schema: schema.Schema,
         logger: logging.Logger | None = None,
         download_timeout: int = 125,
         api_key: str | None = None,
-        schema: schema.Schema | None = None,
     ) -> None:
         self.workspace = workspace
 
@@ -30,7 +33,8 @@ class Manager:
         self.logger = logger
 
         self.api = NvdAPI(api_key=api_key, logger=logger, timeout=download_timeout)
-        self.urls = [self.api._cve_api_url_]  # noqa: SLF001
+        self.overrides = NVDOverrides(workspace=workspace, logger=logger, download_timeout=download_timeout)
+        self.urls = [self.api._cve_api_url_, self.overrides.__url__]  # noqa: SLF001
         self.schema = schema
 
     def get(
@@ -38,9 +42,58 @@ class Manager:
         last_updated: datetime.datetime | None,
         skip_if_exists: bool = False,
     ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
-        yield from self.download_nvd_input(last_updated, skip_if_exists)
+        self.overrides.download()
+
+        cves_processed = set()
+        for record_id, record in self._download_nvd_input(last_updated, skip_if_exists):
+            cves_processed.add(id_to_cve(record_id))
+            yield record_id, record
+
+        override_cves = {cve.lower() for cve in self.overrides.cves()}
+        override_remaining_cves = override_cves - cves_processed
+        with self._sqlite_reader() as reader:
+            for cve in override_remaining_cves:
+                original_record = reader.read(cve_to_id(cve))
+                if not original_record:
+                    self.logger.warning(f"override for {cve} not found in original data")
+                    continue
+                original_record = original_record["item"]
+                yield cve_to_id(cve), self._apply_override(cve, original_record)
+
+        self.logger.debug(f"applied overrides for {len(override_remaining_cves)} CVEs")
+
+    def _download_nvd_input(
+        self,
+        last_updated: datetime.datetime | None,
+        skip_if_exists: bool = False,
+    ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
+        with self._nvd_input_writer() as writer:
+            if skip_if_exists and self._can_update_incrementally(last_updated):
+                yield from self._download_updates(last_updated, writer)  # type: ignore  # noqa: PGH003
+            else:
+                yield from self._download_all(writer)
+
+    def _nvd_input_writer(self) -> result.Writer:
+        return result.Writer(
+            workspace=self.workspace,
+            result_state_policy=result.ResultStatePolicy.KEEP,
+            logger=self.logger,
+            store_strategy=result.StoreStrategy.SQLITE,
+            write_location=self._input_nvd_path,
+        )
+
+    def _sqlite_reader(self) -> result.SQLiteReader:
+        return result.SQLiteReader(sqlite_db_path=self._input_nvd_path)
+
+    @property
+    def _input_nvd_path(self) -> str:
+        return os.path.join(self.workspace.input_path, self.__nvd_input_db__)
 
     def _can_update_incrementally(self, last_updated: datetime.datetime | None) -> bool:
+        input_db_path = os.path.join(self.workspace.input_path, self.__nvd_input_db__)
+        if not os.path.exists(input_db_path):
+            return False
+
         if not last_updated:
             return False
 
@@ -54,17 +107,6 @@ class Manager:
             return False
 
         return True
-
-    def download_nvd_input(
-        self,
-        last_updated: datetime.datetime | None,
-        skip_if_exists: bool = False,
-    ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
-        with self.input_writer() as writer:
-            if skip_if_exists and self._can_update_incrementally(last_updated):
-                yield from self._download_updates(last_updated, writer)  # type: ignore  # noqa: PGH003
-            else:
-                yield from self._download_all(writer)
 
     def _download_all(self, writer: result.Writer) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         self.logger.info("downloading all CVEs")
@@ -98,17 +140,28 @@ class Manager:
     ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         for vuln in response["vulnerabilities"]:
             cve_id = vuln["cve"]["id"]
-            year = cve_id.split("-")[1]
-            record_id = os.path.join(year, cve_id)
-            if self.schema:
-                writer.write(record_id.lower(), self.schema, vuln)
-            yield record_id, vuln
+            record_id = cve_to_id(cve_id)
 
-    def input_writer(self) -> result.Writer:
-        return result.Writer(
-            workspace=self.workspace,
-            result_state_policy=result.ResultStatePolicy.KEEP,
-            logger=self.logger,
-            store_strategy=result.StoreStrategy.SQLITE,
-            write_location=os.path.join(self.workspace.input_path, "nvd-input.db"),
-        )
+            # keep input for future overrides
+            writer.write(record_id, self.schema, vuln)
+
+            # apply overrides to output
+            yield record_id, self._apply_override(cve_id=cve_id, record=vuln)
+
+    def _apply_override(self, cve_id: str, record: dict[str, Any]) -> dict[str, Any]:
+        override = self.overrides.cve(cve_id)
+        if override:
+            # TODO: change to trace
+            self.logger.warning(f"applying override for {cve_id}")
+            # TODO: should we merge or replace?
+            record.update(override)
+        return record
+
+
+def cve_to_id(cve: str) -> str:
+    year = cve.split("-")[1]
+    return os.path.join(year, cve).lower()
+
+
+def id_to_cve(cve_id: str) -> str:
+    return cve_id.split("/")[1]

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -6,6 +6,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from .api import NvdAPI
+from ... import result, schema
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -20,6 +21,7 @@ class Manager:
         logger: logging.Logger | None = None,
         download_timeout: int = 125,
         api_key: str | None = None,
+        schema: schema.Schema | None = None,
     ) -> None:
         self.workspace = workspace
 
@@ -29,19 +31,15 @@ class Manager:
 
         self.api = NvdAPI(api_key=api_key, logger=logger, timeout=download_timeout)
         self.urls = [self.api._cve_api_url_]  # noqa: SLF001
+        self.schema = schema
 
     def get(
         self,
         last_updated: datetime.datetime | None,
         skip_if_exists: bool = False,
     ) -> Generator[tuple[str, dict[str, Any]], Any, None]:
-        # download and process NVD records in realtime (not persisted to the DB)
-        # TODO: instead yield from input db
-        # if skip_if_exists and self._can_update_incrementally(last_updated):
-        #     yield from self._download_updates(last_updated)  # type: ignore  # noqa: PGH003
-        # else:
-        #     yield from self._download_all()
-        yield from set()
+        yield from self.download_nvd_input(last_updated, skip_if_exists)
+
 
     def _can_update_incrementally(self, last_updated: datetime.datetime | None) -> bool:
         if not last_updated:
@@ -61,20 +59,21 @@ class Manager:
     def download_nvd_input(self, last_updated: datetime.datetime | None,
                            skip_if_exists: bool = False
                            )-> Generator[tuple[str, dict[str, Any]], Any, None]:
-        if skip_if_exists and self._can_update_incrementally(last_updated):
-            yield from self._download_updates(last_updated)  # type: ignore  # noqa: PGH003
-        else:
-            yield from self._download_all()
+        with self.input_writer() as writer:
+            if skip_if_exists and self._can_update_incrementally(last_updated):
+                yield from self._download_updates(last_updated, writer)  # type: ignore  # noqa: PGH003
+            else:
+                yield from self._download_all(writer)
 
-    def _download_all(self) -> Generator[tuple[str, dict[str, Any]], Any, None]:
+    def _download_all(self, writer: result.Writer) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         self.logger.info("downloading all CVEs")
 
         # TODO: should we delete all existing state in this case first?
 
         for response in self.api.cve():
-            yield from self._unwrap_records(response)
+            yield from self._unwrap_records(response, writer)
 
-    def _download_updates(self, last_updated: datetime.datetime) -> Generator[tuple[str, dict[str, Any]], Any, None]:
+    def _download_updates(self, last_updated: datetime.datetime, writer: result.Writer) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         self.logger.debug(f"downloading CVEs changed since {last_updated.isoformat()}")
 
         # get the list of CVEs that have been updated since the last sync
@@ -85,10 +84,22 @@ class Manager:
                 if total_results:
                     self.logger.debug(f"discovered {total_results} updated CVEs")
 
-            yield from self._unwrap_records(response)
+            yield from self._unwrap_records(response, writer)
 
-    def _unwrap_records(self, response: dict[str, Any]) -> Generator[tuple[str, dict[str, Any]], Any, None]:
+    def _unwrap_records(self, response: dict[str, Any], writer: result.Writer) -> Generator[tuple[str, dict[str, Any]], Any, None]:
         for vuln in response["vulnerabilities"]:
             cve_id = vuln["cve"]["id"]
             year = cve_id.split("-")[1]
-            yield os.path.join(year, cve_id), vuln
+            record_id = os.path.join(year, cve_id)
+            if self.schema:
+                writer.write(record_id.lower(), self.schema, vuln)
+            yield record_id, vuln
+
+    def input_writer(self) -> result.Writer:
+        return result.Writer(
+            workspace=self.workspace,
+            result_state_policy=result.ResultStatePolicy.KEEP,
+            logger=self.logger,
+            store_strategy=result.StoreStrategy.SQLITE,
+            write_location=os.path.join(self.workspace.input_path, 'nvd-input.db'),
+        )

--- a/src/vunnel/providers/nvd/overrides.py
+++ b/src/vunnel/providers/nvd/overrides.py
@@ -1,0 +1,63 @@
+import glob
+import json
+import logging
+import os
+import tarfile
+from typing import Any
+
+from vunnel.utils import http
+from vunnel.workspace import Workspace
+
+
+class NVDOverrides:
+    __url__ = "http://localhost:8080/overrides.tar.gz"
+    __file_name__ = "nvd-overrides.tar.gz"
+    __extract_name__ = "nvd-overrides"
+
+    def __init__(
+        self,
+        workspace: Workspace,
+        logger: logging.Logger | None = None,
+        download_timeout: int = 125,
+    ):
+        self.workspace = workspace
+        self.download_timeout = download_timeout
+        if not logger:
+            logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logger
+
+    def url(self):
+        return [self.__url__]
+
+    def download(self):
+        req = http.get(self.__url__, self.logger, stream=True, timeout=self.download_timeout)
+
+        file_path = os.path.join(self.workspace.input_path, self.__file_name__)
+        with open(file_path, "wb") as fp:
+            for chunk in req.iter_content():
+                fp.write(chunk)
+
+        untar_file(file_path, self.extract_path)
+
+    @property
+    def extract_path(self):
+        return os.path.join(self.workspace.input_path, self.__extract_name__)
+
+    def cve(self, cve_id: str) -> dict[str, Any] | None:
+        # TODO: implement in-memory index
+        path = os.path.join(self.extract_path, "data", "nvd", "overrides", f"{cve_id.upper()}.json")
+        if os.path.exists(path):
+            with open(path) as f:
+                return json.loads(f.read())
+        return None
+
+    def cves(self) -> list[str]:
+        names = []
+        for path in glob.glob(os.path.join(self.extract_path, "data", "nvd", "overrides", "CVE-*.json")):
+            names.append(os.path.basename(path).replace(".json", ""))
+        return names
+
+
+def untar_file(file_path, extract_path):
+    with tarfile.open(file_path, "r:gz") as tar:
+        tar.extractall(path=extract_path)

--- a/src/vunnel/providers/nvd/overrides.py
+++ b/src/vunnel/providers/nvd/overrides.py
@@ -14,26 +14,32 @@ class NVDOverrides:
     __file_name__ = "nvd-overrides.tar.gz"
     __extract_name__ = "nvd-overrides"
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
+        enabled: bool,
         url: str,
         workspace: Workspace,
         logger: logging.Logger | None = None,
         download_timeout: int = 125,
     ):
+        self.enabled = enabled
         self.__url__ = url
         self.workspace = workspace
         self.download_timeout = download_timeout
         if not logger:
             logger = logging.getLogger(self.__class__.__name__)
         self.logger = logger
-        self.__filepaths_by_cve__ = None
+        self.__filepaths_by_cve__: dict[str, str] = {}
 
     @property
     def url(self) -> str:
         return self.__url__
 
-    def download(self):
+    def download(self) -> None:
+        if not self.enabled:
+            self.logger.debug("overrides are not enabled, skipping download...")
+            return
+
         req = http.get(self.__url__, self.logger, stream=True, timeout=self.download_timeout)
 
         file_path = os.path.join(self.workspace.input_path, self.__file_name__)
@@ -41,21 +47,27 @@ class NVDOverrides:
             for chunk in req.iter_content():
                 fp.write(chunk)
 
-        untar_file(file_path, self.extract_path)
+        untar_file(file_path, self._extract_path)
 
     @property
-    def extract_path(self):
+    def _extract_path(self) -> str:
         return os.path.join(self.workspace.input_path, self.__extract_name__)
 
-    def _build_files_by_cve(self):
-        self.__filepaths_by_cve__ = {}
-        for path in glob.glob(os.path.join(self.extract_path, "**/data/**/", "CVE-*.json"), recursive=True):
+    def _build_files_by_cve(self) -> None:
+        filepaths_by_cve__: dict[str, str] = {}
+        for path in glob.glob(os.path.join(self._extract_path, "**/data/**/", "CVE-*.json"), recursive=True):
             cve_id = os.path.basename(path).removesuffix(".json").upper()
-            self.__filepaths_by_cve__[cve_id] = path
+            filepaths_by_cve__[cve_id] = path
+
+        self.__filepaths_by_cve__ = filepaths_by_cve__
 
     def cve(self, cve_id: str) -> dict[str, Any] | None:
+        if not self.enabled:
+            return None
+
         if self.__filepaths_by_cve__ is None:
             self._build_files_by_cve()
+
         # TODO: implement in-memory index
         path = self.__filepaths_by_cve__.get(cve_id.upper())
         if path and os.path.exists(path):
@@ -64,11 +76,29 @@ class NVDOverrides:
         return None
 
     def cves(self) -> list[str]:
+        if not self.enabled:
+            return []
+
         if self.__filepaths_by_cve__ is None:
             self._build_files_by_cve()
         return list(self.__filepaths_by_cve__.keys())
 
 
-def untar_file(file_path, extract_path):
+def untar_file(file_path: str, extract_path: str) -> None:
     with tarfile.open(file_path, "r:gz") as tar:
-        tar.extractall(path=extract_path)
+
+        def filter_path_traversal(tarinfo: tarfile.TarInfo, path: str) -> tarfile.TarInfo | None:
+            # we do not expect any relative file paths that would result in the clean
+            # path being different from the original path
+            # e.g.
+            #  expected:   results/results.db
+            #  unexpected: results/../../../../etc/passwd
+            # we filter (drop) any such entries
+
+            if path != os.path.normpath(path):
+                return None
+            return tarinfo
+
+        # note: we have a filter that drops any entries that would result in a path traversal
+        # which is what S202 is referring to (linter isn't smart enough to understand this)
+        tar.extractall(path=extract_path, filter=filter_path_traversal)  # noqa: S202

--- a/src/vunnel/result.py
+++ b/src/vunnel/result.py
@@ -42,6 +42,7 @@ class Store:
         result_state_policy: ResultStatePolicy,
         skip_duplicates: bool = False,
         logger: logging.Logger | None = None,
+        **kwargs,
     ):
         self.workspace = workspace
         self.result_state_policy = result_state_policy
@@ -117,6 +118,7 @@ class SQLiteStore(Store):
         self.conn = None
         self.engine = None
         self.table = None
+        self.write_location = kwargs.get('write_location', None)
 
         @db.event.listens_for(db.engine.Engine, "connect")
         def set_sqlite_pragma(dbapi_connection, connection_record):  # type: ignore[no-untyped-def]
@@ -135,6 +137,8 @@ class SQLiteStore(Store):
 
     @property
     def db_file_path(self) -> str:
+        if self.write_location:
+            return self.write_location
         return os.path.join(self.workspace.results_path, self.filename)
 
     @property
@@ -202,6 +206,7 @@ class Writer:
         logger: logging.Logger | None = None,
         skip_duplicates: bool = False,
         store_strategy: StoreStrategy = StoreStrategy.FLAT_FILE,
+        write_location : str | None = None,
     ):
         self.workspace = workspace
         self.skip_duplicates = skip_duplicates
@@ -216,6 +221,7 @@ class Writer:
             result_state_policy=result_state_policy,
             skip_duplicates=skip_duplicates,
             logger=logger,
+            write_location=write_location,
         )
 
     def __enter__(self) -> Writer:

--- a/src/vunnel/result.py
+++ b/src/vunnel/result.py
@@ -279,7 +279,7 @@ class SQLiteReader:
     def read(self, identifier: str) -> dict[str, Any] | None:
         conn, table = self.connection()
         with conn.begin():
-            result = conn.execute(table.select().where(table.c.id == identifier)).first()
+            result = conn.execute(table.select().where(table.c.id == identifier.lower())).first()
             if not result:
                 return None
 

--- a/src/vunnel/result.py
+++ b/src/vunnel/result.py
@@ -6,8 +6,9 @@ import logging
 import os
 import shutil
 import time
+from collections.abc import Generator
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Any
 
 import orjson
 import sqlalchemy as db
@@ -118,7 +119,7 @@ class SQLiteStore(Store):
         self.conn = None
         self.engine = None
         self.table = None
-        self.write_location = kwargs.get('write_location', None)
+        self.write_location = kwargs.get("write_location", None)
         if self.write_location:
             self.filename = os.path.basename(self.write_location)
             self.temp_filename = f"{self.filename}.tmp"
@@ -272,6 +273,7 @@ class Writer:
 
         self.wrote += 1
 
+
 class SQLiteReader:
     def __init__(self, sqlite_db_path: str, table_name: str = "results"):
         self.db_path = sqlite_db_path
@@ -286,7 +288,6 @@ class SQLiteReader:
             all_result = conn.execute(self.table.select())
             for row in all_result:
                 yield row["id"], orjson.loads(row["record"])
-
 
     def connection(self) -> tuple[db.engine.Connection, db.Table]:
         if not self.conn:
@@ -312,7 +313,6 @@ class SQLiteReader:
             self.conn = None
             self.engine = None
             self.table = None
-
 
     # def _create_table(self) -> db.Table:
     #     metadata = db.MetaData()

--- a/src/vunnel/result.py
+++ b/src/vunnel/result.py
@@ -6,7 +6,6 @@ import logging
 import os
 import shutil
 import time
-from collections.abc import Generator
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -43,7 +42,7 @@ class Store:
         result_state_policy: ResultStatePolicy,
         skip_duplicates: bool = False,
         logger: logging.Logger | None = None,
-        **kwargs,
+        **kwargs: dict[str, Any],
     ):
         self.workspace = workspace
         self.result_state_policy = result_state_policy
@@ -194,11 +193,6 @@ class SQLiteStore(Store):
 
             return Envelope(**orjson.loads(result.record))
 
-    def read_all(self) -> Generator[Envelope]:
-        conn, table = self.connection()
-        with conn.begin():
-            result = conn.execute(table.select())
-
     def prepare(self) -> None:
         if os.path.exists(self.temp_db_file_path):
             self.logger.warning("removing unexpected partial result state")
@@ -307,7 +301,7 @@ class SQLiteReader:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ):
+    ) -> None:
         if self.conn:
             self.conn.close()
             self.engine.dispose()
@@ -315,14 +309,3 @@ class SQLiteReader:
             self.conn = None
             self.engine = None
             self.table = None
-
-    # def _create_table(self) -> db.Table:
-    #     metadata = db.MetaData()
-    #     table = db.Table(
-    #         self.table_name,
-    #         metadata,
-    #         db.Column("id", db.String(), primary_key=True, index=True),
-    #         db.Column("record", db.LargeBinary()),
-    #     )
-    #     metadata.create_all(self.engine)
-    #     return table

--- a/src/vunnel/utils/oval_v2.py
+++ b/src/vunnel/utils/oval_v2.py
@@ -94,7 +94,8 @@ class OVALElementParser(ABC):
 
     @staticmethod
     @abstractmethod
-    def parse(xml_element: ET.Element, config: OVALParserConfig) -> Parsed | None: ...
+    def parse(xml_element: ET.Element, config: OVALParserConfig) -> Parsed | None:
+        ...
 
     @staticmethod
     def _find_with_regex(data: str, regex: re.Pattern):

--- a/src/vunnel/utils/oval_v2.py
+++ b/src/vunnel/utils/oval_v2.py
@@ -94,8 +94,7 @@ class OVALElementParser(ABC):
 
     @staticmethod
     @abstractmethod
-    def parse(xml_element: ET.Element, config: OVALParserConfig) -> Parsed | None:
-        ...
+    def parse(xml_element: ET.Element, config: OVALParserConfig) -> Parsed | None: ...
 
     @staticmethod
     def _find_with_regex(data: str, regex: re.Pattern):

--- a/tests/unit/cli/test-fixtures/full.yaml
+++ b/tests/unit/cli/test-fixtures/full.yaml
@@ -37,6 +37,8 @@ providers:
   nvd:
     runtime: *runtime
     request_timeout: 20
+    overrides_enabled: true
+    overrides_url: https://github.com/anchore/nvd-data-overrides/SOMEWHEREELSE/main.tar.gz
   oracle:
     runtime: *runtime
     request_timeout: 20

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -212,6 +212,8 @@ providers:
       result_store: sqlite
   nvd:
     api_key: secret
+    overrides_enabled: false
+    overrides_url: https://github.com/anchore/nvd-data-overrides/archive/refs/heads/main.tar.gz
     request_timeout: 125
     runtime:
       existing_input: keep

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -82,6 +82,8 @@ def test_full_config(helpers):
             nvd=providers.nvd.Config(
                 runtime=runtime_cfg,
                 request_timeout=20,
+                overrides_enabled=True,
+                overrides_url="https://github.com/anchore/nvd-data-overrides/SOMEWHEREELSE/main.tar.gz",
             ),
             oracle=providers.oracle.Config(
                 runtime=runtime_cfg,

--- a/tests/unit/providers/nvd/test_manager.py
+++ b/tests/unit/providers/nvd/test_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 import pytest
-from vunnel import workspace
+from vunnel import workspace, schema
 from vunnel.providers.nvd import manager
 
 
@@ -26,7 +26,11 @@ def test_parser(tmpdir, helpers, mock_data_path, mocker):
         identity = f"{year}/{cve_id}"
         expected_vulns.append((identity, v))
 
-    subject = manager.Manager(workspace=workspace.Workspace(tmpdir, "test", create=True))
+    subject = manager.Manager(
+        workspace=workspace.Workspace(tmpdir, "test", create=True),
+        schema=schema.NVDSchema(),
+        overrides_url="http://example.com",
+    )
     subject.api.cve = mocker.Mock(return_value=[json_dict])
     actual_vulns = list(subject.get(None))
 

--- a/tests/unit/providers/nvd/test_overrides.py
+++ b/tests/unit/providers/nvd/test_overrides.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import tarfile
+from unittest.mock import patch, MagicMock
+
+import pytest
+from vunnel import workspace
+from vunnel.providers.nvd import overrides
+
+
+@pytest.fixture
+def overrides_tar(tmpdir):
+    tar = tmpdir.join("overrides.tar.gz")
+
+    with tarfile.open(tar, "w:gz") as f:
+        f.add("tests/unit/providers/nvd/test-fixtures/single-entry.json", arcname="data/CVE-2011-0022.json")
+
+    return tar
+
+
+@pytest.fixture
+def path_traversal_tar(tmpdir):
+    tar = tmpdir.join("overrides.tar.gz")
+
+    with tarfile.open(tar, "w:gz") as f:
+        f.add("tests/unit/providers/nvd/test-fixtures/single-entry.json", arcname="data/../../CVE-2011-0022.json")
+
+    return tar
+
+
+@patch("requests.get")
+def test_overrides_disabled(mock_requests, tmpdir):
+    subject = overrides.NVDOverrides(
+        enabled=False,
+        url="http://localhost:8080/failed",
+        workspace=workspace.Workspace(tmpdir, "test", create=True),
+    )
+    subject.__filepaths_by_cve__ = {"CVE-2020-0000": '{"fail": true}'}
+
+    # ensure requests.get is not called
+    subject.download()
+    mock_requests.get.assert_not_called()
+
+    # ensure cve returns None
+    assert subject.cve("CVE-2020-0000") is None
+    assert subject.cves() == []
+
+
+@patch("requests.get")
+def test_overrides_enabled(mock_requests, overrides_tar, tmpdir):
+    mock_requests.return_value = MagicMock(status_code=200, iter_content=lambda: [open(overrides_tar, "rb").read()])
+    subject = overrides.NVDOverrides(
+        enabled=True,
+        url="http://localhost:8080/failed",
+        workspace=workspace.Workspace(tmpdir, "test", create=True),
+    )
+
+    subject.download()
+
+    assert subject.cve("CVE-2011-0022") is not None
+    assert subject.cves() == ["CVE-2011-0022"]
+
+
+def test_untar_file(overrides_tar, tmpdir):
+    overrides.untar_file(overrides_tar, tmpdir)
+    assert tmpdir.join("data/CVE-2011-0022.json").check(file=True)
+
+
+def test_untar_file_path_traversal(path_traversal_tar, tmpdir):
+    overrides.untar_file(path_traversal_tar, tmpdir.join("somewhere", "else"))
+    assert tmpdir.join("somewhere/else/CVE-2011-0022.json").check(file=False)


### PR DESCRIPTION
Allows specifying a URL to a tar.gz with NVD overrides data.  This initial version solely supports overriding the `configurations` section of the NVD record and if an override record exists with the CPE configurations section set, it will always override the NVD `configurations` section.

This also integrates the changes to split the NVD data into a separate input database as well as the work done to download from a tar.gz