### PR TITLE
doc: Updates for the Slack to Discourse migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
 
-  - name: Join the Slack community 💬
-    # link to our community Slack registration page
-    url: https://anchore.com/slack
+  - name: Join our Discourse community 💬
+    # link to our community Discourse site
+    url: https://anchore.com/discourse
     about: 'Come chat with us! Ask for help, join our software development efforts, or just give us feedback!'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # vunnel
 
-A tool for fetching, transforming, and storing vulnerability data from a variety of sources.
+**A tool for fetching, transforming, and storing vulnerability data from a variety of sources.**
+
+[![GitHub release](https://img.shields.io/github/release/anchore/vunnel.svg)](https://github.com/anchore/vunnel/releases/latest)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/vunnel/blob/main/LICENSE)
+[![Join our Discourse](https://img.shields.io/badge/Discourse-Join-blue?logo=discourse)](https://anchore.com/discourse)
 
 ![vunnel-demo](https://user-images.githubusercontent.com/590471/226942827-e19742ef-e66e-4e11-8f9b-fb74c40f1dee.gif)
 


### PR DESCRIPTION
This updates the links to the community Slack to Discourse links.