### PR TITLE
fix: update vunnel provider date and option to skip listing check

### DIFF
--- a/src/vunnel/cli/config.py
+++ b/src/vunnel/cli/config.py
@@ -28,6 +28,7 @@ class ImportResults:
     host: str = ""
     path: str = __default_path__
     enabled: bool = False
+    skip_newer_archive_check: bool = False
 
     def __post_init__(self) -> None:
         if not self.path:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -138,6 +138,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   amazon:
     max_allowed_alas_http_403: 25
     request_timeout: 125
@@ -154,6 +155,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
     security_advisories:
       '2': https://alas.aws.amazon.com/AL2/alas.rss
       '2022': https://alas.aws.amazon.com/AL2022/alas.rss
@@ -173,11 +175,13 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   common:
     import_results:
       enabled: false
       host: ''
       path: providers/{provider_name}/listing.json
+      skip_newer_archive_check: false
   debian:
     releases:
       bookworm: '12'
@@ -202,6 +206,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   github:
     api_url: https://api.github.com/graphql
     request_timeout: 125
@@ -218,6 +223,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
     token: secret
   mariner:
     allow_versions:
@@ -237,6 +243,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   nvd:
     api_key: secret
     overrides_enabled: false
@@ -255,6 +262,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   oracle:
     request_timeout: 125
     runtime:
@@ -270,6 +278,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   rhel:
     full_sync_interval: 2
     parallelism: 4
@@ -287,6 +296,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
     skip_namespaces:
       - rhel:3
       - rhel:4
@@ -309,6 +319,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   ubuntu:
     additional_versions: {}
     enable_rev_history: true
@@ -329,6 +340,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
   wolfi:
     request_timeout: 125
     runtime:
@@ -344,6 +356,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_newer_archive_check: false
 root: ./data
 """
     assert expected_output.strip() in res.output


### PR DESCRIPTION
this commit updates the provider date when vunnel is importing results and an options to skip date checks