### PR TITLE
Add configuration to bypass RHEL hydra API failures

### DIFF
--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -25,6 +25,7 @@ class Config:
     full_sync_interval: int = 2  # in days
     skip_namespaces: list[str] = field(default_factory=lambda: ["rhel:3", "rhel:4"])
     rhsa_source: str = "CSAF"  # "CSAF" or "OVAL"
+    ignore_hydra_errors: bool = False
 
 
 class Provider(provider.Provider):
@@ -45,6 +46,7 @@ class Provider(provider.Provider):
             max_workers=self.config.parallelism,
             full_sync_interval=self.config.full_sync_interval,
             rhsa_provider_type=self.config.rhsa_source,
+            ignore_hydra_errors=self.config.ignore_hydra_errors,
             skip_namespaces=self.config.skip_namespaces,
             logger=self.logger,
             skip_download=self.config.runtime.skip_download,

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 import copy
 import logging
 import os
@@ -38,7 +39,6 @@ class Parser:
     __cve_rhel_product_name_base__ = "Red Hat Enterprise Linux"
     __rhel_release_pattern__ = re.compile(__cve_rhel_product_name_base__ + r"\s*(\d+)$")
     __summary_url__ = "https://access.redhat.com/hydra/rest/securitydata/cve.json"
-    __rhsa_url__ = "https://access.redhat.com/hydra/rest/securitydata/oval/{}.json"
     __last_synced_filename__ = "last_synced"
     __cve_download_error_filename__ = "failed_cves"
     __cve_filename_regex__ = re.compile("CVE-[0-9]+-[0-9]+")
@@ -58,6 +58,7 @@ class Parser:
         full_sync_interval=None,
         skip_namespaces=None,
         rhsa_provider_type=None,
+        ignore_hydra_errors: bool = False,
         logger=None,
         skip_download: bool = False,
     ):
@@ -71,6 +72,7 @@ class Parser:
         self.rhsa_dict = None
         self.rhsa_provider: RHSAProvider | None = None
         self.rhsa_provider_type: str | None = rhsa_provider_type
+        self.ignore_hydra_errors = ignore_hydra_errors
         self.skip_download = skip_download
 
         self.urls = [self.__summary_url__]
@@ -144,28 +146,27 @@ class Parser:
 
     def _download_minimal_cve_pages(self) -> int:
         dir_path = os.path.join(self.cve_dir_path, self.__min_pages_dir_name__)
+        backup_dir_path = os.path.join(self.cve_dir_path, self.__min_pages_dir_name__ + "_backup")
 
-        # clear all existing records
-        utils.silent_remove(dir_path, tree=True)
-        os.makedirs(dir_path)
+        # use context manager to enforce cleanup of backup dir and # restore it if necessary
+        with handle_hydra_data(self.ignore_hydra_errors, dir_path, backup_dir_path, self.logger):
+            page = 0
+            count = 0
+            while True:
+                page += 1
+                results = self._download_minimal_cves(page)
 
-        page = 0
-        count = 0
-        while True:
-            page += 1
-            results = self._download_minimal_cves(page)
+                if not isinstance(results, list) or not results:
+                    break
 
-            if not isinstance(results, list) or not results:
-                break
+                min_cve_file = os.path.join(dir_path, f"{page}.json")
 
-            min_cve_file = os.path.join(dir_path, f"{page}.json")
+                count += len(results)
 
-            count += len(results)
+                with open(min_cve_file, "wb") as fp:
+                    fp.write(orjson.dumps(results))
 
-            with open(min_cve_file, "wb") as fp:
-                fp.write(orjson.dumps(results))
-
-        return count
+            return count
 
     def enumerate_minimal_cve_pages(self):
         dir_path = os.path.join(self.cve_dir_path, self.__min_pages_dir_name__)
@@ -841,3 +842,32 @@ class RHELCVSS3:
                 "base_severity": self.cvss3_obj.severities()[0],
             },
         }
