### PR TITLE
fix: add alpine:3.20 to expected namespaces

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -69,6 +69,7 @@ tests:
       - alpine:distro:alpine:3.17
       - alpine:distro:alpine:3.18
       - alpine:distro:alpine:3.19
+      - alpine:distro:alpine:3.20
       - alpine:distro:alpine:edge
 
   - provider: amazon


### PR DESCRIPTION
Otherwise the quality gate will keep failing.

Addresses one of the problems mentioned in https://github.com/anchore/vunnel/issues/583.

The namespace is coming up now.

Manual testing done on `main`:

1. `make dev provider=alpine`
2. `make update-db`
3. see below

``` sql
sqlite3 --header --column .cache/grype/5/vulnerability.db 'select distinct namespace from vulnerability_metadata where namespace like "%alpine%";'
namespace
-------------------------
alpine:distro:alpine:3.14
alpine:distro:alpine:3.15
alpine:distro:alpine:3.16
alpine:distro:alpine:3.17
alpine:distro:alpine:3.10
alpine:distro:alpine:3.11
alpine:distro:alpine:3.12
alpine:distro:alpine:3.13
alpine:distro:alpine:3.18
alpine:distro:alpine:3.19
alpine:distro:alpine:3.20
alpine:distro:alpine:3.8
alpine:distro:alpine:3.9
alpine:distro:alpine:edge
alpine:distro:alpine:3.6
alpine:distro:alpine:3.7
alpine:distro:alpine:3.2
alpine:distro:alpine:3.3
alpine:distro:alpine:3.4
alpine:distro:alpine:3.5
```