### PR TITLE
chore: validations for python 3.12

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -4,7 +4,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.21.x"
+    default: "1.22.x"
   python-version:
     description: "Python version to install"
     required: true
@@ -14,7 +14,7 @@ inputs:
   poetry-version:
     description: "Poetry version to install"
     required: true
-    default: "1.7.0"
+    default: "1.8.3"
   use-poetry-cache:
     description: "Restore poetry cache"
     required: true

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -48,6 +48,9 @@ jobs:
 
           - version: '3.11'
             toxEnv: py311
+
+          - version: '3.12'
+            toxEnv: py312
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # note: this is not a single source of truth (this is also in the .github/workflows/valiations.yml file)
-envlist = py39, py310, py311
+envlist = py39, py310, py311, py312
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
I believe that previously there was some incompatibility with mashumaro and python 3.12; however, that seems to have been addressed with the latest version in https://github.com/anchore/vunnel/commit/418701a5c260cc6d97631a9f8f5b92c789f9075d, so this adds validations for python 3.12