+
+
+# return a context manager function that uses ignore_hydra_errors to handle restoring the backup dir
+@contextlib.contextmanager
+def handle_hydra_data(ignore_hydra_errors: bool, dir_path: str, backup_dir_path: str, logger):
+    if ignore_hydra_errors:
+        # move existing min pages dir to temp dir in case we need to restore it
+        utils.silent_remove(backup_dir_path, tree=True)
+        if os.path.exists(dir_path):
+            logger.debug(f"moving existing {dir_path} to {backup_dir_path}")
+            utils.move_dir(dir_path, backup_dir_path)
+        else:
+            logger.debug(f"no existing {dir_path} to move, starting fresh")
+    else:
+        # clear all existing records
+        utils.silent_remove(dir_path, tree=True)
+
+    os.makedirs(dir_path)
+
+    try:
+        yield
+    except Exception as e:
+        logger.error(f"error processing minimal CVE pages: {e}")
+        if ignore_hydra_errors:
+            logger.debug("restoring backup directory")
+            utils.silent_remove(dir_path, tree=True)
+            utils.move_dir(backup_dir_path, dir_path)
+        else:
+            raise

--- a/src/vunnel/utils/__init__.py
+++ b/src/vunnel/utils/__init__.py
@@ -53,3 +53,10 @@ def silent_remove(path: str, tree: bool = False) -> None:
         # note: errno.ENOENT = no such file or directory
         if e.errno != errno.ENOENT:
             raise
+
+
+def move_dir(src: str, dst: str) -> None:
+    """Move a directory from src to dst, ensuring the destination directory is empty."""
+    if os.path.exists(dst):
+        silent_remove(dst, tree=True)
+    shutil.move(src, dst)

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -362,6 +362,7 @@ providers:
       skip_newer_archive_check: false
   rhel:
     full_sync_interval: 2
+    ignore_hydra_errors: false
     parallelism: 4
     request_timeout: 125
     rhsa_source: CSAF

--- a/tests/unit/providers/rhel/test-fixtures/csaf/input/cve/min_pages/1.json
+++ b/tests/unit/providers/rhel/test-fixtures/csaf/input/cve/min_pages/1.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "CVE": "CVE-2024_11255",
+    "severity": "low",
+    "public_date": "2025-05-30T19:21:14Z",
+    "advisories": [],
+    "bugzilla": "2369500",
+    "bugzilla_description": "liboqs: liboqs affected by theoretical design flaw in HQC",
+    "cvss_score": null,
+    "cvss_scoring_vector": null,
+    "CWE": "CWE-327",
+    "affected_packages": [],
+    "package_state": null,
+    "resource_url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2024_11255.json",
+    "cvss3_scoring_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+    "cvss3_score": "3.7"
+  }
+]

