### PR TITLE
Feat: RHEL provider emits copies with AlmaLinux fixes

### DIFF
--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -25,6 +26,7 @@ class Config:
     full_sync_interval: int = 2  # in days
     skip_namespaces: list[str] = field(default_factory=lambda: ["rhel:3", "rhel:4"])
     rhsa_source: str = "CSAF"  # "CSAF" or "OVAL"
+    include_alma_fixes: bool = True
 
 
 class Provider(provider.Provider):
@@ -48,6 +50,7 @@ class Provider(provider.Provider):
             skip_namespaces=self.config.skip_namespaces,
             logger=self.logger,
             skip_download=self.config.runtime.skip_download,
+            include_alma_fixes=self.config.include_alma_fixes,
         )
 
     @classmethod
@@ -58,16 +61,109 @@ class Provider(provider.Provider):
     def supports_skip_download(cls) -> bool:
         return True
 
+    def create_alma_vulnerability_copy(self, namespace: str, record: dict) -> dict | None:
+        """
+        Create an Alma Linux copy of a RHEL vulnerability record if applicable.
+
+        Args:
+            namespace: The vulnerability namespace (e.g., "rhel:8")
+            record: The vulnerability record dict
+
+        Returns:
+            Modified copy for Alma Linux if applicable, None otherwise
+        """
+        if not self.config.include_alma_fixes:
+            return None
+
+        # Only process RHEL 8, 9, and 10
+        if namespace not in ["rhel:8", "rhel:9", "rhel:10"]:
+            return None
+
+        # Extract version from namespace
+        rhel_version = namespace.split(":")[1]
+        alma_namespace = f"almalinux:{rhel_version}"
+
+        # Create a deep copy of the record (expects {"Vulnerability": {...}})
+        alma_record = copy.deepcopy(record)
+
+        # Update the namespace in the record
+        alma_record["Vulnerability"]["NamespaceName"] = alma_namespace
+
+        # Process each FixedIn entry
+        fixed_in_entries = alma_record["Vulnerability"]["FixedIn"]
+        for fixed_in in fixed_in_entries:
+            # Update namespace
+            fixed_in["NamespaceName"] = alma_namespace
+
+            # Try to get Alma fix information
+            package_name = fixed_in["Name"]
+            vendor_advisory = fixed_in.get("VendorAdvisory", {})
+
+            if vendor_advisory.get("NoAdvisory", True):
+                # No RHEL advisory, so no Alma equivalent - package remains unfixed
+                continue
+
+            # Look for RHSA advisory
+            advisory_summaries = vendor_advisory.get("AdvisorySummary", [])
+            alma_fix_found = False
+
+            for advisory in advisory_summaries:
+                rhsa_id = advisory.get("ID", "")
+                if not rhsa_id.startswith(("RHSA-", "RHBA-", "RHEA-")):
+                    continue
+
+                # Try to get Alma fix version
+                if self.parser.alma_parser:
+                    alma_fix_version = self.parser.alma_parser.get_alma_fix_version(
+                        rhsa_id,
+                        rhel_version,
+                        package_name,
+                    )
+
+                    if alma_fix_version:
+                        # Update version and advisory info
+                        fixed_in["Version"] = alma_fix_version
+
+                        # Convert RHSA to ALSA in advisory
+                        alma_advisory_id = rhsa_id.replace("RHSA-", "ALSA-").replace("RHBA-", "ALBA-").replace("RHEA-", "ALEA-")
+                        advisory["ID"] = alma_advisory_id
+                        advisory["Link"] = f"https://errata.almalinux.org/{alma_advisory_id}.html"
+
+                        alma_fix_found = True
+                        break
+
+            if not alma_fix_found:
+                # No Alma fix found - mark as not fixed
+                fixed_in["Version"] = "None"
+                fixed_in["VendorAdvisory"] = {"NoAdvisory": True}
+
+        return alma_record
+
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
+        # Download Alma data if needed
+        self.parser.download_alma_data()
+
         with self.results_writer() as writer:
             for namespace, vuln_id, record in self.parser.get(skip_if_exists=self.config.runtime.skip_if_exists):
                 namespace = namespace.lower()
                 vuln_id = vuln_id.lower()
