### PR TITLE
chore: remove unneeded noqa, enable lint for same

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ ignore = [
   "PGH004", # no blanked "noqa" usage, can be improved over time, but not now
   "PLR2004", # a little too agressive, not allowing any magic numbers
   "PLW2901", # "Outer for loop variable X overwritten by inner assignment target", not useful in most cases
-  "RUF100", # no blanket "noqa" usage, can be improved over time, but not now
   "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)` -- not compatible with python 3.9 (even with __future__ import)
 ]
 

--- a/src/vunnel/cli/cli.py
+++ b/src/vunnel/cli/cli.py
@@ -92,7 +92,7 @@ def show_config(cfg: config.Application) -> None:
     logging.info("showing application config")
 
     class IndentDumper(yaml.Dumper):
-        def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:  # noqa: ARG002
+        def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
             return super().increase_indent(flow, False)
 
     def enum_asdict_factory(data: list[tuple[str, Any]]) -> dict[Any, Any]:
@@ -189,7 +189,7 @@ def status_provider(cfg: config.Application, provider_names: str, show_empty: bo
         error: str | None = None
         enabled: bool = True
 
-        def format(self, fill: str) -> str:  # noqa: A003
+        def format(self, fill: str) -> str:
             if self.error:
                 return f"""\
 {fill}      unable to load state: {self.error}"""

--- a/src/vunnel/provider.py
+++ b/src/vunnel/provider.py
@@ -44,7 +44,7 @@ class OnErrorConfig:
     # the number of seconds to wait between retries
     retry_delay: int = 5
     # what to do with the input directory when an error occurs
-    input: InputStatePolicy = InputStatePolicy.KEEP  # noqa: A003
+    input: InputStatePolicy = InputStatePolicy.KEEP
     # what to do with the result directory when an error occurs
     results: ResultStatePolicy = ResultStatePolicy.KEEP
 

--- a/src/vunnel/providers/amazon/parser.py
+++ b/src/vunnel/providers/amazon/parser.py
@@ -36,7 +36,7 @@ class Parser:
     _rss_file_name_ = "{}_rss.xml"
     _html_dir_name_ = "{}_html"
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         workspace,
         download_timeout=125,

--- a/src/vunnel/providers/github/parser.py
+++ b/src/vunnel/providers/github/parser.py
@@ -49,7 +49,7 @@ GITHUB_RATE_LIMIT_RESET_HEADER = "x-ratelimit-reset"
 
 
 class Parser:
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         workspace,
         token,

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -45,7 +45,7 @@ class Manager:
             download_timeout=download_timeout,
         )
 
-        self.urls = [self.api._cve_api_url_]  # noqa: SLF001
+        self.urls = [self.api._cve_api_url_]
         self.schema = schema
 
     def get(

--- a/src/vunnel/providers/nvd/overrides.py
+++ b/src/vunnel/providers/nvd/overrides.py
@@ -17,7 +17,7 @@ class NVDOverrides:
     __file_name__ = "nvd-overrides.tar.gz"
     __extract_name__ = "nvd-overrides"
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         enabled: bool,
         url: str,

--- a/src/vunnel/providers/oracle/parser.py
+++ b/src/vunnel/providers/oracle/parser.py
@@ -115,7 +115,7 @@ class KspliceFilterer:
         epoch, version, release = rpm.split_fullversion(version)
         return cls.ksplice_regex.match(release) is not None
 
-    def filter(self, vuln_dict: dict) -> dict:  # noqa: A003
+    def filter(self, vuln_dict: dict) -> dict:
         """
 
         Filters affected packages and ELSAs that are for ksplice packages since the matching logic for these in Grype isn't

--- a/src/vunnel/providers/rhel/oval_parser.py
+++ b/src/vunnel/providers/rhel/oval_parser.py
@@ -67,7 +67,7 @@ class Parser:
                         extracted.write(uncchunk)
 
                 self.logger.info(f"finish downloading OVAL file from {oval_url}")
-            else:  # noqa: RET505
+            else:
                 raise Exception(f"GET {oval_url} failed with HTTP error {r.status_code}")
         except Exception:
             self.logger.exception("error downloading OVAL file")

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -866,7 +866,7 @@ class Parser:
 
 
 class AffectedRelease:
-    def __init__(self, name=None, version=None, platform=None, rhsa_id=None, module=None):  # noqa: PLR0913
+    def __init__(self, name=None, version=None, platform=None, rhsa_id=None, module=None):
         self.name = name
         self.version = version
         self.platform = platform

--- a/src/vunnel/providers/ubuntu/git.py
+++ b/src/vunnel/providers/ubuntu/git.py
@@ -53,7 +53,7 @@ class GitWrapper:
     _head_rev_cmd_ = "git rev-parse HEAD"
     _ubuntu_server_503_message = "error: RPC failed; HTTP 503 curl 22 The requested URL returned error: 503"
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         source: str,
         branch: str,

--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -742,7 +742,7 @@ class Parser:
             self._delete_merged_cve(cve_id)
         self.logger.info("finish processing deletes")
 
-    def _process_cve(  # noqa: PLR0913
+    def _process_cve(
         self,
         cve_id: str,
         cve_rel_path: str,
@@ -982,7 +982,7 @@ class Parser:
 
         return parsed_cve
 
-    def _resolve_patches_using_history(  # noqa: C901, PLR0912, PLR0915, PLR0913
+    def _resolve_patches_using_history(  # noqa: C901, PLR0912, PLR0915
         self,
         cve_id: str,
         cve_rel_path: str,

--- a/src/vunnel/providers/wolfi/parser.py
+++ b/src/vunnel/providers/wolfi/parser.py
@@ -14,13 +14,13 @@ class Parser:
     _release_ = "rolling"
     _secdb_dir_ = "secdb"
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         workspace,
         url: str,
         namespace: str,
         download_timeout: int = 125,
-        logger: logging.Logger | None = None,  # noqa: PLR0913
+        logger: logging.Logger | None = None,
     ):
         self.download_timeout = download_timeout
         self.secdb_dir_path = os.path.join(workspace.input_path, self._secdb_dir_)

--- a/src/vunnel/schema.py
+++ b/src/vunnel/schema.py
@@ -54,7 +54,7 @@ def MatchExclusionSchema(version: str = MATCH_EXCLUSION_SCHEMA_VERSION) -> Schem
 def GithubSecurityAdvisorySchema(version: str = GITHUB_SECURITY_ADVISORY_SCHEMA_VERSION) -> Schema:
     return Schema(
         version=version,
-        url=f"https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/github-security-advisory/schema-{version}.json",  # noqa: E501
+        url=f"https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/github-security-advisory/schema-{version}.json",
     )
 
 

--- a/src/vunnel/utils/oval_parser.py
+++ b/src/vunnel/utils/oval_parser.py
@@ -58,7 +58,7 @@ def get_opener(filename: str) -> Callable:
     return open
 
 
-def parse(dest_file: str, config: Config, vuln_dict: dict | None = None):  # noqa: C901, PLR0912
+def parse(dest_file: str, config: Config, vuln_dict: dict | None = None):
     """
     Parse the oval file and return a dictionary with tuple (ID, namespace) as the key
     and tuple (version, vulnerability-dictionary) as the value


### PR DESCRIPTION
Previously, RUF100 was disabled, meaning that ruff would pass even if there were noqa comments that were not needed. Remove unneeded noqa comments and enable this lint. This is important because unneeded noqa comments leave the door open for re-introducing linter errors that are previously fixed.

Aside from the pyproject.toml change, this diff was generated by running:

  ruff check . --extend-select RUF100 --fix