### PR TITLE
feat: add skip download CLI option

### DIFF
--- a/src/vunnel/cli/cli.py
+++ b/src/vunnel/cli/cli.py
@@ -145,11 +145,16 @@ def show_config(cfg: config.Application) -> None:
 
 @cli.command(name="run", help="run a vulnerability provider")
 @click.argument("provider_name", metavar="PROVIDER")
+@click.option("--skip-download", is_flag=True, help="skip downloading data", default=False)
 @click.pass_obj
-def run_provider(cfg: config.Application, provider_name: str) -> None:
+def run_provider(cfg: config.Application, provider_name: str, skip_download: bool) -> None:
     logging.info(f"running {provider_name} provider")
+    config = cfg.providers.get(provider_name)
+    # technically config has type Any | None, so double check to appease mypy
+    if config and config.runtime and hasattr(config.runtime, "skip_download"):
+        config.runtime.skip_download = skip_download
 
-    provider = providers.create(provider_name, cfg.root, config=cfg.providers.get(provider_name))
+    provider = providers.create(provider_name, cfg.root, config=config)
     provider.run()
 
 

--- a/src/vunnel/provider.py
+++ b/src/vunnel/provider.py
@@ -70,6 +70,8 @@ class RuntimeConfig:
     result_store: result.StoreStrategy = result.StoreStrategy.FLAT_FILE
     # skip checks for newer archive if true (always download latest)
     skip_newer_archive_check: bool = False
+    # skip downloading any data; useful for working on a provider with a slow download step
+    skip_download: bool = False
 
     import_results_host: Optional[str] = None  # noqa: UP007 - breaks mashumaro
     import_results_path: Optional[str] = None  # noqa: UP007 - breaks mashumaro
@@ -128,10 +130,16 @@ class Provider(abc.ABC):
                 raise RuntimeError("enabling import results requires path")
 
         self.runtime_cfg = runtime_cfg
+        if runtime_cfg.skip_download and not self.__class__.supports_skip_download():
+            self.logger.warning(f"skip_download is not supported by {self.name()}")
 
     @classmethod
     def version(cls) -> int:
         return cls.__version__ + (cls.distribution_version() - 1)
+
+    @classmethod
+    def supports_skip_download(cls) -> bool:
+        return False
 
     @classmethod
     def distribution_version(cls) -> int:

--- a/src/vunnel/providers/rocky/__init__.py
+++ b/src/vunnel/providers/rocky/__init__.py
@@ -38,6 +38,7 @@ class Provider(provider.Provider):
         self.parser = Parser(
             ws=self.workspace,
             logger=self.logger,
+            skip_download=config.runtime.skip_download,
         )
 
         # this provider requires the previous state from former runs
@@ -46,6 +47,10 @@ class Provider(provider.Provider):
     @classmethod
     def name(cls) -> str:
         return "rocky"
+
+    @classmethod
+    def supports_skip_download(cls) -> bool:
+        return True
 
     @classmethod
     def compatible_schema(cls, schema_version: str) -> schema.Schema | None:
@@ -69,5 +74,6 @@ class Provider(provider.Provider):
                     schema=vuln_schema,
                     payload=record,
                 )
-
+        if len(writer) == 0 and self.config.runtime.skip_download:
+            raise RuntimeError("download skipped on empty workspace")
         return self.parser.urls, len(writer)

--- a/src/vunnel/providers/rocky/client.py
+++ b/src/vunnel/providers/rocky/client.py
@@ -17,6 +17,7 @@ class Client:
         logger: logging.Logger | None = None,
         rocky_versions: list[str] | None = None,
         api_host: str = "https://apollo.build.resf.org",
+        skip_download: bool = False,
     ):
         if rocky_versions is None:
             rocky_versions = ["8", "9"]
@@ -27,6 +28,7 @@ class Client:
             logger = logging.getLogger("rocky-linux-apollo-client")
         self.logger = logger
         self.download_path = download_path
+        self._skip_download = skip_download
 
     def _download(self) -> None:
         next_page = self._default_api_path_
@@ -44,6 +46,9 @@ class Client:
 
     def get(self) -> Generator[Path, None, None]:
         os.makedirs(self.download_path, exist_ok=True)
