### PR TITLE
feat: alma linux OSV provider

### DIFF
--- a/schema/vulnerability/osv/schema-1.7.0.json
+++ b/schema/vulnerability/osv/schema-1.7.0.json
@@ -1,0 +1,490 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ossf/osv-schema/main/validation/schema.json",
+  "title": "Open Source Vulnerability",
+  "description": "A schema for describing a vulnerability in an open source package. See also https://ossf.github.io/osv-schema/",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "id": {
+      "$ref": "#/$defs/prefix"
+    },
+    "modified": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "published": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "withdrawn": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "aliases": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "related": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "upstream": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "summary": {
+      "type": "string"
+    },
+    "details": {
+      "type": "string"
+    },
+    "severity": {
+      "$ref": "#/$defs/severity"
+    },
+    "affected": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "package": {
+            "type": "object",
+            "properties": {
+              "ecosystem": {
+                "$ref": "#/$defs/ecosystemWithSuffix"
+              },
+              "name": {
+                "type": "string"
+              },
+              "purl": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "ecosystem",
+              "name"
+            ]
+          },
+          "severity": {
+            "$ref": "#/$defs/severity"
+          },
+          "ranges": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "GIT",
+                    "SEMVER",
+                    "ECOSYSTEM"
+                  ]
+                },
+                "repo": {
+                  "type": "string"
+                },
+                "events": {
+                  "title": "events must contain an introduced object and may contain fixed, last_affected or limit objects",
+                  "type": "array",
+                  "contains": {
+                    "required": [
+                      "introduced"
+                    ]
+                  },
+                  "items": {
+                    "type": "object",
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "introduced": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "introduced"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "fixed": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fixed"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "last_affected": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "last_affected"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "limit": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "limit"
+                        ]
+                      }
+                    ]
+                  },
+                  "minItems": 1
+                },
+                "database_specific": {
+                  "type": "object"
+                }
+              },
+              "allOf": [
+                {
+                  "title": "GIT ranges require a repo",
+                  "if": {
+                    "properties": {
+                      "type": {
+                        "const": "GIT"
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "repo"
+                    ]
+                  }
+                },
+                {
+                  "title": "last_affected and fixed events are mutually exclusive",
+                  "if": {
+                    "properties": {
+                      "events": {
+                        "contains": {
+                          "required": [
+                            "last_affected"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "then": {
+                    "not": {
+                      "properties": {
+                        "events": {
+                          "contains": {
+                            "required": [
+                              "fixed"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "type",
+                "events"
+              ]
+            }
+          },
+          "versions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ecosystem_specific": {
+            "type": "object"
+          },
+          "database_specific": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "references": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ADVISORY",
+              "ARTICLE",
+              "DETECTION",
+              "DISCUSSION",
+              "REPORT",
+              "FIX",
+              "INTRODUCED",
+              "GIT",
+              "PACKAGE",
+              "EVIDENCE",
+              "WEB"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ]
+      }
+    },
+    "credits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "contact": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "FINDER",
+              "REPORTER",
+              "ANALYST",
+              "COORDINATOR",
+              "REMEDIATION_DEVELOPER",
+              "REMEDIATION_REVIEWER",
+              "REMEDIATION_VERIFIER",
+              "TOOL",
+              "SPONSOR",
+              "OTHER"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    "database_specific": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "id",
+    "modified"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "required": [
+          "severity"
+        ]
+      },
+      "then": {
+        "properties": {
+          "affected": {
+            "items": {
+              "properties": {
+                "severity": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "ecosystemName": {
+      "type": "string",
+      "title": "Currently supported ecosystems",
+      "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
+      "enum": [
+        "AlmaLinux",
+        "Alpine",
+        "Android",
+        "Bioconductor",
+        "Bitnami",
+        "Chainguard",
+        "ConanCenter",
+        "CRAN",
+        "crates.io",
+        "Debian",
+        "GHC",
+        "GitHub Actions",
+        "Go",
+        "Hackage",
+        "Hex",
+        "Kubernetes",
+        "Linux",
+        "Mageia",
+        "Maven",
+        "npm",
+        "NuGet",
+        "openSUSE",
+        "OSS-Fuzz",
+        "Packagist",
+        "Photon OS",
+        "Pub",
+        "PyPI",
+        "Red Hat",
+        "Rocky Linux",
+        "RubyGems",
+        "SUSE",
+        "SwiftURL",
+        "Ubuntu",
+        "Wolfi"
+      ]
+    },
+    "ecosystemSuffix": {
+      "type": "string",
+      "pattern": ":.+"
+    },
+    "ecosystemWithSuffix": {
+      "type": "string",
+      "title": "Currently supported ecosystems",
+      "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
+      "pattern": "^(AlmaLinux|Alpine|Android|Bioconductor|Bitnami|Chainguard|ConanCenter|CRAN|crates\\.io|Debian|GHC|GitHub Actions|Go|Hackage|Hex|Kubernetes|Linux|Mageia|Maven|npm|NuGet|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|RubyGems|SUSE|SwiftURL|Ubuntu|Wolfi|GIT)(:.+)?$"
+    },
+    "prefix": {
+      "type": "string",
+      "title": "Currently supported home database identifier prefixes",
+      "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|MAL|MGASA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
+    },
+    "severity": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "CVSS_V2",
+              "CVSS_V3",
+              "CVSS_V4",
+              "Ubuntu"
+            ]
+          },
+          "score": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "CVSS_V2"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "score": {
+                  "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "CVSS_V3"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "score": {
+                  "pattern": "^CVSS:3[.][01]/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "CVSS_V4"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "score": {
+                  "pattern": "^CVSS:4[.]0/AV:[NALP]/AC:[LH]/AT:[NP]/PR:[NLH]/UI:[NPA]/VC:[HLN]/VI:[HLN]/VA:[HLN]/SC:[HLN]/SI:[HLN]/SA:[HLN](/E:[XAPU])?(/CR:[XHML])?(/IR:[XHML])?(/AR:[XHML])?(/MAV:[XNALP])?(/MAC:[XLH])?(/MAT:[XNP])?(/MPR:[XNLH])?(/MUI:[XNPA])?(/MVC:[XNLH])?(/MVI:[XNLH])?(/MVA:[XNLH])?(/MSC:[XNLH])?(/MSI:[XNLHS])?(/MSA:[XNLHS])?(/S:[XNP])?(/AU:[XNY])?(/R:[XAUI])?(/V:[XDC])?(/RE:[XLMH])?(/U:(X|Clear|Green|Amber|Red))?$"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "Ubuntu"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "score": {
+                  "enum": [
+                    "negligible",
+                    "low",
+                    "medium",
+                    "high",
+                    "critical"
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "required": [
+          "type",
+          "score"
+        ]
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/vunnel/cli/config.py
+++ b/src/vunnel/cli/config.py
@@ -42,6 +42,7 @@ class CommonProviderConfig:
 
 @dataclass
 class Providers:
+    alma: providers.alma.Config = field(default_factory=providers.alma.Config)
     alpine: providers.alpine.Config = field(default_factory=providers.alpine.Config)
     amazon: providers.amazon.Config = field(default_factory=providers.amazon.Config)
     bitnami: providers.bitnami.Config = field(default_factory=providers.bitnami.Config)

--- a/src/vunnel/providers/__init__.py
+++ b/src/vunnel/providers/__init__.py
@@ -5,6 +5,7 @@ from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
 
 from vunnel.providers import (
+    alma,
     alpine,
     amazon,
     bitnami,
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
 
 _providers: dict[str, type[provider.Provider]] = {
     # vulnerability providers
+    alma.Provider.name(): alma.Provider,
     alpine.Provider.name(): alpine.Provider,
     amazon.Provider.name(): amazon.Provider,
     bitnami.Provider.name(): bitnami.Provider,

--- a/src/vunnel/providers/alma/__init__.py
+++ b/src/vunnel/providers/alma/__init__.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from vunnel import provider, result, schema
+
+from .parser import Parser
+
+if TYPE_CHECKING:
+    import datetime
+
+
+@dataclass
+class Config:
+    runtime: provider.RuntimeConfig = field(
+        default_factory=lambda: provider.RuntimeConfig(
+            result_store=result.StoreStrategy.SQLITE,
+            existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
+        ),
+    )
+    request_timeout: int = 125
+
+
+class Provider(provider.Provider):
+    __schema__ = schema.OSVSchema()
+    __distribution_version__ = int(__schema__.major_version)
+
+    def __init__(self, root: str, config: Config | None = None):
+        if not config:
+            config = Config()
+
+        super().__init__(root, runtime_cfg=config.runtime)
+        self.config = config
+        self.logger.debug(f"config: {config}")
+
+        self.schema = self.__schema__
+        self.parser = Parser(
+            ws=self.workspace,
+            logger=self.logger,
+        )
+
+        # this provider requires the previous state from former runs
+        provider.disallow_existing_input_policy(config.runtime)
+
+    @classmethod
+    def name(cls) -> str:
+        return "alma"
+
+    @classmethod
+    def compatible_schema(cls, schema_version: str) -> schema.Schema | None:
+        candidate = schema.OSVSchema(schema_version)
+        if candidate.major_version == cls.__schema__.major_version:
+            return candidate
+        return None
+
+    def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
+        # TODO: use of last_updated as NVD provider does to avoid downloading all
+        # vulnerability data from the source and make incremental updates instead
+        with self.results_writer() as writer:
+            for vuln_id, vuln_schema_version, record in self.parser.get():
+                vuln_schema = self.compatible_schema(vuln_schema_version)
+                if not vuln_schema:
+                    self.logger.warning(
+                        f"skipping vulnerability {vuln_id} with schema version {vuln_schema_version} ",
+                        f"as is incompatible with provider schema version {self.schema.version}",
+                    )
+                    continue
+                writer.write(
+                    identifier=vuln_id.lower(),
+                    schema=vuln_schema,
+                    payload=record,
+                )
+
+        return self.parser.urls, len(writer)

--- a/src/vunnel/providers/alma/git.py
+++ b/src/vunnel/providers/alma/git.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+
+from vunnel import utils
+
+
+@dataclass
+class GitRevision:
+    sha: str
+    file: str
+
+
+class GitWrapper:
+    _check_cmd_ = "git --version"
+    _is_git_repo_cmd_ = "git rev-parse --is-inside-work-tree"
+    _clone_cmd_ = "git clone -b {branch} {src} {dest}"
+    _check_out_cmd_ = "git checkout {branch}"
+
+    def __init__(
+        self,
+        source: str,
+        branch: str,
+        checkout_dest: str,
+        logger: logging.Logger | None = None,
+    ):
+        self.src = source
+        self.branch = branch
+        self.dest = checkout_dest
+        self.workspace = tempfile.gettempdir()
+
+        if not logger:
+            logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logger
+
+        try:
+            out = self._exec_cmd(self._check_cmd_)
+            self.logger.trace(f"git executable verified using cmd: {self._check_cmd_}, output: {out}")  # type: ignore[attr-defined]
+        except:
+            self.logger.exception('could not find required "git" executable. Please install git on host')
+            raise
+
+    def delete_repo(self) -> None:
+        if os.path.exists(self.dest):
+            self.logger.debug("deleting existing repository")
+            shutil.rmtree(self.dest, ignore_errors=True)
+
+    @utils.retry_with_backoff()
+    def clone_repo(self) -> None:
+        try:
+            self.logger.info(f"cloning git repository {self.src} branch {self.branch} to {self.dest}")
+            cmd = self._clone_cmd_.format(src=self.src, dest=self.dest, branch=self.branch)
+            out = self._exec_cmd(cmd)
+            self.logger.debug(f"initialized git repo, cmd: {cmd}, output: {out}")
+        except:
+            self.logger.exception(f"failed to clone git repository {self.src} branch {self.branch} to {self.dest}")
+            raise
+
+    def _exec_cmd(self, cmd: str) -> str:
+        """
+        Run a command with errors etc handled
+        :param cmd: list of arguments (including command name, e.g. ['ls', '-l])
+        :param args:
+        :param kwargs:
+        :return:
+        """
+        try:
+            self.logger.trace(f"running: {cmd}")  # type: ignore[attr-defined]
+            cmd_list = shlex.split(cmd)
+            # S603 disable explanation: running git commands by design
+            return subprocess.check_output(cmd_list, text=True, stderr=subprocess.PIPE)  # noqa: S603
+        except Exception as e:
+            self.logger.exception(f"error executing command: {cmd}")
+            raise e

--- a/src/vunnel/providers/alma/parser.py
+++ b/src/vunnel/providers/alma/parser.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+import orjson
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from vunnel.workspace import Workspace
+
+from .git import GitWrapper
+
+
+class Parser:
+    _git_src_url_ = "https://github.com/AlmaLinux/osv-database.git"
+    _git_src_branch_ = "master"
+
+    def __init__(self, ws: Workspace, logger: logging.Logger | None = None, alma_linux_versions: list[str] | None = None):
+        if alma_linux_versions is None:
+            alma_linux_versions = ["8", "9"]
+        self.alma_linux_versions = alma_linux_versions
+        self.workspace = ws
+        self.git_url = self._git_src_url_
+        self.git_branch = self._git_src_branch_
+        self.urls = [self.git_url]
+        if not logger:
+            logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logger
+        _checkout_dst_ = os.path.join(self.workspace.input_path, "osv-database")
+        self.git_wrapper = GitWrapper(
+            source=self.git_url,
+            branch=self.git_branch,
+            checkout_dest=_checkout_dst_,
+            logger=self.logger,
+        )
+
+    def _load(self, version: str) -> Generator[dict[str, Any], None, None]:
+        self.logger.info("loading data from git repository")
+
+        # TODO: almalinux8 and almalinux9 subdirectories
+        vuln_data_dir = os.path.join(self.workspace.input_path, "osv-database", "advisories", f"almalinux{version}")
+        for root, dirs, files in os.walk(vuln_data_dir):
+            dirs.sort()
+            for file in sorted(files):
+                full_path = os.path.join(root, file)
+                with open(full_path, encoding="utf-8") as f:
+                    yield orjson.loads(f.read())
+
+    def _normalize(self, vuln_entry: dict[str, Any], version: str) -> tuple[str, str, dict[str, Any]]:
+        self.logger.trace("normalizing vulnerability data")  # type: ignore[attr-defined]
+
+        # We want to return the OSV record as it is (using OSV schema)
+        # We'll transform it into the Grype-specific vulnerability schema
+        # on grype-db
+        vuln_id = vuln_entry["id"]
+        vuln_schema = vuln_entry.get("schema_version", "1.7.0")  # TODO: this is a bit of a hack;
+        # we should see whether upstream is willing to put schema versions in the data.
+        return os.path.join(f"almalinux{version}", vuln_id), vuln_schema, vuln_entry
+
+    def get(self) -> Generator[tuple[str, str, dict[str, Any]], None, None]:
+        # Initialize the git repository
+        self.git_wrapper.delete_repo()
+        self.git_wrapper.clone_repo()
+        for version in self.alma_linux_versions:
+            for vuln_entry in self._load(version):
+                # Normalize the loaded data
+                yield self._normalize(vuln_entry, version)

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -123,6 +123,22 @@ log:
   show_timestamp: false
   slim: false
 providers:
+  alma:
+    request_timeout: 125
+    runtime:
+      existing_input: keep
+      existing_results: delete-before-write
+      import_results_enabled: false
+      import_results_host: ''
+      import_results_path: providers/{provider_name}/listing.json
+      on_error:
+        action: fail
+        input: keep
+        results: keep
+        retry_count: 3
+        retry_delay: 5
+      result_store: sqlite
+      skip_newer_archive_check: false
   alpine:
     request_timeout: 125
     runtime:

--- a/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux8/ALBA-2021:4378.json
+++ b/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux8/ALBA-2021:4378.json
@@ -1,0 +1,149 @@
+{
+  "id": "ALBA-2021:4378",
+  "summary": "krb5 bug fix and enhancement update",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "krb5-devel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.2-14.el8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "krb5-libs"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.2-14.el8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "krb5-pkinit"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.2-14.el8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "krb5-server"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.2-14.el8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "krb5-server-ldap"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.2-14.el8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "krb5-workstation"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.2-14.el8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "libkadm5"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.18.2-14.el8"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "related": [],
+  "published": "2021-11-09T09:14:31Z",
+  "modified": "2021-11-09T13:10:03Z",
+  "details": "For detailed information on changes in this release, see the AlmaLinux Release Notes linked from the References section.",
+  "references": [
+    {
+      "url": "https://errata.almalinux.org/8/ALBA-2021-4378.html",
+      "type": "ADVISORY"
+    }
+  ]
+}

--- a/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux8/ALSA-2023:4520.json
+++ b/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux8/ALSA-2023:4520.json
@@ -1,0 +1,49 @@
+{
+  "id": "ALSA-2023:4520",
+  "summary": "Moderate: python-requests security update",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:8",
+        "name": "python3-requests"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.20.0-3.el8_8"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "related": [
+    "CVE-2023-32681"
+  ],
+  "published": "2023-08-08T00:00:00Z",
+  "modified": "2023-08-09T11:03:48Z",
+  "details": "The python-requests package contains a library designed to make HTTP requests easy for developers.\n\nSecurity Fix(es):\n\n* python-requests: Unintended leak of Proxy-Authorization header (CVE-2023-32681)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+  "references": [
+    {
+      "url": "https://access.redhat.com/errata/RHSA-2023:4520",
+      "type": "ADVISORY"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2023-32681",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2209469",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://errata.almalinux.org/8/ALSA-2023-4520.html",
+      "type": "ADVISORY"
+    }
+  ]
+}

--- a/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux9/ALSA-2022:8194.json
+++ b/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux9/ALSA-2022:8194.json
@@ -1,0 +1,168 @@
+{
+  "id": "ALSA-2022:8194",
+  "summary": "Moderate: libtiff security update",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "libtiff"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.4.0-2.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "libtiff-devel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.4.0-2.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "libtiff-tools"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "4.4.0-2.el9"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "related": [
+    "CVE-2022-0561",
+    "CVE-2022-0562",
+    "CVE-2022-0865",
+    "CVE-2022-0924",
+    "CVE-2022-1355",
+    "CVE-2022-22844",
+    "CVE-2022-0891",
+    "CVE-2022-0908",
+    "CVE-2022-0909",
+    "CVE-2022-1354"
+  ],
+  "published": "2022-11-15T00:00:00Z",
+  "modified": "2022-11-18T13:09:36Z",
+  "details": "The libtiff packages contain a library of functions for manipulating Tagged Image File Format (TIFF) files.\n\nSecurity Fix(es):\n\n* libtiff: Denial of Service via crafted TIFF file (CVE-2022-0561)\n* libtiff: Null source pointer lead to Denial of Service via crafted TIFF file (CVE-2022-0562)\n* libtiff: reachable assertion (CVE-2022-0865)\n* libtiff: Out-of-bounds Read error in tiffcp (CVE-2022-0924)\n* libtiff: stack-buffer-overflow in tiffcp.c in main() (CVE-2022-1355)\n* libtiff: out-of-bounds read in _TIFFmemcpy() in tif_unix.c (CVE-2022-22844)\n* libtiff: heap buffer overflow in extractImageSection (CVE-2022-0891)\n* tiff: Null source pointer passed as an argument to memcpy in TIFFFetchNormalTag() in tif_dirread.c (CVE-2022-0908)\n* tiff: Divide By Zero error in tiffcrop (CVE-2022-0909)\n* libtiff: heap-buffer-overflow in TIFFReadRawDataStriped() in tiffinfo.c (CVE-2022-1354)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the AlmaLinux Release Notes linked from the References section.",
+  "references": [
+    {
+      "url": "https://access.redhat.com/errata/RHSA-2022:8194",
+      "type": "ADVISORY"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-0561",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-0562",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-0865",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-0891",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-0908",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-0909",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-0924",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-1354",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-1355",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2022-22844",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2042603",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2054494",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2054495",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2064145",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2064146",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2064148",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2064406",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2064411",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2074404",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2074415",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://errata.almalinux.org/9/ALSA-2022-8194.html",
+      "type": "ADVISORY"
+    }
+  ]
+}

--- a/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux9/ALSA-2024:2433.json
+++ b/tests/unit/providers/alma/test-fixtures/osv-database/advisories/almalinux9/ALSA-2024:2433.json
@@ -1,0 +1,256 @@
+{
+  "id": "ALSA-2024:2433",
+  "summary": "Moderate: avahi security update",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-compat-howl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-compat-howl-devel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-compat-libdns_sd"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-compat-libdns_sd-devel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-devel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-glib"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-glib-devel"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-libs"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "AlmaLinux:9",
+        "name": "avahi-tools"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.8-20.el9"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "related": [
+    "CVE-2023-38469",
+    "CVE-2023-38470",
+    "CVE-2023-38471",
+    "CVE-2023-38472",
+    "CVE-2023-38473"
+  ],
+  "published": "2024-04-30T00:00:00Z",
+  "modified": "2024-05-07T15:04:20Z",
+  "details": "Avahi is an implementation of the DNS Service Discovery and Multicast DNS specifications for Zero Configuration Networking. It facilitates service discovery on a local network. Avahi and Avahi-aware applications allow you to plug your computer into a network and, with no configuration, view other people to chat with, view printers to print with, and find shared files on other computers.\n\nSecurity Fix(es):\n\n* avahi: Reachable assertion in avahi_dns_packet_append_record (CVE-2023-38469)\n* avahi: Reachable assertion in avahi_escape_label (CVE-2023-38470)\n* avahi: Reachable assertion in dbus_set_host_name (CVE-2023-38471)\n* avahi: Reachable assertion in avahi_rdata_parse (CVE-2023-38472)\n* avahi: Reachable assertion in avahi_alternative_host_name (CVE-2023-38473)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the AlmaLinux Release Notes linked from the References section.",
+  "references": [
+    {
+      "url": "https://access.redhat.com/errata/RHSA-2024:2433",
+      "type": "ADVISORY"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2023-38469",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2023-38470",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2023-38471",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2023-38472",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://access.redhat.com/security/cve/CVE-2023-38473",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2191687",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2191690",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2191691",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2191692",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://bugzilla.redhat.com/2191694",
+      "type": "REPORT"
+    },
+    {
+      "url": "https://errata.almalinux.org/9/ALSA-2024-2433.html",
+      "type": "ADVISORY"
+    }
+  ]
+}

--- a/tests/unit/providers/alma/test_alma.py
+++ b/tests/unit/providers/alma/test_alma.py
@@ -1,0 +1,44 @@
+
+import shutil
+from unittest.mock import patch
+
+from vunnel import result
+from vunnel.providers.alma import Config, Provider
+from vunnel.providers.alma.parser import Parser
+
+
+@patch("vunnel.providers.alma.git.GitWrapper.clone_repo")
+@patch("vunnel.providers.alma.git.GitWrapper.delete_repo")
+def test_provider_schema(mock_git_delete, mock_git_clone, helpers):
+    mock_git_clone.return_value = None
+    mock_git_delete.return_value = None
+    workspace = helpers.provider_workspace_helper(name=Provider.name())
+    c = Config()
+    c.runtime.result_store = result.StoreStrategy.FLAT_FILE
+    p = Provider(root=workspace.root, config=c)
+    mock_data_path = helpers.local_dir("test-fixtures")
+    shutil.copytree(mock_data_path, workspace.input_dir, dirs_exist_ok=True)
+    p.update(None)
+
+    assert 4 == workspace.num_result_entries()
+    assert workspace.result_schemas_valid(require_entries=True)
+
+@patch("vunnel.providers.alma.git.GitWrapper.clone_repo")
+@patch("vunnel.providers.alma.git.GitWrapper.delete_repo")
+def test_parser(mock_git_delete, mock_git_clone, helpers):
+    mock_git_clone.return_value = None
+    mock_git_delete.return_value = None
+    workspace = helpers.provider_workspace_helper(name=Provider.name())
+    mock_data_path = helpers.local_dir("test-fixtures")
+    shutil.copytree(mock_data_path, workspace.input_dir, dirs_exist_ok=True)
+    parser = Parser(ws=workspace, logger=None)
+    vuln_tuples = list(parser.get())
+    assert len(vuln_tuples) == 4
+    assert vuln_tuples[0][0] == "almalinux8/ALBA-2021:4378"
+    assert vuln_tuples[0][1] == "1.7.0"
+    assert vuln_tuples[1][0] == "almalinux8/ALSA-2023:4520"
+    assert vuln_tuples[1][1] == "1.7.0"
+    assert vuln_tuples[2][0] == "almalinux9/ALSA-2022:8194"
+    assert vuln_tuples[2][1] == "1.7.0"
+    assert vuln_tuples[3][0] == "almalinux9/ALSA-2024:2433"
+    assert vuln_tuples[3][1] == "1.7.0"

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -964,6 +964,7 @@ def test_provider_versions(tmpdir):
     # WARNING: changing the values of these versions has operational impact! Do not change them without
     # understanding the implications!
     expected = {
+        "alma": 1,
         "alpine": 1,
         "amazon": 1,
         "bitnami": 1,
@@ -995,6 +996,7 @@ def test_provider_distribution_versions(tmpdir):
     # WARNING: changing the values of these distributions has operational impact! Do not change them without
     # understanding the implications!
     expected = {
+        "alma": 1,
         "alpine": 1,
         "amazon": 1,
         "bitnami": 1,


### PR DESCRIPTION
This creates a new Vunnel provider that pulls AlmaLinux's OSV data from https://github.com/AlmaLinux/osv-database.

It will make use of the grype-db OSV transform currently in progress in anchore/grype-db#217.

How to interpret this data once it's in Grype's database is another question. For example, is this data intended to supplement or replace upstream data from RedHat? I think we can discuss those questions during or even after review of this PR, because this PR just makes the data available to grype db without any real interpretation.

The only caveat on the data so far is that, AFAICT, Alma's repo does not say which version of the OSV spec will be emitted. Because the code that generates the repo depends on the latest version of the `osv` PyPI package, I've assumed that they are emitting the latest version, 1.7.0 as of this writing.