### PR TITLE
chore: switch to uv dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: daily


### PR DESCRIPTION
It looks like dependabot is not correctly detecting dependencies for the uv ecosystem when the ecosystem is declared as pip (which it did for poetry), so switch the declared ecossytem to uv and try that.

Example of dependency detection failure since switch: https://github.com/anchore/vunnel/pull/798#issuecomment-2743575637

Link to docs that say that `uv` should be the package ecosystem: https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories