### PR TITLE
Input sqlite db should follow lowercase identifier convention

### DIFF
--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -81,8 +81,8 @@ class Manager:
                     yield cve_to_id(cve), self._apply_override(cve, original_record)
 
             self.logger.debug(f"applied overrides for {len(override_remaining_cves)} CVEs")
-
-        self.logger.debug("overrides are not enabled, skipping...")
+        else:
+            self.logger.debug("overrides are not enabled, skipping...")
 
     def _download_nvd_input(
         self,

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -165,7 +165,7 @@ class Manager:
             record_id = cve_to_id(cve_id)
 
             # keep input for future overrides
-            writer.write(record_id, self.schema, vuln)
+            writer.write(record_id.lower(), self.schema, vuln)
 
             # apply overrides to output
             yield record_id, self._apply_override(cve_id=cve_id, record=vuln)

--- a/tests/unit/providers/nvd/test_manager.py
+++ b/tests/unit/providers/nvd/test_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 from vunnel import workspace, schema
@@ -35,3 +36,5 @@ def test_parser(tmpdir, helpers, mock_data_path, mocker):
     actual_vulns = list(subject.get(None))
 
     assert expected_vulns == actual_vulns
+    for vuln in actual_vulns:
+        assert subject._sqlite_reader().read(vuln[0].lower()) is not None

--- a/tests/unit/providers/nvd/test_manager.py
+++ b/tests/unit/providers/nvd/test_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 import pytest
 from vunnel import workspace, schema


### PR DESCRIPTION
This fixes an issue where fetching the record to apply the override would always fail to find the record because it was written with an uppercase key but fetched with a lowercase key.