### PR TITLE
chore: add alpine:3.21 to expected namespaces

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -78,6 +78,7 @@ tests:
       - alpine:distro:alpine:3.18
       - alpine:distro:alpine:3.19
       - alpine:distro:alpine:3.20
+      - alpine:distro:alpine:3.21
       - alpine:distro:alpine:edge
       - nvd:cpe # alpine lists fixes to NVD entries, so NVD entries are also expected
     validations:


### PR DESCRIPTION
Fixes https://github.com/anchore/vunnel/actions/runs/12193244522/job/34022256218#step:4:2245