### PR TITLE
feat: add ubuntu 24.10 codename to version mapping

### DIFF
--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -85,6 +85,7 @@ ubuntu_version_names = {
     "lunar": "23.04",
     "mantic": "23.10",
     "noble": "24.04",
+    "oracular": "24.10",
 }
 
 # driver workspace


### PR DESCRIPTION
The codename for Ubuntu 24.10 is `Oracular Oriole` per https://wiki.ubuntu.com/Releases, so this gets the mapping to version in place well in advance