--- a/tests/unit/providers/rhel/test_parser.py
+++ b/tests/unit/providers/rhel/test_parser.py
@@ -1,0 +1,318 @@
+import os
+import tempfile
+import shutil
+from unittest.mock import Mock, patch, call
+
+import pytest
+
+from vunnel.providers.rhel import parser
+
+
+class TestHandleHydraData:
+
+    @pytest.fixture
+    def mock_logger(self):
+        return Mock()
+
+    @pytest.fixture
+    def temp_dirs(self):
+        with tempfile.TemporaryDirectory() as temp_root:
+            dir_path = os.path.join(temp_root, "main_dir")
+            backup_dir_path = os.path.join(temp_root, "backup_dir")
+            yield dir_path, backup_dir_path
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_ignore_hydra_errors_true_with_existing_dir(self, mock_move_dir, mock_silent_remove,
+                                                        mock_exists, mock_makedirs, mock_logger):
+        """Test behavior when ignore_hydra_errors=True and directory exists."""
+        mock_exists.return_value = True
+
+        dir_path = "/tmp/test/dir"
+        backup_dir_path = "/tmp/test/backup"
+
+        with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+            pass
+
+        mock_silent_remove.assert_called_with(backup_dir_path, tree=True)
+        mock_makedirs.assert_has_calls([call(dir_path)])
+        mock_move_dir.assert_called_once_with(dir_path, backup_dir_path)
+        mock_logger.debug.assert_called_with(f"moving existing {dir_path} to {backup_dir_path}")
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_ignore_hydra_errors_true_without_existing_dir(self, mock_move_dir, mock_silent_remove,
+                                                           mock_exists, mock_makedirs, mock_logger):
+        """Test behavior when ignore_hydra_errors=True and directory doesn't exist."""
+        mock_exists.return_value = False
+
+        dir_path = "/tmp/test/dir"
+        backup_dir_path = "/tmp/test/backup"
+
+        with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+            pass
+
+        mock_silent_remove.assert_called_once_with(backup_dir_path, tree=True)
+        mock_makedirs.assert_has_calls([call(dir_path)])
+        mock_move_dir.assert_not_called()
+        mock_logger.debug.assert_called_with(f"no existing {dir_path} to move, starting fresh")
+
+    @patch('os.makedirs')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    def test_ignore_hydra_errors_false(self, mock_silent_remove, mock_makedirs, mock_logger):
+        """Test behavior when ignore_hydra_errors=False."""
+        dir_path = "/tmp/test/dir"
+        backup_dir_path = "/tmp/test/backup"
+
+        with parser.handle_hydra_data(False, dir_path, backup_dir_path, mock_logger):
+            pass
+
+        # Verify only dir_path is removed and recreated
+        mock_silent_remove.assert_called_once_with(dir_path, tree=True)
+        mock_makedirs.assert_called_once_with(dir_path)
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_exception_with_ignore_hydra_errors_true(self, mock_move_dir, mock_silent_remove,
+                                                     mock_exists, mock_makedirs, mock_logger):
+        """Test exception handling when ignore_hydra_errors=True."""
+        mock_exists.return_value = True
+
+        dir_path = "/tmp/test/dir"
+        backup_dir_path = "/tmp/test/backup"
+        test_exception = ValueError("Test error")
+
+        # Exception should be caught and handled, not re-raised
+        with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+            raise test_exception
+
+        # verify restoration calls (2 silent_remove calls: setup + restoration)
+        assert mock_silent_remove.call_count == 2
+        mock_silent_remove.assert_has_calls([
+            call(backup_dir_path, tree=True),  # Setup
+            call(dir_path, tree=True)          # Restoration
+        ])
+
+        # verify move operations (2 calls: setup + restoration)
+        assert mock_move_dir.call_count == 2
+        mock_move_dir.assert_has_calls([
+            call(dir_path, backup_dir_path),   # Setup
+            call(backup_dir_path, dir_path)    # Restoration
+        ])
+
+    @patch('os.makedirs')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    def test_exception_with_ignore_hydra_errors_false(self, mock_silent_remove, mock_makedirs, mock_logger):
+        """Test exception handling when ignore_hydra_errors=False."""
+        dir_path = "/tmp/test/dir"
+        backup_dir_path = "/tmp/test/backup"
+        test_exception = ValueError("Test error")
+
+        with pytest.raises(ValueError, match="Test error"):
+            with parser.handle_hydra_data(False, dir_path, backup_dir_path, mock_logger):
+                raise test_exception
+
+        # verify error is logged
+        mock_logger.error.assert_called_with(f"error processing minimal CVE pages: {test_exception}")
+        # no restoration debug message should be logged
+        assert not any(call.args[0] == "restoring backup directory" for call in mock_logger.debug.call_args_list)
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_makedirs_called_correctly(self, mock_move_dir, mock_silent_remove,
+                                       mock_exists, mock_makedirs, mock_logger):
+        """Test that os.makedirs is called with correct parameters."""
+        mock_exists.return_value = False
+
+        dir_path = "/tmp/test/dir"
+        backup_dir_path = "/tmp/test/backup"
+
+        with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+            pass
+
+        # verify makedirs called for the main directory only (backup should not be created since only move operations will place it)
+        expected_calls = [call(dir_path)]
+        mock_makedirs.assert_has_calls(expected_calls)
+        assert mock_makedirs.call_count == 1
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_logging_messages(self, mock_move_dir, mock_silent_remove,
+                              mock_exists, mock_makedirs, mock_logger):
+        """Test that appropriate logging messages are generated."""
+        dir_path = "/custom/path"
+        backup_dir_path = "/custom/backup"
+
+        # test with existing directory
+        mock_exists.return_value = True
+        with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+            pass
+
+        mock_logger.debug.assert_called_with(f"moving existing {dir_path} to {backup_dir_path}")
+
+        # reset and test without existing directory
+        mock_logger.reset_mock()
+        mock_exists.return_value = False
+
+        with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+            pass
+
+        mock_logger.debug.assert_called_with(f"no existing {dir_path} to move, starting fresh")
+
+    def test_real_filesystem_operations(self, temp_dirs, mock_logger):
+        """Integration test with real filesystem operations."""
+        dir_path, backup_dir_path = temp_dirs
+
+        # create initial directory with some content
+        os.makedirs(dir_path)
+        test_file = os.path.join(dir_path, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("test content")
+
+        with patch('vunnel.providers.rhel.parser.utils.silent_remove', side_effect=lambda path, tree=False: shutil.rmtree(path) if tree and os.path.exists(path) else None):
+            with patch('vunnel.providers.rhel.parser.utils.move_dir', side_effect=shutil.move):
+                # test successful execution
+                with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+                    # directory should exist and be empty
+                    assert os.path.exists(dir_path)
+                    assert len(os.listdir(dir_path)) == 0
+
+                # recreate the directory with content
+                os.makedirs(dir_path, exist_ok=True)
+                with open(test_file, "w") as f:
+                    f.write("test content")
+
+                # now test exception handling
+                with parser.handle_hydra_data(True, dir_path, backup_dir_path, mock_logger):
+                    raise ValueError("Test error")
+
+                # directory should be restored with original content
+                assert os.path.exists(dir_path)
+                assert os.path.exists(test_file)
+                with open(test_file, "r") as f:
+                    assert f.read() == "test content"
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_parameter_combinations(self, mock_move_dir, mock_silent_remove,
+                                    mock_exists, mock_makedirs, mock_logger):
+        """Test different parameter combinations."""
+        test_cases = [
+            (True, True),   # ignore_hydra_errors=True, dir exists
+            (True, False),  # ignore_hydra_errors=True, dir doesn't exist
+            (False, True),  # ignore_hydra_errors=False, dir exists
+            (False, False), # ignore_hydra_errors=False, dir doesn't exist
+        ]
+
+        for ignore_errors, dir_exists in test_cases:
+            mock_exists.return_value = dir_exists
+            mock_makedirs.reset_mock()
+            mock_silent_remove.reset_mock()
+            mock_move_dir.reset_mock()
+            mock_logger.reset_mock()
+
+            with parser.handle_hydra_data(ignore_errors, "/tmp/test/dir", "/tmp/test/backup", mock_logger):
+                pass
+
+            # all cases should create the main directory
+            mock_makedirs.assert_called_with("/tmp/test/dir")
+
+            if ignore_errors:
+                # should always remove backup dir and create the main dir (not create the backup dir, since only move operations will place it)
+                mock_silent_remove.assert_any_call("/tmp/test/backup", tree=True)
+                mock_makedirs.assert_any_call("/tmp/test/dir")
+
+                if dir_exists:
+                    # should move existing dir to backup
+                    mock_move_dir.assert_called_once_with("/tmp/test/dir", "/tmp/test/backup")
+                else:
+                    # should not move anything
+                    mock_move_dir.assert_not_called()
+            else:
+                # should only remove main dir
+                mock_silent_remove.assert_called_once_with("/tmp/test/dir", tree=True)
+
+
+    @patch('os.makedirs', side_effect=OSError("Permission denied"))
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    def test_makedirs_failure(self, mock_silent_remove, mock_makedirs, mock_logger):
+        """Test behavior when os.makedirs fails."""
+        with pytest.raises(OSError, match="Permission denied"):
+            with parser.handle_hydra_data(False, "/tmp/test/dir", "/tmp/test/backup", mock_logger):
+                pass
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir', side_effect=OSError("Move failed"))
+    def test_move_dir_failure_during_setup(self, mock_move_dir, mock_silent_remove,
+                                           mock_exists, mock_makedirs, mock_logger):
+        """Test behavior when vunnel.providers.rhel.parser.utils.move_dir fails during setup."""
+        mock_exists.return_value = True
+
+        with pytest.raises(OSError, match="Move failed"):
+            with parser.handle_hydra_data(True, "/tmp/test/dir", "/tmp/test/backup", mock_logger):
+                pass
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_multiple_exceptions(self, mock_move_dir, mock_silent_remove,
+                                 mock_exists, mock_makedirs, mock_logger):
+        """Test handling of multiple different exception types."""
+        mock_exists.return_value = True
+
+        exception_types = [
+            ValueError("Value error"),
+            RuntimeError("Runtime error"),
+            KeyError("Key error"),
+            FileNotFoundError("File not found"),
+        ]
+
+        for exception in exception_types:
+            mock_logger.reset_mock()
+
+            with parser.handle_hydra_data(True, "/tmp/test/dir", "/tmp/test/backup", mock_logger):
+                raise exception
+
+            # should log the specific exception
+            mock_logger.error.assert_called_with(f"error processing minimal CVE pages: {exception}")
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove', side_effect=OSError("Cleanup failed"))
+    @patch('vunnel.providers.rhel.parser.utils.move_dir')
+    def test_cleanup_failure_during_exception_handling(self, mock_move_dir, mock_silent_remove,
+                                                       mock_exists, mock_makedirs, mock_logger):
+        """Test behavior when cleanup operations fail during exception handling."""
+        mock_exists.return_value = True
+
+        # the context manager should still handle the original exception properly
+        # even if cleanup fails
+        with pytest.raises(OSError, match="Cleanup failed"):
+            with parser.handle_hydra_data(True, "/tmp/test/dir", "/tmp/test/backup", mock_logger):
+                raise ValueError("Original error")
+
+    @patch('os.makedirs')
+    @patch('vunnel.providers.rhel.parser.utils.silent_remove')
+    def test_empty_paths(self, mock_silent_remove, mock_makedirs, mock_logger):
+        """Test behavior with empty or unusual path strings."""
+        # test with empty strings
+        with parser.handle_hydra_data(False, "", "/tmp/backup", mock_logger):
+            pass
+
+        mock_makedirs.assert_called_with("")
+        mock_silent_remove.assert_called_with("", tree=True)

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import os
-import shutil
 from unittest.mock import patch
 
 import pytest
 
 from vunnel import result, workspace
-from vunnel.providers.rhel import Config, Provider, parser
+from vunnel.providers.rhel import Config, Provider
 from vunnel.providers.rhel.parser import Advisory, AffectedRelease, FixedIn, Parser
 from vunnel.providers.rhel.rhsa_provider import OVALRHSAProvider
 
@@ -590,3 +589,32 @@ def test_rhel_provider_supports_skip_download(mock_sync_cves, helpers):
         p.update(None)
         assert e.match("skip download used on empty workspace")
     assert mock_sync_cves.call_count == 0
+
+@patch("vunnel.providers.rhel.parser.http.get")
+def test_rhel_provider_supports_ignore_hydra_errors(mock_http_get, helpers):
+
+    workspace = helpers.provider_workspace_helper(
+        name=Provider.name(),
+        input_fixture="test-fixtures/csaf/input",
+    )
+
+    mock_http_get.side_effect = RuntimeError("simulate HTTP error")
+
+    c = Config()
+    c.runtime.result_store = result.StoreStrategy.FLAT_FILE
+    c.ignore_hydra_errors = True
+    c.rhsa_source = "CSAF"
+    p = Provider(root=workspace.root, config=c)
+
+    # don't do unnecessary work in the sync
+    p.parser.enumerate_minimal_cve_pages = lambda: []
+
+    # succeed with results from the cache
+    p.parser._sync_cves()
+
+    c.ignore_hydra_errors = False
+    p = Provider(root=workspace.root, config=c)
+
+    # API failures result in sync failure
+    with pytest.raises(RuntimeError) as e:
+        p.parser._sync_cves()


### PR DESCRIPTION
There was an extended period of time where the hydra API was returning 403s for https://access.redhat.com/hydra/rest/securitydata/cve.json, causing the provider to fail.... however, this is an unauthenticated endpoint. We already have previous hydra data in the input workspace, this PR adds a new `ignore_hydra_errors` configuration to ignore such errors and use cached data instead.