### PR TITLE
[alpine,wolfi,chainguard]: prefer specific vulnerability reference urls

### DIFF
--- a/src/vunnel/providers/wolfi/parser.py
+++ b/src/vunnel/providers/wolfi/parser.py
@@ -14,14 +14,16 @@ from vunnel.utils import vulnerability
 class Parser:
     _release_ = "rolling"
     _secdb_dir_ = "secdb"
+    _security_reference_url_ = "https://images.chainguard.dev/security"
 
-    def __init__(
+    def __init__( # noqa: PLR0913
         self,
         workspace,
         url: str,
         namespace: str,
         download_timeout: int = 125,
         logger: logging.Logger | None = None,
+        security_reference_url: str | None = None,
     ):
         self.download_timeout = download_timeout
         self.secdb_dir_path = os.path.join(workspace.input_path, self._secdb_dir_)
@@ -29,6 +31,7 @@ class Parser:
         self.url = url
         self.namespace = namespace
         self._db_filename = self._extract_filename_from_url(url)
+        self.security_reference_url = security_reference_url.strip("/") if security_reference_url else Parser._security_reference_url_
 
         if not logger:
             logger = logging.getLogger(self.__class__.__name__)
@@ -37,6 +40,12 @@ class Parser:
     @staticmethod
     def _extract_filename_from_url(url):
         return os.path.basename(urlparse(url).path)
+
+    def build_reference_links(self, vulnerability_id: str) -> list[str]:
+        urls = []
+        urls.append(f"{self.security_reference_url}/{vulnerability_id}")
+        urls.extend(vulnerability.build_reference_links(vulnerability_id))
+        return urls
 
     def _download(self):
         """
@@ -103,7 +112,7 @@ class Parser:
                         # create a new record
                         vuln_dict[vid] = copy.deepcopy(vulnerability.vulnerability_element)
                         vuln_record = vuln_dict[vid]
-                        reference_links = vulnerability.build_reference_links(vid)
+                        reference_links = self.build_reference_links(vid)
 
                         # populate the static information about the new vuln record
                         vuln_record["Vulnerability"]["Name"] = str(vid)

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1071.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1071.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-1071",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2018-1071",
       "Metadata": {},
       "Name": "CVE-2018-1071",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1083.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1083.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-1083",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2018-1083",
       "Metadata": {},
       "Name": "CVE-2018-1083",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-25032.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-25032.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-25032",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2018-25032",
       "Metadata": {},
       "Name": "CVE-2018-25032",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-11922.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-11922.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-11922",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2019-11922",
       "Metadata": {},
       "Name": "CVE-2019-11922",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-13132.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-13132.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-13132",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2019-13132",
       "Metadata": {},
       "Name": "CVE-2019-13132",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-20044.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-20044.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-20044",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2019-20044",
       "Metadata": {},
       "Name": "CVE-2019-20044",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-6250.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-6250.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6250",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2019-6250",
       "Metadata": {},
       "Name": "CVE-2019-6250",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-9210.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-9210.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-9210",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2019-9210",
       "Metadata": {},
       "Name": "CVE-2019-9210",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-14929.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-14929.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-14929",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2020-14929",
       "Metadata": {},
       "Name": "CVE-2020-14929",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-15166.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-15166.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-15166",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2020-15166",
       "Metadata": {},
       "Name": "CVE-2020-15166",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24031.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24031.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-24031",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2021-24031",
       "Metadata": {},
       "Name": "CVE-2021-24031",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24032.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24032.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-24032",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2021-24032",
       "Metadata": {},
       "Name": "CVE-2021-24032",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-38370.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-38370.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-38370",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2021-38370",
       "Metadata": {},
       "Name": "CVE-2021-38370",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-45444.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-45444.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-45444",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2021-45444",
       "Metadata": {},
       "Name": "CVE-2021-45444",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-1271.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-1271.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-1271",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2022-1271",
       "Metadata": {},
       "Name": "CVE-2022-1271",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-37434.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-37434.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-37434",
+      "Link": "https://security.alpinelinux.org/vuln/CVE-2022-37434",
       "Metadata": {},
       "Name": "CVE-2022-37434",
       "NamespaceName": "alpine:3.15",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-2728.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-2728.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2007-2728",
+      "Link": "https://images.chainguard.dev/security/CVE-2007-2728",
       "Metadata": {},
       "Name": "CVE-2007-2728",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-3205.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-3205.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2007-3205",
+      "Link": "https://images.chainguard.dev/security/CVE-2007-3205",
       "Metadata": {},
       "Name": "CVE-2007-3205",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4559.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4559.json
@@ -24,7 +24,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2007-4559",
+      "Link": "https://images.chainguard.dev/security/CVE-2007-4559",
       "Metadata": {},
       "Name": "CVE-2007-4559",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4596.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4596.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2007-4596",
+      "Link": "https://images.chainguard.dev/security/CVE-2007-4596",
       "Metadata": {},
       "Name": "CVE-2007-4596",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2010-4756.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2010-4756.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2010-4756",
+      "Link": "https://images.chainguard.dev/security/CVE-2010-4756",
       "Metadata": {},
       "Name": "CVE-2010-4756",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2102.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2102.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2016-2102",
+      "Link": "https://images.chainguard.dev/security/CVE-2016-2102",
       "Metadata": {},
       "Name": "CVE-2016-2102",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2781.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2781.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2016-2781",
+      "Link": "https://images.chainguard.dev/security/CVE-2016-2781",
       "Metadata": {},
       "Name": "CVE-2016-2781",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-9131.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-9131.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2016-9131",
+      "Link": "https://images.chainguard.dev/security/CVE-2016-9131",
       "Metadata": {},
       "Name": "CVE-2016-9131",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-9147.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-9147.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2016-9147",
+      "Link": "https://images.chainguard.dev/security/CVE-2016-9147",
       "Metadata": {},
       "Name": "CVE-2016-9147",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-9444.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-9444.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2016-9444",
+      "Link": "https://images.chainguard.dev/security/CVE-2016-9444",
       "Metadata": {},
       "Name": "CVE-2016-9444",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3136.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3136.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2017-3136",
+      "Link": "https://images.chainguard.dev/security/CVE-2017-3136",
       "Metadata": {},
       "Name": "CVE-2017-3136",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3137.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3137.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2017-3137",
+      "Link": "https://images.chainguard.dev/security/CVE-2017-3137",
       "Metadata": {},
       "Name": "CVE-2017-3137",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3138.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3138.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2017-3138",
+      "Link": "https://images.chainguard.dev/security/CVE-2017-3138",
       "Metadata": {},
       "Name": "CVE-2017-3138",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3145.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-3145.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2017-3145",
+      "Link": "https://images.chainguard.dev/security/CVE-2017-3145",
       "Metadata": {},
       "Name": "CVE-2017-3145",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-7507.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-7507.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2017-7507",
+      "Link": "https://images.chainguard.dev/security/CVE-2017-7507",
       "Metadata": {},
       "Name": "CVE-2017-7507",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-8806.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-8806.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2017-8806",
+      "Link": "https://images.chainguard.dev/security/CVE-2017-8806",
       "Metadata": {},
       "Name": "CVE-2017-8806",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-1000156.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-1000156.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-1000156",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-1000156",
       "Metadata": {},
       "Name": "CVE-2018-1000156",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-12020.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-12020.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-12020",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-12020",
       "Metadata": {},
       "Name": "CVE-2018-12020",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-20969.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-20969.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-20969",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-20969",
       "Metadata": {},
       "Name": "CVE-2018-20969",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-25032.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-25032.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-25032",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-25032",
       "Metadata": {},
       "Name": "CVE-2018-25032",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5736.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5736.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-5736",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-5736",
       "Metadata": {},
       "Name": "CVE-2018-5736",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5737.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5737.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-5737",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-5737",
       "Metadata": {},
       "Name": "CVE-2018-5737",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5738.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5738.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-5738",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-5738",
       "Metadata": {},
       "Name": "CVE-2018-5738",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5740.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5740.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-5740",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-5740",
       "Metadata": {},
       "Name": "CVE-2018-5740",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5743.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5743.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-5743",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-5743",
       "Metadata": {},
       "Name": "CVE-2018-5743",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5744.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5744.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-5744",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-5744",
       "Metadata": {},
       "Name": "CVE-2018-5744",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5745.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-5745.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-5745",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-5745",
       "Metadata": {},
       "Name": "CVE-2018-5745",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-6951.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-6951.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-6951",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-6951",
       "Metadata": {},
       "Name": "CVE-2018-6951",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-6952.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2018-6952.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-6952",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-6952",
       "Metadata": {},
       "Name": "CVE-2018-6952",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010022.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010022.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-1010022",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-1010022",
       "Metadata": {},
       "Name": "CVE-2019-1010022",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010023.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010023.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-1010023",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-1010023",
       "Metadata": {},
       "Name": "CVE-2019-1010023",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010024.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010024.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-1010024",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-1010024",
       "Metadata": {},
       "Name": "CVE-2019-1010024",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010025.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010025.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-1010025",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-1010025",
       "Metadata": {},
       "Name": "CVE-2019-1010025",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-12290.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-12290.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-12290",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-12290",
       "Metadata": {},
       "Name": "CVE-2019-12290",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-13636.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-13636.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-13636",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-13636",
       "Metadata": {},
       "Name": "CVE-2019-13636",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-13638.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-13638.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-13638",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-13638",
       "Metadata": {},
       "Name": "CVE-2019-13638",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-14855.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-14855.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-14855",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-14855",
       "Metadata": {},
       "Name": "CVE-2019-14855",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-18224.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-18224.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-18224",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-18224",
       "Metadata": {},
       "Name": "CVE-2019-18224",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-20633.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-20633.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-20633",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-20633",
       "Metadata": {},
       "Name": "CVE-2019-20633",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-3829.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-3829.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-3829",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-3829",
       "Metadata": {},
       "Name": "CVE-2019-3829",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-3836.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-3836.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-3836",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-3836",
       "Metadata": {},
       "Name": "CVE-2019-3836",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6293.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6293.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6293",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6293",
       "Metadata": {},
       "Name": "CVE-2019-6293",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6465.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6465.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6465",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6465",
       "Metadata": {},
       "Name": "CVE-2019-6465",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6467.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6467.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6467",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6467",
       "Metadata": {},
       "Name": "CVE-2019-6467",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6470.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6470.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6470",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6470",
       "Metadata": {},
       "Name": "CVE-2019-6470",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6471.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6471.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6471",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6471",
       "Metadata": {},
       "Name": "CVE-2019-6471",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6475.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6475.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6475",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6475",
       "Metadata": {},
       "Name": "CVE-2019-6475",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6476.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6476.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6476",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6476",
       "Metadata": {},
       "Name": "CVE-2019-6476",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6477.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6477.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6477",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6477",
       "Metadata": {},
       "Name": "CVE-2019-6477",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6706.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6706.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6706",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6706",
       "Metadata": {},
       "Name": "CVE-2019-6706",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-10735.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-10735.json
@@ -24,7 +24,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-10735",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-10735",
       "Metadata": {},
       "Name": "CVE-2020-10735",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-11501.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-11501.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-11501",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-11501",
       "Metadata": {},
       "Name": "CVE-2020-11501",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-13777.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-13777.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-13777",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-13777",
       "Metadata": {},
       "Name": "CVE-2020-13777",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-24659.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-24659.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-24659",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-24659",
       "Metadata": {},
       "Name": "CVE-2020-24659",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-25125.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-25125.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-25125",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-25125",
       "Metadata": {},
       "Name": "CVE-2020-25125",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29509.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29509.json
@@ -18,7 +18,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-29509",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-29509",
       "Metadata": {},
       "Name": "CVE-2020-29509",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29511.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29511.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-29511",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-29511",
       "Metadata": {},
       "Name": "CVE-2020-29511",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8616.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8616.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8616",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8616",
       "Metadata": {},
       "Name": "CVE-2020-8616",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8617.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8617.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8617",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8617",
       "Metadata": {},
       "Name": "CVE-2020-8617",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8618.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8618.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8618",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8618",
       "Metadata": {},
       "Name": "CVE-2020-8618",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8619.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8619.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8619",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8619",
       "Metadata": {},
       "Name": "CVE-2020-8619",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8620.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8620.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8620",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8620",
       "Metadata": {},
       "Name": "CVE-2020-8620",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8621.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8621.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8621",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8621",
       "Metadata": {},
       "Name": "CVE-2020-8621",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8622.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8622.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8622",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8622",
       "Metadata": {},
       "Name": "CVE-2020-8622",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8623.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8623.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8623",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8623",
       "Metadata": {},
       "Name": "CVE-2020-8623",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8624.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8624.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8624",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8624",
       "Metadata": {},
       "Name": "CVE-2020-8624",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8625.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8625.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8625",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8625",
       "Metadata": {},
       "Name": "CVE-2020-8625",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8927.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-8927.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8927",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8927",
       "Metadata": {},
       "Name": "CVE-2020-8927",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-20231.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-20231.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-20231",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-20231",
       "Metadata": {},
       "Name": "CVE-2021-20231",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-20232.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-20232.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-20232",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-20232",
       "Metadata": {},
       "Name": "CVE-2021-20232",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-20305.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-20305.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-20305",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-20305",
       "Metadata": {},
       "Name": "CVE-2021-20305",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25214.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25214.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-25214",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-25214",
       "Metadata": {},
       "Name": "CVE-2021-25214",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25215.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25215.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-25215",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-25215",
       "Metadata": {},
       "Name": "CVE-2021-25215",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25216.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25216.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-25216",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-25216",
       "Metadata": {},
       "Name": "CVE-2021-25216",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25218.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25218.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-25218",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-25218",
       "Metadata": {},
       "Name": "CVE-2021-25218",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25219.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25219.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-25219",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-25219",
       "Metadata": {},
       "Name": "CVE-2021-25219",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25220.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-25220.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-25220",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-25220",
       "Metadata": {},
       "Name": "CVE-2021-25220",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-30218.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-30218.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-30218",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-30218",
       "Metadata": {},
       "Name": "CVE-2021-30218",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-30219.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-30219.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-30219",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-30219",
       "Metadata": {},
       "Name": "CVE-2021-30219",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-3121.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-3121.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-3121",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-3121",
       "Metadata": {},
       "Name": "CVE-2021-3121",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-33621.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-33621.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-33621",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-33621",
       "Metadata": {},
       "Name": "CVE-2021-33621",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-3580.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-3580.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-3580",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-3580",
       "Metadata": {},
       "Name": "CVE-2021-3580",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-36156.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-36156.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-36156",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-36156",
       "Metadata": {},
       "Name": "CVE-2021-36156",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-41803.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-41803.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-41803",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-41803",
       "Metadata": {},
       "Name": "CVE-2021-41803",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-43618.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-43618.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-43618",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-43618",
       "Metadata": {},
       "Name": "CVE-2021-43618",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-46848.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2021-46848.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-46848",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-46848",
       "Metadata": {},
       "Name": "CVE-2021-46848",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-0396.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-0396.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-0396",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-0396",
       "Metadata": {},
       "Name": "CVE-2022-0396",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-0543.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-0543.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-0543",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-0543",
       "Metadata": {},
       "Name": "CVE-2022-0543",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-1586.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-1586.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-1586",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-1586",
       "Metadata": {},
       "Name": "CVE-2022-1586",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-1587.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-1587.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-1587",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-1587",
       "Metadata": {},
       "Name": "CVE-2022-1587",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-23469.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-23469.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-23469",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-23469",
       "Metadata": {},
       "Name": "CVE-2022-23469",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-23521.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-23521.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-23521",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-23521",
       "Metadata": {},
       "Name": "CVE-2022-23521",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2509.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2509.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-2509",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-2509",
       "Metadata": {},
       "Name": "CVE-2022-2509",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-26691.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-26691.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-26691",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-26691",
       "Metadata": {},
       "Name": "CVE-2022-26691",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-27404.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-27404.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-27404",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-27404",
       "Metadata": {},
       "Name": "CVE-2022-27404",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-27405.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-27405.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-27405",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-27405",
       "Metadata": {},
       "Name": "CVE-2022-27405",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-27406.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-27406.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-27406",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-27406",
       "Metadata": {},
       "Name": "CVE-2022-27406",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2795.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2795.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-2795",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-2795",
       "Metadata": {},
       "Name": "CVE-2022-2795",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-28391.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-28391.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-28391",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-28391",
       "Metadata": {},
       "Name": "CVE-2022-28391",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-28506.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-28506.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-28506",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-28506",
       "Metadata": {},
       "Name": "CVE-2022-28506",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-28805.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-28805.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-28805",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-28805",
       "Metadata": {},
       "Name": "CVE-2022-28805",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2881.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2881.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-2881",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-2881",
       "Metadata": {},
       "Name": "CVE-2022-2881",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2906.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-2906.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-2906",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-2906",
       "Metadata": {},
       "Name": "CVE-2022-2906",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-29458.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-29458.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-29458",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-29458",
       "Metadata": {},
       "Name": "CVE-2022-29458",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-30065.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-30065.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-30065",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-30065",
       "Metadata": {},
       "Name": "CVE-2022-30065",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3080.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3080.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3080",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3080",
       "Metadata": {},
       "Name": "CVE-2022-3080",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3094.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3094.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3094",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3094",
       "Metadata": {},
       "Name": "CVE-2022-3094",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31107.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31107.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-31107",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-31107",
       "Metadata": {},
       "Name": "CVE-2022-31107",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31123.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31123.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-31123",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-31123",
       "Metadata": {},
       "Name": "CVE-2022-31123",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31130.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31130.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-31130",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-31130",
       "Metadata": {},
       "Name": "CVE-2022-31130",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31630.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-31630.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-31630",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-31630",
       "Metadata": {},
       "Name": "CVE-2022-31630",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-32221.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-32221.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-32221",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-32221",
       "Metadata": {},
       "Name": "CVE-2022-32221",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-33070.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-33070.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-33070",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-33070",
       "Metadata": {},
       "Name": "CVE-2022-33070",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3358.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3358.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3358",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3358",
       "Metadata": {},
       "Name": "CVE-2022-3358",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-34903.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-34903.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-34903",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-34903",
       "Metadata": {},
       "Name": "CVE-2022-34903",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3515.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3515.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3515",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3515",
       "Metadata": {},
       "Name": "CVE-2022-3515",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-35977.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-35977.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-35977",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-35977",
       "Metadata": {},
       "Name": "CVE-2022-35977",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3602.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3602.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3602",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3602",
       "Metadata": {},
       "Name": "CVE-2022-3602",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-36021.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-36021.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-36021",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-36021",
       "Metadata": {},
       "Name": "CVE-2022-36021",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-36227.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-36227.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-36227",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-36227",
       "Metadata": {},
       "Name": "CVE-2022-36227",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3647.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3647.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3647",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3647",
       "Metadata": {},
       "Name": "CVE-2022-3647",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3734.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3734.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3734",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3734",
       "Metadata": {},
       "Name": "CVE-2022-3734",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3736.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3736.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3736",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3736",
       "Metadata": {},
       "Name": "CVE-2022-3736",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-37434.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-37434.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-37434",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-37434",
       "Metadata": {},
       "Name": "CVE-2022-37434",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3786.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3786.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3786",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3786",
       "Metadata": {},
       "Name": "CVE-2022-3786",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38126.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38126.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38126",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38126",
       "Metadata": {},
       "Name": "CVE-2022-38126",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38128.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38128.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38128",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38128",
       "Metadata": {},
       "Name": "CVE-2022-38128",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38177.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38177.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38177",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38177",
       "Metadata": {},
       "Name": "CVE-2022-38177",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38178.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38178.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38178",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38178",
       "Metadata": {},
       "Name": "CVE-2022-38178",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38533.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-38533.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38533",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38533",
       "Metadata": {},
       "Name": "CVE-2022-38533",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39046.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39046.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39046",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39046",
       "Metadata": {},
       "Name": "CVE-2022-39046",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39201.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39201.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39201",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39201",
       "Metadata": {},
       "Name": "CVE-2022-39201",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3924.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3924.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3924",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3924",
       "Metadata": {},
       "Name": "CVE-2022-3924",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39253.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39253.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39253",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39253",
       "Metadata": {},
       "Name": "CVE-2022-39253",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39260.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39260.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39260",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39260",
       "Metadata": {},
       "Name": "CVE-2022-39260",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39379.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-39379.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39379",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39379",
       "Metadata": {},
       "Name": "CVE-2022-39379",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3996.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-3996.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3996",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3996",
       "Metadata": {},
       "Name": "CVE-2022-3996",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40303.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40303.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-40303",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-40303",
       "Metadata": {},
       "Name": "CVE-2022-40303",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40304.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40304.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-40304",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-40304",
       "Metadata": {},
       "Name": "CVE-2022-40304",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40674.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40674.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-40674",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-40674",
       "Metadata": {},
       "Name": "CVE-2022-40674",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40716.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-40716.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-40716",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-40716",
       "Metadata": {},
       "Name": "CVE-2022-40716",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41716.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41716.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41716",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41716",
       "Metadata": {},
       "Name": "CVE-2022-41716",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41717.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41717.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41717",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41717",
       "Metadata": {},
       "Name": "CVE-2022-41717",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41720.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41720.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41720",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41720",
       "Metadata": {},
       "Name": "CVE-2022-41720",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41723.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41723.json
@@ -18,7 +18,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41723",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41723",
       "Metadata": {},
       "Name": "CVE-2022-41723",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41862.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41862.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41862",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41862",
       "Metadata": {},
       "Name": "CVE-2022-41862",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41903.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-41903.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41903",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41903",
       "Metadata": {},
       "Name": "CVE-2022-41903",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42010.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42010.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42010",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42010",
       "Metadata": {},
       "Name": "CVE-2022-42010",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42011.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42011.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42011",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42011",
       "Metadata": {},
       "Name": "CVE-2022-42011",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42012.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42012.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42012",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42012",
       "Metadata": {},
       "Name": "CVE-2022-42012",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-4203.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-4203.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-4203",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-4203",
       "Metadata": {},
       "Name": "CVE-2022-4203",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42916.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-42916.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42916",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42916",
       "Metadata": {},
       "Name": "CVE-2022-42916",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-4304.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-4304.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-4304",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-4304",
       "Metadata": {},
       "Name": "CVE-2022-4304",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-43551.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-43551.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-43551",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-43551",
       "Metadata": {},
       "Name": "CVE-2022-43551",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-43552.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-43552.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-43552",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-43552",
       "Metadata": {},
       "Name": "CVE-2022-43552",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-43680.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-43680.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-43680",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-43680",
       "Metadata": {},
       "Name": "CVE-2022-43680",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-4450.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-4450.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-4450",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-4450",
       "Metadata": {},
       "Name": "CVE-2022-4450",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-44617.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-44617.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-44617",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-44617",
       "Metadata": {},
       "Name": "CVE-2022-44617",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-45142.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-45142.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-45142",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-45142",
       "Metadata": {},
       "Name": "CVE-2022-45142",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-46153.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-46153.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-46153",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-46153",
       "Metadata": {},
       "Name": "CVE-2022-46153",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-46908.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-46908.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-46908",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-46908",
       "Metadata": {},
       "Name": "CVE-2022-46908",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-47015.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-47015.json
@@ -18,7 +18,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-47015",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-47015",
       "Metadata": {},
       "Name": "CVE-2022-47015",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-47629.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2022-47629.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-47629",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-47629",
       "Metadata": {},
       "Name": "CVE-2022-47629",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0215.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0215.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-0215",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-0215",
       "Metadata": {},
       "Name": "CVE-2023-0215",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0216.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0216.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-0216",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-0216",
       "Metadata": {},
       "Name": "CVE-2023-0216",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0217.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0217.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-0217",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-0217",
       "Metadata": {},
       "Name": "CVE-2023-0217",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0286.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0286.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-0286",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-0286",
       "Metadata": {},
       "Name": "CVE-2023-0286",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0401.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0401.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-0401",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-0401",
       "Metadata": {},
       "Name": "CVE-2023-0401",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0464.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-0464.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-0464",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-0464",
       "Metadata": {},
       "Name": "CVE-2023-0464",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1127.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1127.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-1127",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-1127",
       "Metadata": {},
       "Name": "CVE-2023-1127",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1175.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1175.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-1175",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-1175",
       "Metadata": {},
       "Name": "CVE-2023-1175",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1264.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1264.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-1264",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-1264",
       "Metadata": {},
       "Name": "CVE-2023-1264",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1355.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-1355.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-1355",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-1355",
       "Metadata": {},
       "Name": "CVE-2023-1355",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22458.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22458.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-22458",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-22458",
       "Metadata": {},
       "Name": "CVE-2023-22458",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22490.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22490.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-22490",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-22490",
       "Metadata": {},
       "Name": "CVE-2023-22490",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22499.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22499.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-22499",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-22499",
       "Metadata": {},
       "Name": "CVE-2023-22499",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22743.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22743.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-22743",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-22743",
       "Metadata": {},
       "Name": "CVE-2023-22743",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-23946.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-23946.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-23946",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-23946",
       "Metadata": {},
       "Name": "CVE-2023-23946",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-24056.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-24056.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-24056",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-24056",
       "Metadata": {},
       "Name": "CVE-2023-24056",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-24532.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-24532.json
@@ -18,7 +18,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-24532",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-24532",
       "Metadata": {},
       "Name": "CVE-2023-24532",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-24999.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-24999.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-24999",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-24999",
       "Metadata": {},
       "Name": "CVE-2023-24999",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25136.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25136.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-25136",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-25136",
       "Metadata": {},
       "Name": "CVE-2023-25136",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25139.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25139.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-25139",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-25139",
       "Metadata": {},
       "Name": "CVE-2023-25139",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25155.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25155.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-25155",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-25155",
       "Metadata": {},
       "Name": "CVE-2023-25155",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25165.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25165.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-25165",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-25165",
       "Metadata": {},
       "Name": "CVE-2023-25165",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25725.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-25725.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-25725",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-25725",
       "Metadata": {},
       "Name": "CVE-2023-25725",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-26489.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-26489.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-26489",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-26489",
       "Metadata": {},
       "Name": "CVE-2023-26489",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-27477.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-27477.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-27477",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-27477",
       "Metadata": {},
       "Name": "CVE-2023-27477",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-27898.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-27898.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-27898",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-27898",
       "Metadata": {},
       "Name": "CVE-2023-27898",
       "NamespaceName": "chainguard:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2016-2781.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2016-2781.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2016-2781",
+      "Link": "https://images.chainguard.dev/security/CVE-2016-2781",
       "Metadata": {},
       "Name": "CVE-2016-2781",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2017-8806.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2017-8806.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2017-8806",
+      "Link": "https://images.chainguard.dev/security/CVE-2017-8806",
       "Metadata": {},
       "Name": "CVE-2017-8806",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-1000156.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-1000156.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-1000156",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-1000156",
       "Metadata": {},
       "Name": "CVE-2018-1000156",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-20969.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-20969.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-20969",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-20969",
       "Metadata": {},
       "Name": "CVE-2018-20969",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-25032.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-25032.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-25032",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-25032",
       "Metadata": {},
       "Name": "CVE-2018-25032",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-6951.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-6951.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-6951",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-6951",
       "Metadata": {},
       "Name": "CVE-2018-6951",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-6952.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2018-6952.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2018-6952",
+      "Link": "https://images.chainguard.dev/security/CVE-2018-6952",
       "Metadata": {},
       "Name": "CVE-2018-6952",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-13636.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-13636.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-13636",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-13636",
       "Metadata": {},
       "Name": "CVE-2019-13636",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-13638.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-13638.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-13638",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-13638",
       "Metadata": {},
       "Name": "CVE-2019-13638",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-20633.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-20633.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-20633",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-20633",
       "Metadata": {},
       "Name": "CVE-2019-20633",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-6293.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-6293.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2019-6293",
+      "Link": "https://images.chainguard.dev/security/CVE-2019-6293",
       "Metadata": {},
       "Name": "CVE-2019-6293",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2020-10735.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2020-10735.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-10735",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-10735",
       "Metadata": {},
       "Name": "CVE-2020-10735",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2020-8927.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2020-8927.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2020-8927",
+      "Link": "https://images.chainguard.dev/security/CVE-2020-8927",
       "Metadata": {},
       "Name": "CVE-2020-8927",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2021-30218.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2021-30218.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-30218",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-30218",
       "Metadata": {},
       "Name": "CVE-2021-30218",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2021-30219.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2021-30219.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-30219",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-30219",
       "Metadata": {},
       "Name": "CVE-2021-30219",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2021-43618.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2021-43618.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2021-43618",
+      "Link": "https://images.chainguard.dev/security/CVE-2021-43618",
       "Metadata": {},
       "Name": "CVE-2021-43618",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-1586.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-1586.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-1586",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-1586",
       "Metadata": {},
       "Name": "CVE-2022-1586",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-1587.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-1587.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-1587",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-1587",
       "Metadata": {},
       "Name": "CVE-2022-1587",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-26691.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-26691.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-26691",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-26691",
       "Metadata": {},
       "Name": "CVE-2022-26691",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-27404.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-27404.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-27404",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-27404",
       "Metadata": {},
       "Name": "CVE-2022-27404",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-27405.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-27405.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-27405",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-27405",
       "Metadata": {},
       "Name": "CVE-2022-27405",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-27406.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-27406.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-27406",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-27406",
       "Metadata": {},
       "Name": "CVE-2022-27406",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-28391.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-28391.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-28391",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-28391",
       "Metadata": {},
       "Name": "CVE-2022-28391",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-28506.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-28506.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-28506",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-28506",
       "Metadata": {},
       "Name": "CVE-2022-28506",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-29458.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-29458.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-29458",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-29458",
       "Metadata": {},
       "Name": "CVE-2022-29458",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-30065.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-30065.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-30065",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-30065",
       "Metadata": {},
       "Name": "CVE-2022-30065",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-32221.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-32221.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-32221",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-32221",
       "Metadata": {},
       "Name": "CVE-2022-32221",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-3358.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-3358.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3358",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3358",
       "Metadata": {},
       "Name": "CVE-2022-3358",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-3602.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-3602.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3602",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3602",
       "Metadata": {},
       "Name": "CVE-2022-3602",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-36227.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-36227.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-36227",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-36227",
       "Metadata": {},
       "Name": "CVE-2022-36227",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-37434.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-37434.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-37434",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-37434",
       "Metadata": {},
       "Name": "CVE-2022-37434",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-3786.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-3786.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-3786",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-3786",
       "Metadata": {},
       "Name": "CVE-2022-3786",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-38126.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-38126.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38126",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38126",
       "Metadata": {},
       "Name": "CVE-2022-38126",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-38128.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-38128.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38128",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38128",
       "Metadata": {},
       "Name": "CVE-2022-38128",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-38533.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-38533.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-38533",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-38533",
       "Metadata": {},
       "Name": "CVE-2022-38533",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-39046.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-39046.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39046",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39046",
       "Metadata": {},
       "Name": "CVE-2022-39046",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-39253.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-39253.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39253",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39253",
       "Metadata": {},
       "Name": "CVE-2022-39253",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-39260.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-39260.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-39260",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-39260",
       "Metadata": {},
       "Name": "CVE-2022-39260",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-40303.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-40303.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-40303",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-40303",
       "Metadata": {},
       "Name": "CVE-2022-40303",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-40304.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-40304.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-40304",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-40304",
       "Metadata": {},
       "Name": "CVE-2022-40304",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-40674.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-40674.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-40674",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-40674",
       "Metadata": {},
       "Name": "CVE-2022-40674",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-41716.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-41716.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41716",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41716",
       "Metadata": {},
       "Name": "CVE-2022-41716",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-41717.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-41717.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41717",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41717",
       "Metadata": {},
       "Name": "CVE-2022-41717",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-41720.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-41720.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-41720",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-41720",
       "Metadata": {},
       "Name": "CVE-2022-41720",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42010.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42010.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42010",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42010",
       "Metadata": {},
       "Name": "CVE-2022-42010",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42011.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42011.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42011",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42011",
       "Metadata": {},
       "Name": "CVE-2022-42011",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42012.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42012.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42012",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42012",
       "Metadata": {},
       "Name": "CVE-2022-42012",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42916.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-42916.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-42916",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-42916",
       "Metadata": {},
       "Name": "CVE-2022-42916",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-43680.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-43680.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-43680",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-43680",
       "Metadata": {},
       "Name": "CVE-2022-43680",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-46908.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2022-46908.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2022-46908",
+      "Link": "https://images.chainguard.dev/security/CVE-2022-46908",
       "Metadata": {},
       "Name": "CVE-2022-46908",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-28840.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-28840.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-28840",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-28840",
       "Metadata": {},
       "Name": "CVE-2023-28840",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-28841.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-28841.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-28841",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-28841",
       "Metadata": {},
       "Name": "CVE-2023-28841",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-28842.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-28842.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-28842",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-28842",
       "Metadata": {},
       "Name": "CVE-2023-28842",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-30551.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-30551.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-30551",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-30551",
       "Metadata": {},
       "Name": "CVE-2023-30551",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-39325.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-39325.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-39325",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-39325",
       "Metadata": {},
       "Name": "CVE-2023-39325",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-3978.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-3978.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-3978",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-3978",
       "Metadata": {},
       "Name": "CVE-2023-3978",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45283.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45283.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-45283",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-45283",
       "Metadata": {},
       "Name": "CVE-2023-45283",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45284.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45284.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://www.cve.org/CVERecord?id=CVE-2023-45284",
+      "Link": "https://images.chainguard.dev/security/CVE-2023-45284",
       "Metadata": {},
       "Name": "CVE-2023-45284",
       "NamespaceName": "wolfi:rolling",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/GHSA-jq35-85cj-fj4p.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/GHSA-jq35-85cj-fj4p.json
@@ -12,7 +12,7 @@
           "VersionFormat": "apk"
         }
       ],
-      "Link": "https://github.com/advisories/GHSA-jq35-85cj-fj4p",
+      "Link": "https://images.chainguard.dev/security/GHSA-jq35-85cj-fj4p",
       "Metadata": {},
       "Name": "GHSA-jq35-85cj-fj4p",
       "NamespaceName": "wolfi:rolling",


### PR DESCRIPTION
Alpine, Wolfi, and Chainguard all now have specific webpages dedicated to vulnerability identifiers existing in their security feeds, so prefer those over the generic cve.org ones

Examples:
- https://security.alpinelinux.org/vuln/CVE-2025-6663
- https://images.chainguard.dev/security/CVE-2017-8806
- https://images.chainguard.dev/security/GHSA-jq35-85cj-fj4p