### PR TITLE
Add SLES 15.6 to quality gate

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -218,6 +218,7 @@ tests:
       - sles:distro:sles:15.3
       - sles:distro:sles:15.4
       - sles:distro:sles:15.5
+      - sles:distro:sles:15.6
 
   - provider: ubuntu
     # ideally we would not use cache, however, the ubuntu provider is currently very expensive to run.


### PR DESCRIPTION
Since SLES 15.6 is out, this PR updates the quality gate check to include it as an expected namespace.

Additionally updates vulnerability match labels to account for failure.