### PR TITLE
chore: remove redundant release check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,7 +99,6 @@ jobs:
     needs:
       - tag
     runs-on: ubuntu-22.04
-    environment: release
     permissions:
       contents: read
       # required to authenticate with PyPI via OIDC token


### PR DESCRIPTION
Currently, the release workflow asks for manual deployment before beginning, and again before pypi release. The second request for manual review is unintentional; this commit removes it.