### PR TITLE
Revert "chore: remove redundant release check (#820)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,7 @@ jobs:
     needs:
       - tag
     runs-on: ubuntu-22.04
+    environment: release
     permissions:
       contents: read
       # required to authenticate with PyPI via OIDC token

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,7 @@ jobs:
     needs:
       - tag
     runs-on: ubuntu-22.04
+    # important! PyPI OIDC auth will fail without environment: release
     environment: release
     permissions:
       contents: read


### PR DESCRIPTION
This reverts commit 1f2fac203aa199e61a5c0908a56c9f3c000deada. The first release after that commit was made failed with a permissions error in the step that was changed. Therefore, reverting the commit on the assumption that it was to blame. This will have the side effect of causing there to once again be two manual confirmation steps in a vunnel release, but this is preferable to partially executed releases.

Here's the failure that the reverted commit seems to have caused: https://github.com/anchore/vunnel/actions/runs/15567277745/job/43834459062#step:4:600