+
+                # Write the original RHEL record
                 writer.write(
                     identifier=os.path.join(namespace, vuln_id),
                     schema=self.__schema__,
                     payload=record,
                 )
+
+                # If applicable, create and write Alma copy
+                alma_record = self.create_alma_vulnerability_copy(namespace, record)
+                if alma_record:
+                    alma_namespace = alma_record["Vulnerability"]["NamespaceName"]
+                    writer.write(
+                        identifier=os.path.join(alma_namespace, vuln_id),
+                        schema=self.__schema__,
+                        payload=alma_record,
+                    )
         if len(writer) == 0 and self.config.runtime.skip_download:
             raise RuntimeError("skip download used on empty workspace")
         return self.parser.urls, len(writer)

--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vunnel import provider, result, schema
 
@@ -61,7 +61,7 @@ class Provider(provider.Provider):
     def supports_skip_download(cls) -> bool:
         return True
 
-    def create_alma_vulnerability_copy(self, namespace: str, record: dict) -> dict | None:
+    def create_alma_vulnerability_copy(self, namespace: str, record: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]] | None:
         """
         Create an Alma Linux copy of a RHEL vulnerability record if applicable.
 
@@ -127,7 +127,9 @@ class Provider(provider.Provider):
                         # Convert RHSA to ALSA in advisory
                         alma_advisory_id = rhsa_id.replace("RHSA-", "ALSA-").replace("RHBA-", "ALBA-").replace("RHEA-", "ALEA-")
                         advisory["ID"] = alma_advisory_id
-                        advisory["Link"] = f"https://errata.almalinux.org/{alma_advisory_id}.html"
+                        # Convert colon to hyphen for URL format (ALSA-2024:10953 -> ALSA-2024-10953)
+                        alma_advisory_url_id = alma_advisory_id.replace(":", "-")
+                        advisory["Link"] = f"https://errata.almalinux.org/{rhel_version}/{alma_advisory_url_id}.html"
 
                         alma_fix_found = True
                         break

--- a/src/vunnel/providers/rhel/alma_git.py
+++ b/src/vunnel/providers/rhel/alma_git.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+
+from vunnel import utils
+
+
+@dataclass
+class GitRevision:
+    sha: str
+    file: str
+
+
+class AlmaGitWrapper:
+    _check_cmd_ = "git --version"
+    _is_git_repo_cmd_ = "git rev-parse --is-inside-work-tree"
+    _clone_cmd_ = "git clone -b {branch} {src} {dest}"
+    _check_out_cmd_ = "git checkout {branch}"
+
+    def __init__(
+        self,
+        source: str,
+        branch: str,
+        checkout_dest: str,
+        logger: logging.Logger | None = None,
+    ):
+        self.src = source
+        self.branch = branch
+        self.dest = checkout_dest
+        self.workspace = tempfile.gettempdir()
+
+        if not logger:
+            logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logger
+
+        try:
+            out = self._exec_cmd(self._check_cmd_)
+            self.logger.trace(f"git executable verified using cmd: {self._check_cmd_}, output: {out}")  # type: ignore[attr-defined]
+        except:
+            self.logger.exception('could not find required "git" executable. Please install git on host')
+            raise
+
+    def delete_repo(self) -> None:
+        if os.path.exists(self.dest):
+            self.logger.debug("deleting existing alma repository")
+            shutil.rmtree(self.dest, ignore_errors=True)
+
+    @utils.retry_with_backoff()
+    def clone_repo(self) -> None:
+        try:
+            self.logger.info(f"cloning alma git repository {self.src} branch {self.branch} to {self.dest}")
+            cmd = self._clone_cmd_.format(src=self.src, dest=self.dest, branch=self.branch)
+            out = self._exec_cmd(cmd)
+            self.logger.debug(f"initialized alma git repo, cmd: {cmd}, output: {out}")
+        except:
+            self.logger.exception(f"failed to clone alma git repository {self.src} branch {self.branch} to {self.dest}")
+            raise
+
+    def _exec_cmd(self, cmd: str) -> str:
+        """
+        Run a command with errors etc handled
+        :param cmd: list of arguments (including command name, e.g. ['ls', '-l])
+        :param args:
+        :param kwargs:
+        :return:
+        """
+        try:
+            self.logger.trace(f"running: {cmd}")  # type: ignore[attr-defined]
+            cmd_list = shlex.split(cmd)
+            # S603 disable explanation: running git commands by design
+            return subprocess.check_output(cmd_list, text=True, stderr=subprocess.PIPE)  # noqa: S603
+        except Exception as e:
+            self.logger.exception(f"error executing command: {cmd}")
+            raise e

--- a/src/vunnel/providers/rhel/alma_parser.py
+++ b/src/vunnel/providers/rhel/alma_parser.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import orjson
+
+if TYPE_CHECKING:
+    from vunnel.workspace import Workspace
+
+from .alma_git import AlmaGitWrapper
+
+
+class AlmaParser:
+    _git_src_url_ = "https://github.com/AlmaLinux/osv-database.git"
+    _git_src_branch_ = "master"
+
+    def __init__(self, workspace: Workspace, logger: logging.Logger | None = None, alma_linux_versions: list[str] | None = None):
+        if alma_linux_versions is None:
+            alma_linux_versions = ["8", "9", "10"]
+        self.alma_linux_versions = alma_linux_versions
+        self.workspace = workspace
+        self.git_url = self._git_src_url_
+        self.git_branch = self._git_src_branch_
+        self.urls = [self.git_url]
+        if not logger:
+            logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logger
+
+        self._checkout_dst = os.path.join(self.workspace.input_path, "alma-osv-database")
+        self.git_wrapper = AlmaGitWrapper(
+            source=self.git_url,
+            branch=self.git_branch,
+            checkout_dest=self._checkout_dst,
+            logger=self.logger,
+        )
+
+    def download_alma_data(self) -> None:
+        self.logger.info("downloading Alma Linux OSV database for RHEL provider")
+        self.git_wrapper.delete_repo()
+        self.git_wrapper.clone_repo()
+
+    def _rhsa_to_alsa(self, rhsa_id: str) -> str:
+        if rhsa_id.startswith("RHSA-"):
+            return rhsa_id.replace("RHSA-", "ALSA-")
+        if rhsa_id.startswith("RHBA-"):
+            return rhsa_id.replace("RHBA-", "ALBA-")
+        if rhsa_id.startswith("RHEA-"):
+            return rhsa_id.replace("RHEA-", "ALEA-")
+        return rhsa_id.replace("RH", "AL")
+
+    def _get_alma_advisory_file_path(self, alma_advisory_id: str, version: str) -> str:
+        return os.path.join(
+            self._checkout_dst,
+            "advisories",
+            f"almalinux{version}",
+            f"{alma_advisory_id}.json",
+        )
+
+    def _normalize_rpm_version(self, version: str) -> str:
+        """Add explicit epoch of '0:' if version doesn't already have one."""
+        if version and ":" not in version:
+            return f"0:{version}"
+        return version
+
+    def get_alma_fix_version(self, rhsa_id: str, version: str, package_name: str) -> str | None:
+        alma_advisory_id = self._rhsa_to_alsa(rhsa_id)
+        file_path = self._get_alma_advisory_file_path(alma_advisory_id, version)
+
+        if not os.path.exists(file_path):
+            self.logger.debug(f"Alma advisory file not found: {file_path}")
+            return None
+
+        try:
+            with open(file_path, encoding="utf-8") as f:
+                advisory_data = orjson.loads(f.read())
+
+            affected = advisory_data.get("affected", [])
+            for affected_item in affected:
+                package = affected_item.get("package", {})
+                if package.get("name") == package_name:
+                    ranges = affected_item.get("ranges", [])
+                    for range_item in ranges:
+                        events = range_item.get("events", [])
+                        for event in events:
+                            if "fixed" in event:
+                                fixed_version = event["fixed"]
+                                normalized_version = self._normalize_rpm_version(fixed_version)
+                                self.logger.debug(f"Found Alma fix for {package_name} in {alma_advisory_id}: {normalized_version}")
+                                return normalized_version
+
+        except Exception as e:
+            self.logger.warning(f"Failed to parse Alma advisory file {file_path}: {e}")
+            return None
+
+        self.logger.debug(f"No fix found for package {package_name} in Alma advisory {alma_advisory_id}")
+        return None

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -20,6 +20,8 @@ from vunnel.utils import http_wrapper as http
 from vunnel.utils import rpm
 from vunnel.utils.vulnerability import vulnerability_element
 
+from .alma_parser import AlmaParser
+
 if TYPE_CHECKING:
     import requests
 
@@ -60,6 +62,7 @@ class Parser:
         rhsa_provider_type=None,
         logger=None,
         skip_download: bool = False,
+        include_alma_fixes: bool = False,
     ):
         self.workspace = workspace
         self.cve_dir_path = os.path.join(workspace.input_path, self.__cve_dir_name__)
@@ -72,12 +75,23 @@ class Parser:
         self.rhsa_provider: RHSAProvider | None = None
         self.rhsa_provider_type: str | None = rhsa_provider_type
         self.skip_download = skip_download
+        self.include_alma_fixes = include_alma_fixes
 
         self.urls = [self.__summary_url__]
 
         if not logger:
             logger = logging.getLogger(self.__class__.__name__)
         self.logger = logger
+
+        # Initialize Alma parser if needed
+        self.alma_parser: AlmaParser | None = None
+        if self.include_alma_fixes:
+            self.alma_parser = AlmaParser(workspace=workspace, logger=logger)
+
+    def download_alma_data(self) -> None:
+        """Download Alma Linux data if include_alma_fixes is enabled"""
+        if self.include_alma_fixes and self.alma_parser:
+            self.alma_parser.download_alma_data()
 
     def _download_minimal_cves(self, page, limit=1000):
         path_params = {"per_page": str(limit), "page": page, "product": self.__cve_rhel_product_name_base__}

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -396,6 +396,7 @@ providers:
       skip_newer_archive_check: false
   rhel:
     full_sync_interval: 2
+    include_alma_fixes: true
     parallelism: 4
     request_timeout: 125
     rhsa_source: CSAF

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -537,7 +537,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch):
 
     p.update(None)
 
