### PR TITLE
Add fix date processing for alpine

### DIFF
--- a/src/vunnel/providers/alpine/__init__.py
+++ b/src/vunnel/providers/alpine/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
+from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -20,6 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
+    add_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -34,8 +36,13 @@ class Provider(provider.Provider):
         self.config = config
         self.logger.debug(f"config: {self.config}")
 
+        fixdater = None
+        if config.add_fix_dates:
+            fixdater = fixdate.default_finder(self.workspace, self.name())
+
         self.parser = Parser(
             workspace=self.workspace,
+            fixdater=fixdater,
             download_timeout=self.config.request_timeout,
             logger=self.logger,
         )

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -177,6 +177,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   alpine:
+    add_fix_dates: false
     request_timeout: 125
     runtime:
       existing_input: keep

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1071.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1071.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zsh",
           "NamespaceName": "alpine:3.15",
           "Version": "5.4.2-r1",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1083.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-1083.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zsh",
           "NamespaceName": "alpine:3.15",
           "Version": "5.4.2-r1",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-25032.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2018-25032.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zlib",
           "NamespaceName": "alpine:3.15",
           "Version": "1.2.12-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-11922.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-11922.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zstd",
           "NamespaceName": "alpine:3.15",
           "Version": "1.3.8-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-13132.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-13132.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zeromq",
           "NamespaceName": "alpine:3.15",
           "Version": "4.3.2-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-20044.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-20044.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zsh",
           "NamespaceName": "alpine:3.15",
           "Version": "5.8-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-6250.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-6250.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zeromq",
           "NamespaceName": "alpine:3.15",
           "Version": "4.3.1-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-9210.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2019-9210.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "advancecomp",
           "NamespaceName": "alpine:3.15",
           "Version": "2.1-r2",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-14929.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-14929.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "alpine",
           "NamespaceName": "alpine:3.15",
           "Version": "2.23-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-15166.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2020-15166.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zeromq",
           "NamespaceName": "alpine:3.15",
           "Version": "4.3.3-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24031.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24031.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zstd",
           "NamespaceName": "alpine:3.15",
           "Version": "1.4.1-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24032.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-24032.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zstd",
           "NamespaceName": "alpine:3.15",
           "Version": "1.4.9-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-38370.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-38370.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "alpine",
           "NamespaceName": "alpine:3.15",
           "Version": "2.25-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-45444.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2021-45444.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zsh",
           "NamespaceName": "alpine:3.15",
           "Version": "5.8.1-r0",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-1271.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-1271.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "xz",
           "NamespaceName": "alpine:3.15",
           "Version": "5.2.5-r1",

--- a/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-37434.json
+++ b/tests/unit/providers/alpine/test-fixtures/snapshots/3.15/cve-2022-37434.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zlib",
           "NamespaceName": "alpine:3.15",
           "Version": "1.2.12-r2",

--- a/tests/unit/providers/alpine/test_alpine.py
+++ b/tests/unit/providers/alpine/test_alpine.py
@@ -190,7 +190,7 @@ class TestAlpineProvider:
         assert Parser._link_finder_regex_.findall(content) == expected
 
 
-def test_provider_schema(helpers, disable_get_requests, monkeypatch):
+def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 
     c = Config()
@@ -214,7 +214,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch):
     assert workspace.result_schemas_valid(require_entries=True)
 
 
-def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch):
+def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/input",


### PR DESCRIPTION
This adds adding fix-date information based on first-observed fix information to records for the alpine provider.

Partially implements #742 

## PR Stack
- #852