### PR TITLE
feat: add ubuntu 25.04 codename to version mapping

### DIFF
--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -86,6 +86,7 @@ ubuntu_version_names = {
     "mantic": "23.10",
     "noble": "24.04",
     "oracular": "24.10",
+    "plucky": "25.04",
 }
 
 # driver workspace


### PR DESCRIPTION
The codename for Ubuntu 25.04 is `Plucky Puffin` per https://wiki.ubuntu.com/Releases, so this gets the mapping to version in place. This Ubuntu release is out on 17th April.