### PR TITLE
chore: switch submodule back to main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/quality/vulnerability-match-labels"]
 	path = tests/quality/vulnerability-match-labels
 	url = https://github.com/anchore/vulnerability-match-labels.git
-	branch = ubuntu-label-updates
+	branch = main


### PR DESCRIPTION
The branch it previously pointed at has been removed in the remote, which messes updating submodules from remote because git can't find the remote branch to update from.

It looks to me like anchore/vunnel#597 needed this until anchore/vulnerability-match-labels#136 was merged, but I don't think it needs it any more.

## Manual testing:

Without change:
``` sh
$ git clone --recurse-submodules git@github.com:anchore/vunnel
$ cd vunnel
$ git submodule update --remote --recursive
fatal: Unable to find refs/remotes/origin/ubuntu-label-updates revision in submodule path 'tests/quality/vulnerability-match-labels'
```

With change:
``` sh
$ git clone --recurse-submodules git@github.com:anchore/vunnel -b chore-back-to-main-vulns
$ cd vunnel
$ git submodule update --remote --recursive # succeeds!
```