### PR TITLE
chore: rename http to http_wrapper

### DIFF
--- a/src/vunnel/provider.py
+++ b/src/vunnel/provider.py
@@ -11,7 +11,8 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 from urllib.parse import urlparse
 
-from vunnel.utils import archive, hasher, http
+from vunnel.utils import archive, hasher
+from vunnel.utils import http_wrapper as http
 
 from . import distribution, result, workspace
 from . import schema as schema_def

--- a/src/vunnel/providers/alpine/parser.py
+++ b/src/vunnel/providers/alpine/parser.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 from vunnel.utils.vulnerability import build_reference_links, vulnerability_element
 
 if TYPE_CHECKING:

--- a/src/vunnel/providers/amazon/parser.py
+++ b/src/vunnel/providers/amazon/parser.py
@@ -8,7 +8,8 @@ from html.parser import HTMLParser
 
 import defusedxml.ElementTree as ET
 
-from vunnel.utils import http, rpm
+from vunnel.utils import http_wrapper as http
+from vunnel.utils import rpm
 
 namespace = "amzn"
 

--- a/src/vunnel/providers/debian/parser.py
+++ b/src/vunnel/providers/debian/parser.py
@@ -11,7 +11,8 @@ from typing import Any
 import orjson
 
 from vunnel.result import SQLiteReader
-from vunnel.utils import http, vulnerability
+from vunnel.utils import http_wrapper as http
+from vunnel.utils import vulnerability
 
 DSAFixedInTuple = namedtuple("DSAFixedInTuple", ["dsa", "link", "distro", "pkg", "ver"])
 DSACollection = namedtuple("DSACollection", ["cves", "nocves"])

--- a/src/vunnel/providers/kev/manager.py
+++ b/src/vunnel/providers/kev/manager.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from typing import Any
 
 from vunnel import workspace
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 
 
 class Manager:

--- a/src/vunnel/providers/mariner/parser.py
+++ b/src/vunnel/providers/mariner/parser.py
@@ -8,7 +8,7 @@ from xsdata.formats.dataclass.parsers import XmlParser
 from xsdata.formats.dataclass.parsers.config import ParserConfig
 
 from vunnel.providers.mariner.model import Definition, RpminfoObject, RpminfoState, RpminfoTest
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 from vunnel.utils.vulnerability import FixedIn, Vulnerability
 
 if TYPE_CHECKING:

--- a/src/vunnel/providers/nvd/api.py
+++ b/src/vunnel/providers/nvd/api.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/src/vunnel/providers/nvd/overrides.py
+++ b/src/vunnel/providers/nvd/overrides.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 from orjson import loads
 
-from vunnel.utils import archive, http
+from vunnel.utils import archive
+from vunnel.utils import http_wrapper as http
 
 if TYPE_CHECKING:
     from vunnel.workspace import Workspace

--- a/src/vunnel/providers/oracle/parser.py
+++ b/src/vunnel/providers/oracle/parser.py
@@ -5,7 +5,8 @@ import logging
 import os
 import re
 
-from vunnel.utils import http, rpm
+from vunnel.utils import http_wrapper as http
+from vunnel.utils import rpm
 from vunnel.utils.oval_parser import Config, parse
 
 # One time initialization of driver specific configuration

--- a/src/vunnel/providers/rhel/csaf_client.py
+++ b/src/vunnel/providers/rhel/csaf_client.py
@@ -6,7 +6,7 @@ import logging
 import os
 from datetime import UTC, datetime
 
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 from vunnel.utils.archive import extract
 from vunnel.utils.csaf_types import CSAFDoc
 from vunnel.utils.csaf_types import from_path as csaf_from_path

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -16,7 +16,8 @@ from dateutil import parser as dt_parser
 
 from vunnel import utils
 from vunnel.providers.rhel.rhsa_provider import AffectedRelease, CSAFRHSAProvider, OVALRHSAProvider
