### PR TITLE
test: add validation for ubuntu 24.10 namespace

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -296,6 +296,7 @@ tests:
       - ubuntu:distro:ubuntu:23.04
       - ubuntu:distro:ubuntu:23.10
       - ubuntu:distro:ubuntu:24.04
+      - ubuntu:distro:ubuntu:24.10
     validations:
       - *default-validations
 


### PR DESCRIPTION
Now that vulnerability data is being published for Ubuntu 24.10, we need to add the vulnerability namespace to the expected namespace validation