### PR TITLE
Allow for missing ALAS files in Amazon provider

### DIFF
--- a/src/vunnel/providers/amazon/__init__.py
+++ b/src/vunnel/providers/amazon/__init__.py
@@ -22,6 +22,7 @@ class Config:
         ),
     )
     request_timeout: int = 125
+    max_allowed_alas_http_403: int = 25
 
     def __post_init__(self) -> None:
         self.security_advisories = {str(k): str(v) for k, v in self.security_advisories.items()}
@@ -45,6 +46,7 @@ class Provider(provider.Provider):
             security_advisories=config.security_advisories,
             download_timeout=config.request_timeout,
             logger=self.logger,
+            max_allowed_alas_http_403=config.max_allowed_alas_http_403,
         )
 
     @classmethod

--- a/tests/unit/cli/test-fixtures/full.yaml
+++ b/tests/unit/cli/test-fixtures/full.yaml
@@ -19,6 +19,7 @@ providers:
   amazon:
     runtime: *runtime
     request_timeout: 20
+    max_allowed_alas_http_403: 33
     security_advisories:
       42: "https://alas.aws.amazon.com/AL2/alas-42.rss"
   chainguard:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -139,6 +139,7 @@ providers:
         retry_delay: 5
       result_store: sqlite
   amazon:
+    max_allowed_alas_http_403: 25
     request_timeout: 125
     runtime:
       existing_input: keep

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -52,6 +52,7 @@ def test_full_config(helpers):
                 },
                 runtime=runtime_cfg,
                 request_timeout=20,
+                max_allowed_alas_http_403=33,
             ),
             chainguard=providers.chainguard.Config(
                 runtime=runtime_cfg,


### PR DESCRIPTION
It seems that there are some irregularities in the amazon vulnerability data, where the RSS feed that lists ALAS records is not synced with the accompanying HTML files with the advisory details. When this happens, on the first failed request for a non-existing ALAS record we get a HTTP 403 response code and the provider bails with error. This has been happening intermittently for weeks and is most prone to happen when there is no pre-existing state for a given record (as with the vunnel quality gate, and less likely with nightly grype-db builds).

This PR changes the behavior to allow for a limited number of HTTP 403s across all requests for ALAS HTML files, printing the summary of failures at the end of processing:
```bash
[WARNING] failed to fetch 9 ALAS entries due to HTTP 403 response code
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-282.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-283.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-284.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-285.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-286.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-287.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-288.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-289.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-290.html
[INFO ] wrote 2955 entries
[INFO ] recording workspace state
[DEBUG] wrote workspace state to ./data/amazon/metadata.json
# (exit code 0)
```

If the number of 403 responses goes over the allowed amount, then a exception is raised (immediately):
```bash
[DEBUG] loading existing ALAS from ./data/amazon/input/2022_html/ALAS-2023-280
[DEBUG] loading existing ALAS from ./data/amazon/input/2022_html/ALAS-2023-281
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-282.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-282.html
[WARNING] skipping ALAS-2023-282
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-283.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-283.html
[WARNING] skipping ALAS-2023-283
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-284.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-284.html
[WARNING] skipping ALAS-2023-284
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-285.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-285.html
[WARNING] skipping ALAS-2023-285
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-286.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-286.html
[WARNING] skipping ALAS-2023-286
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-287.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-287.html
[WARNING] skipping ALAS-2023-287
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-288.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-288.html
[WARNING] skipping ALAS-2023-288
[DEBUG] http GET https://alas.aws.amazon.com/AL2022/ALAS-2023-289.html
[WARNING] 403 Forbidden: https://alas.aws.amazon.com/AL2022/ALAS-2023-289.html
[ERROR] error downloading data from https://alas.aws.amazon.com/AL2022/ALAS-2023-289.html
Traceback (most recent call last):
  File "/Users/wagoodman/code/vunnel/src/vunnel/providers/amazon/parser.py", line 118, in _get_alas_html
    raise ValueError(
ValueError: exceeded maximum allowed 403 responses (7) from ALAS requests
[WARNING] failed to fetch 8 ALAS entries due to HTTP 403 response code
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-282.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-283.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-284.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-285.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-286.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-287.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-288.html
[WARNING]  - https://alas.aws.amazon.com/AL2022/ALAS-2023-289.html
[INFO ] wrote 2329 entries
[ERROR] error during update: exceeded maximum allowed 403 responses (7) from ALAS requests
# (exit code 1)
```

The new configuration is for the amazon provider exclusively, `max_allowed_alas_http_403`, and defaults to 25 (arbitrary value).