### PR TITLE
fix: update python constraint to allow 3.13.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vunnel"
 dynamic = ["version"]
-requires-python = "<=3.13,>=3.11"
+requires-python = "<3.14,>=3.11"
 authors = [
     {name = "Alex Goodman", email = "alex.goodman@anchore.com"},
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.11, <=3.13"
+requires-python = ">=3.11, <3.14"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
update python constraint to allow 3.13.x

fixes #809

relates to 
- https://github.com/anchore/vunnel/pull/762
- https://github.com/Homebrew/homebrew-core/pull/227476

