### PR TITLE
fix: more verbose ubuntu provider logging to clearly show progress

### DIFF
--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -748,7 +748,7 @@ class Parser:
         to_rev: str,
         updated_paths: list[str],
     ) -> CVEFile | None:
-        self.logger.debug(f"begin processing {cve_id} to rev {to_rev}")
+        self.logger.info(f"begin processing {cve_id} to rev {to_rev}")
 
         if cve_rel_path in updated_paths:
             # merge cves updated since last revision or all if the last processed revision is not available
@@ -763,7 +763,7 @@ class Parser:
             # self.logger.debug("reprocessing merged CVE {}".format(cve_rel_path))
             result = self._reprocess_merged_cve(cve_id, cve_rel_path)
 
-        self.logger.debug(f"finish processing {cve_id} to rev {to_rev}")
+        self.logger.info(f"finish processing {cve_id} to rev {to_rev}")
         return result
 
     def _load_last_processed_rev(self):


### PR DESCRIPTION
Moves some debug messages to info level. This does make the logs much more verbose, but for cases where the task is long-running, its helpful to be able to verify that progress is being made.

I'm open to other approaches such as chunked-counters if this is too verbose. My goal is only to ensure that when this provider runs for many minutes to hours, that its clear in the logs that it is working and making progress rather than being frozen at info-level logs.