-        self._download()
+        if not self._skip_download:
+            self._download()
+        else:
+            self.logger.info("Skipping download of Rocky Linux advisories")
         downloads = Path(self.download_path)
         yield from sorted(downloads.rglob("*.json"))

--- a/src/vunnel/providers/rocky/parser.py
+++ b/src/vunnel/providers/rocky/parser.py
@@ -15,7 +15,7 @@ from .client import Client
 
 
 class Parser:
-    def __init__(self, ws: Workspace, logger: logging.Logger | None = None):
+    def __init__(self, ws: Workspace, logger: logging.Logger | None = None, skip_download: bool = False):
         self.workspace = ws
         if not logger:
             logger = logging.getLogger(self.__class__.__name__)
@@ -23,6 +23,7 @@ class Parser:
         self.client = Client(
             download_path=os.path.join(self.workspace.input_path, "osv"),
             logger=self.logger,
+            skip_download=skip_download,
         )
         self.urls = self.client.urls
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -138,6 +138,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   alpine:
     request_timeout: 125
@@ -154,6 +155,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   amazon:
     max_allowed_alas_http_403: 25
@@ -171,6 +173,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
     security_advisories:
       '2': https://alas.aws.amazon.com/AL2/alas.rss
@@ -191,6 +194,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   chainguard:
     request_timeout: 125
@@ -207,6 +211,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   common:
     import_results:
@@ -238,6 +243,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   epss:
     dataset: current
@@ -255,6 +261,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
     url_template: https://epss.cyentia.com/epss_scores-{}.csv.gz
   github:
@@ -273,6 +280,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
     token: secret
   kev:
@@ -290,6 +298,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
     url: https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
   mariner:
@@ -311,6 +320,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   nvd:
     api_key: secret
@@ -331,6 +341,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   oracle:
     request_timeout: 125
@@ -347,6 +358,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   rhel:
     full_sync_interval: 2
@@ -366,6 +378,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
     skip_namespaces:
       - rhel:3
@@ -385,6 +398,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   sles:
     allow_versions:
@@ -405,6 +419,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   ubuntu:
     additional_versions: {}
@@ -426,6 +441,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
   wolfi:
     request_timeout: 125
@@ -442,6 +458,7 @@ providers:
         retry_count: 3
         retry_delay: 5
       result_store: sqlite
+      skip_download: false
       skip_newer_archive_check: false
 root: ./data
 """


### PR DESCRIPTION
This adds the ability to skip downloading to the CLI, so that users can run "vunnel run <provider> --skip-download". This is useful when working on a provider with a slow download step.

Currently, only Rocky Linux provider supports this. Other providers passed this flag will log a warning and then ignore the flag.

Right now:
* running with `--skip-download` on rocky provider works and skips downloads
* Running with `--skip-download` on rocky provider when there's no input will raise an error
* Running other providers with `--skip-download` will log a warning but carry on

Outputs:

```
❯ vunnel -v run rocky --skip-download
[DEBUG] discovered plugins: 0
[INFO ] running rocky provider
... snip ...
[INFO ] Skipping download of Rocky Linux advisories
[INFO ] wrote 1578 entries

❯ vunnel -v run rocky
[DEBUG] discovered plugins: 0
[INFO ] running rocky provider
... snip ...
[DEBUG] http GET https://apollo.build.resf.org/api/v3/osv/ timeout=30 retries=5 backoff=3
... snip ...
[INFO ] wrote 1629 entries
[INFO ] recording workspace state
[DEBUG] wrote workspace state to ./data/rocky/metadata.json

❯ vunnel -v run rhel --skip-download
[DEBUG] discovered plugins: 0
[INFO ] running rhel provider
[WARNING] skip_download is not supported by rhel
... snip ...

❯ rm -rf ./data/rocky/input
❯ uv run vunnel -v run rocky --skip-download
[DEBUG] discovered plugins: 0
[INFO ] running rocky provider
... snip ...
[INFO ] Skipping download of Rocky Linux advisories
[INFO ] wrote 0 entries
[ERROR] error during update: download skipped on empty workspace
< stack trace >
```