-from vunnel.utils import http, rpm
+from vunnel.utils import http_wrapper as http
+from vunnel.utils import rpm
 from vunnel.utils.vulnerability import vulnerability_element
 
 if TYPE_CHECKING:

--- a/src/vunnel/providers/sles/parser.py
+++ b/src/vunnel/providers/sles/parser.py
@@ -12,7 +12,7 @@ import requests
 from cvss import CVSS3
 from cvss.exceptions import CVSS3MalformedError
 
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 from vunnel.utils.oval_v2 import (
     ArtifactParser,
     Impact,

--- a/src/vunnel/providers/wolfi/parser.py
+++ b/src/vunnel/providers/wolfi/parser.py
@@ -7,7 +7,8 @@ from urllib.parse import urlparse
 
 import orjson
 
-from vunnel.utils import http, vulnerability
+from vunnel.utils import http_wrapper as http
+from vunnel.utils import vulnerability
 
 
 class Parser:

--- a/src/vunnel/utils/http_wrapper.py
+++ b/src/vunnel/utils/http_wrapper.py
@@ -1,4 +1,3 @@
-# noqa: A005
 from __future__ import annotations
 
 import random

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,7 @@ def disable_get_requests(monkeypatch):
 
     from vunnel import utils
 
-    return monkeypatch.setattr(utils.http, "get", disabled)
+    return monkeypatch.setattr(utils.http_wrapper, "get", disabled)
 
 
 def _validate_json_schema(instance: dict, schema: dict):

--- a/tests/unit/providers/amazon/test_amazon.py
+++ b/tests/unit/providers/amazon/test_amazon.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 from vunnel import result, workspace
-from vunnel.utils.http import requests
+from vunnel.utils.http_wrapper import requests
 from vunnel.providers.amazon import Config, Provider, parser
 
 

--- a/tests/unit/providers/kev/test_kev.py
+++ b/tests/unit/providers/kev/test_kev.py
@@ -59,7 +59,7 @@ def test_provider_schema(helpers, mock_data_path, expected_written_entries, disa
     mock_response_obj.text = json.dumps(mock_response)
     mock_response_obj.json.return_value = mock_response
 
-    mocker.patch('vunnel.utils.http.get', return_value=mock_response_obj)
+    mocker.patch('vunnel.utils.http_wrapper.get', return_value=mock_response_obj)
 
     p.update(None)
 
@@ -97,7 +97,7 @@ def test_provider_via_snapshot(helpers, mock_data_path, disable_get_requests, mo
     mock_response_obj.text = json.dumps(mock_response)
     mock_response_obj.json.return_value = mock_response
 
-    mocker.patch('vunnel.utils.http.get', return_value=mock_response_obj)
+    mocker.patch('vunnel.utils.http_wrapper.get', return_value=mock_response_obj)
 
     p.update(None)
 

--- a/tests/unit/providers/nvd/test_api.py
+++ b/tests/unit/providers/nvd/test_api.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import pytest
 from vunnel.providers.nvd import api
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 
 
 @pytest.fixture()

--- a/tests/unit/providers/rhel/test_csaf_client.py
+++ b/tests/unit/providers/rhel/test_csaf_client.py
@@ -21,7 +21,7 @@ def mock_workspace(helpers, fixture_dir):
 
 @pytest.fixture
 def mock_http_get(mocker, fixture_dir):
-    mock = mocker.patch('vunnel.utils.http.get')
+    mock = mocker.patch('vunnel.utils.http_wrapper.get')
 
     fs = fixture_dir / "csaf/server"
 

--- a/tests/unit/utils/test_http_wrapper.py
+++ b/tests/unit/utils/test_http_wrapper.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 import requests
 from unittest.mock import patch, MagicMock, call
-from vunnel.utils import http
+from vunnel.utils import http_wrapper as http
 
 
 class TestGetRequests:


### PR DESCRIPTION
Previously, vunnel.utils.http was shadowing standard lib http, which led to some weird behavior if a library expected to use the standard lib http but the symbol was shadowed.