### PR TITLE
fix: remove sha256 verification for oval parser

### DIFF
--- a/src/vunnel/providers/rhel/oval_parser.py
+++ b/src/vunnel/providers/rhel/oval_parser.py
@@ -78,9 +78,8 @@ class Parser:
                         break
 
                 if len(unmatched_oval_paths) > 0:
-                    error = f"no matching sha256 found for {unmatched_oval_paths}"
-                    self.logger.error(error)
-                    raise Exception(error)
+                    warning = f"no matching sha256 found for {unmatched_oval_paths}"
+                    self.logger.warning(warning)
 
                 self.logger.info(f"finish processing manifest from {manifest_url}")
                 return path_to_sha

--- a/src/vunnel/providers/rhel/oval_parser.py
+++ b/src/vunnel/providers/rhel/oval_parser.py
@@ -84,7 +84,8 @@ class Parser:
 
             for p in oval_paths:
                 self._urls.add(f"{base_url}/{p}")
-                self._download_oval_file(base_url, p)
+                if not skip_download:
+                    self._download_oval_file(base_url, p)
 
     def xml_paths(self):
         paths = []

--- a/src/vunnel/providers/rhel/oval_parser.py
+++ b/src/vunnel/providers/rhel/oval_parser.py
@@ -79,6 +79,7 @@ class Parser:
             base_url = m["base_url"]
             manifest_path = m["manifest_path"]
             oval_paths = m["oval_paths"]
+            skip_download = m.get("skip_download", False)
             self._urls.add(f"{base_url}/{manifest_path}")
 
             for p in oval_paths:


### PR DESCRIPTION
## Summary
This removes the sha256 check from the oval provider so that users will always skip the checksum matching when parsing the following oval data.

It was previously used as a method to skip the download if there was no change. We now opt to always download and remove the complexity based on the below manifest not always having a sha to check against

https://www.redhat.com/security/data/oval/v2/PULP_MANIFEST