-    assert workspace.num_result_entries() == 64
+    assert workspace.num_result_entries() == 86
 
     assert workspace.result_schemas_valid(require_entries=True)
 
@@ -551,6 +551,7 @@ def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch):
     c = Config()
     c.runtime.result_store = result.StoreStrategy.FLAT_FILE
     c.rhsa_source = "OVAL"
+    c.include_alma_fixes = False
     p = Provider(root=workspace.root, config=c)
 
     def mock_sync_cves(*args, **kwargs):

--- a/tests/unit/providers/rhel/test_rhel_with_alma.py
+++ b/tests/unit/providers/rhel/test_rhel_with_alma.py
@@ -1,0 +1,269 @@
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+from vunnel.providers.rhel import Config, Provider
+from vunnel.workspace import Workspace
+
+
+class TestRHELWithAlmaIntegration:
+    @pytest.fixture
+    def rhel_config_with_alma(self):
+        return Config(include_alma_fixes=True)
+
+    @pytest.fixture
+    def rhel_config_without_alma(self):
+        return Config(include_alma_fixes=False)
+
+    @pytest.fixture
+    def mock_alma_advisory_data(self):
+        return {
+            "id": "ALSA-2022:6158",
+            "summary": "Moderate: php:7.4 security update",
+            "affected": [
+                {
+                    "package": {"ecosystem": "AlmaLinux:8", "name": "php"},
+                    "ranges": [
+                        {
+                            "type": "ECOSYSTEM",
+                            "events": [
+                                {"introduced": "0"},
+                                {"fixed": "7.4.19-4.module_el8.6.0+3238+624bf8b8"}
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "related": ["CVE-2022-31625"],
+            "published": "2022-08-24T00:00:00Z",
+            "modified": "2022-11-23T22:19:30Z"
+        }
+
+    @pytest.fixture
+    def rhel_vulnerability_record(self):
+        return {
+            'Vulnerability': {
+                'Severity': 'Medium',
+                'NamespaceName': 'rhel:8',
+                'FixedIn': [{
+                    'Name': 'php',
+                    'Version': '0:7.4.19-4.module+el8.6.0+16316+906f6c6d',
+                    'Module': 'php:7.4',
+                    'VersionFormat': 'rpm',
+                    'NamespaceName': 'rhel:8',
+                    'VendorAdvisory': {
+                        'NoAdvisory': False,
+                        'AdvisorySummary': [{'ID': 'RHSA-2022:6158', 'Link': 'https://access.redhat.com/errata/RHSA-2022:6158'}]
+                    }
+                }],
+                'Link': 'https://access.redhat.com/security/cve/CVE-2022-31625',
+                'Description': 'A vulnerability was found in PHP due to an uninitialized array in pg_query_params() function.',
+                'Metadata': {},
+                'Name': 'CVE-2022-31625',
+                'CVSS': []
+            }
+        }
+
+    @pytest.fixture
+    def mock_alma_workspace(self, mock_alma_advisory_data):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create the directory structure that the RHEL provider expects
+            # Provider creates workspace at root/rhel, so alma files should be at root/rhel/input/alma-osv-database
+            rhel_input_dir = os.path.join(tmpdir, "rhel", "input")
+            alma_dir = os.path.join(rhel_input_dir, "alma-osv-database", "advisories", "almalinux8")
+            os.makedirs(alma_dir, exist_ok=True)
+
+            import orjson
+            advisory_file = os.path.join(alma_dir, "ALSA-2022:6158.json")
+            with open(advisory_file, "wb") as f:
+                f.write(orjson.dumps(mock_alma_advisory_data))
+
+            # Return a mock workspace that just has the _root attribute
+            class MockWorkspace:
+                def __init__(self, root):
+                    self._root = root
+
+            yield MockWorkspace(tmpdir)
+
+    def test_config_includes_alma_fixes_flag(self, rhel_config_with_alma, rhel_config_without_alma):
+        assert rhel_config_with_alma.include_alma_fixes is True
+        assert rhel_config_without_alma.include_alma_fixes is False
+
+    def test_provider_initializes_alma_parser_when_enabled(self, mock_alma_workspace, rhel_config_with_alma):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+
+        assert provider.config.include_alma_fixes is True
+        assert provider.parser.include_alma_fixes is True
+        assert provider.parser.alma_parser is not None
+
+    def test_provider_does_not_initialize_alma_parser_when_disabled(self, mock_alma_workspace, rhel_config_without_alma):
+        provider = Provider(mock_alma_workspace._root, rhel_config_without_alma)
+
+        assert provider.config.include_alma_fixes is False
+        assert provider.parser.include_alma_fixes is False
+        assert provider.parser.alma_parser is None
+
+    def test_alma_copy_creation_disabled_when_config_false(self, mock_alma_workspace, rhel_config_without_alma, rhel_vulnerability_record):
+        provider = Provider(mock_alma_workspace._root, rhel_config_without_alma)
+
+        alma_record = provider.create_alma_vulnerability_copy('rhel:8', rhel_vulnerability_record)
+        assert alma_record is None
+
+    def test_alma_copy_creation_skips_non_target_versions(self, mock_alma_workspace, rhel_config_with_alma, rhel_vulnerability_record):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+
+        assert provider.create_alma_vulnerability_copy('rhel:7', rhel_vulnerability_record) is None
+        assert provider.create_alma_vulnerability_copy('rhel:5', rhel_vulnerability_record) is None
+        assert provider.create_alma_vulnerability_copy('rhel:8', rhel_vulnerability_record) is not None
+
+    def test_alma_copy_transforms_namespace_and_identifier(self, mock_alma_workspace, rhel_config_with_alma, rhel_vulnerability_record):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+
+        alma_record = provider.create_alma_vulnerability_copy('rhel:8', rhel_vulnerability_record)
+
+        assert alma_record is not None
+        assert alma_record['Vulnerability']['NamespaceName'] == 'almalinux:8'
+        assert alma_record['Vulnerability']['FixedIn'][0]['NamespaceName'] == 'almalinux:8'
+
+    def test_alma_copy_with_found_alma_advisory(self, mock_alma_workspace, rhel_config_with_alma, rhel_vulnerability_record):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+        alma_record = provider.create_alma_vulnerability_copy('rhel:8', rhel_vulnerability_record)
+
+        assert alma_record is not None
+        fixed_in = alma_record['Vulnerability']['FixedIn'][0]
+
+        assert fixed_in['Version'] == '0:7.4.19-4.module_el8.6.0+3238+624bf8b8'
+        assert fixed_in['VendorAdvisory']['NoAdvisory'] is False
+        assert fixed_in['VendorAdvisory']['AdvisorySummary'][0]['ID'] == 'ALSA-2022:6158'
+        assert fixed_in['VendorAdvisory']['AdvisorySummary'][0]['Link'] == 'https://errata.almalinux.org/ALSA-2022:6158.html'
+
+    def test_alma_copy_with_missing_alma_advisory(self, rhel_config_with_alma, rhel_vulnerability_record):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Workspace(tmpdir, "test")
+            provider = Provider(workspace._root, rhel_config_with_alma)
+
+            alma_record = provider.create_alma_vulnerability_copy('rhel:8', rhel_vulnerability_record)
+
+            assert alma_record is not None
+            fixed_in = alma_record['Vulnerability']['FixedIn'][0]
+
+            assert fixed_in['Version'] == 'None'
+            assert fixed_in['VendorAdvisory']['NoAdvisory'] is True
+
+    def test_alma_copy_preserves_vulnerability_metadata(self, mock_alma_workspace, rhel_config_with_alma, rhel_vulnerability_record):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+
+        alma_record = provider.create_alma_vulnerability_copy('rhel:8', rhel_vulnerability_record)
+
+        assert alma_record is not None
+        alma_vuln = alma_record['Vulnerability']
+        rhel_vuln = rhel_vulnerability_record['Vulnerability']
+
+        assert alma_vuln['Name'] == rhel_vuln['Name']
+        assert alma_vuln['Severity'] == rhel_vuln['Severity']
+        assert alma_vuln['Link'] == rhel_vuln['Link']
+        assert alma_vuln['Description'] == rhel_vuln['Description']
+        assert alma_vuln['CVSS'] == rhel_vuln['CVSS']
+        assert alma_vuln['Metadata'] == rhel_vuln['Metadata']
+
+    def test_alma_copy_handles_no_advisory_case(self, mock_alma_workspace, rhel_config_with_alma):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+
+        rhel_record_no_advisory = {
+            'Vulnerability': {
+                'Name': 'CVE-2005-2541',
+                'NamespaceName': 'rhel:8',
+                'FixedIn': [{
+                    'Name': 'tar',
+                    'Version': 'None',
+                    'NamespaceName': 'rhel:8',
+                    'VendorAdvisory': {'NoAdvisory': True}
+                }]
+            }
+        }
+
+        alma_record = provider.create_alma_vulnerability_copy('rhel:8', rhel_record_no_advisory)
+
+        assert alma_record is not None
+        fixed_in = alma_record['Vulnerability']['FixedIn'][0]
+
+        assert fixed_in['NamespaceName'] == 'almalinux:8'
+        assert fixed_in['Version'] == 'None'
+        assert fixed_in['VendorAdvisory']['NoAdvisory'] is True
+
+    def test_rhsa_to_alsa_conversion(self, mock_alma_workspace, rhel_config_with_alma):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+        alma_parser = provider.parser.alma_parser
+
+        assert alma_parser._rhsa_to_alsa('RHSA-2022:6158') == 'ALSA-2022:6158'
+        assert alma_parser._rhsa_to_alsa('RHBA-2022:1234') == 'ALBA-2022:1234'
+        assert alma_parser._rhsa_to_alsa('RHEA-2022:5678') == 'ALEA-2022:5678'
+        assert alma_parser._rhsa_to_alsa('RHXX-2022:9999') == 'ALXX-2022:9999'
+
+    def test_rpm_version_normalization(self, mock_alma_workspace, rhel_config_with_alma):
+        provider = Provider(mock_alma_workspace._root, rhel_config_with_alma)
+        alma_parser = provider.parser.alma_parser
+
+        # Test that versions without epoch get '0:' prepended
+        assert alma_parser._normalize_rpm_version('1.2.3-4.el8') == '0:1.2.3-4.el8'
+        assert alma_parser._normalize_rpm_version('7.4.19-4.module_el8.6.0+3238+624bf8b8') == '0:7.4.19-4.module_el8.6.0+3238+624bf8b8'
+
+        # Test that versions with epoch are left unchanged
+        assert alma_parser._normalize_rpm_version('1:1.2.3-4.el8') == '1:1.2.3-4.el8'
+        assert alma_parser._normalize_rpm_version('0:7.4.19-4.module_el8.6.0+3238+624bf8b8') == '0:7.4.19-4.module_el8.6.0+3238+624bf8b8'
+
+        # Test edge cases
+        assert alma_parser._normalize_rpm_version('') == ''
+        assert alma_parser._normalize_rpm_version(None) == None
+
+
+def test_real_rhel_to_alma_conversion():
+    real_workspace_path = '/Users/willmurphy/work/vunnel/data/rhel'
+
+    if not os.path.exists(real_workspace_path):
+        pytest.skip("Real RHEL workspace not available")
+
+    config = Config(include_alma_fixes=True)
+    provider = Provider(real_workspace_path, config)
+
+    rhel_record = {
+        'Vulnerability': {
+            'Severity': 'Medium',
+            'NamespaceName': 'rhel:8',
+            'FixedIn': [{
+                'Name': 'php',
+                'Version': '0:7.4.19-4.module+el8.6.0+16316+906f6c6d',
+                'Module': 'php:7.4',
+                'VersionFormat': 'rpm',
+                'NamespaceName': 'rhel:8',
+                'VendorAdvisory': {
+                    'NoAdvisory': False,
+                    'AdvisorySummary': [{'ID': 'RHSA-2022:6158', 'Link': 'https://access.redhat.com/errata/RHSA-2022:6158'}]
+                }
+            }],
+            'Link': 'https://access.redhat.com/security/cve/CVE-2022-31625',
+            'Description': 'A vulnerability was found in PHP...',
+            'Metadata': {},
+            'Name': 'CVE-2022-31625',
+            'CVSS': []
+        }
+    }
+
+    alma_record = provider.create_alma_vulnerability_copy('rhel:8', rhel_record)
+
+    assert alma_record is not None
+    assert alma_record['Vulnerability']['NamespaceName'] == 'almalinux:8'
+
+    fixed_in = alma_record['Vulnerability']['FixedIn'][0]
+
+    # Should find the actual alma fix or mark as not fixed
+    assert fixed_in['Version'] in ['0:7.4.19-4.module_el8.6.0+3238+624bf8b8', 'None']
+
+    if fixed_in['Version'] != 'None':
+        assert fixed_in['VendorAdvisory']['NoAdvisory'] is False
+        assert fixed_in['VendorAdvisory']['AdvisorySummary'][0]['ID'] == 'ALSA-2022:6158'
+        assert 'errata.almalinux.org' in fixed_in['VendorAdvisory']['AdvisorySummary'][0]['Link']
+    else:
+        assert fixed_in['VendorAdvisory']['NoAdvisory'] is True


### PR DESCRIPTION
Part of work for https://github.com/anchore/grype/issues/2745

AlmaLinux has no equivalent page to CVE listings like https://access.redhat.com/security/cve/cve-2016-3707 or to the API behind them, but it does have its own errata/advisories, e.g. https://errata.almalinux.org/8/ALSA-2024-10953.html instead of https://access.redhat.com/errata/RHSA-2024:10953.

This PR proposes a feature where the RHEL provider in Vunnel optionally emits second copies for RHEL vulnerabilities where the namespace is changed to the corresponding alma version and the fix info and advisory links are updated to the corresponding AlmaLinux advisory.

Note that this does not yet account for situations where AlmaLinux publishes their own advisories that have no RHEL equivalent, such as https://errata.almalinux.org/8/ALSA-2025-A001.html - that might be worth adding to this PR, or might be worth a future enhancement.