### PR TITLE
Add fix date processing for minimos 

### DIFF
--- a/src/vunnel/providers/minimos/__init__.py
+++ b/src/vunnel/providers/minimos/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
+from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -20,6 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
+    add_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -38,8 +40,13 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
+        fixdater = None
+        if config.add_fix_dates:
+            fixdater = fixdate.default_finder(self.workspace, self.name())
+
         self.parser = Parser(
             workspace=self.workspace,
+            fixdater=fixdater,
             url=self._url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,

--- a/src/vunnel/providers/minimos/parser.py
+++ b/src/vunnel/providers/minimos/parser.py
@@ -15,20 +15,23 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from vunnel import workspace
+    from vunnel.tool import fixdate
 
 
 class Parser:
     _release_ = "rolling"
     _secdb_dir_ = "secdb"
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         workspace: workspace.Workspace,
         url: str,
         namespace: str,
+        fixdater: fixdate.Finder | None = None,
         download_timeout: int = 125,
         logger: logging.Logger | None = None,
     ):
+        self.fixdater = fixdater
         self.download_timeout = download_timeout
         self.secdb_dir_path = os.path.join(workspace.input_path, self._secdb_dir_)
         self.metadata_url = url.strip("/")
@@ -51,6 +54,9 @@ class Parser:
         """
         if not os.path.exists(self.secdb_dir_path):
             os.makedirs(self.secdb_dir_path, exist_ok=True)
+
+        if self.fixdater:
+            self.fixdater.download()
 
         try:
             self.logger.info(f"downloading {self.namespace} secdb {self.url}")
@@ -79,7 +85,7 @@ class Parser:
             self.logger.exception(f"failed to load {self.namespace} sec db data")
             raise
 
-    def _normalize(self, release: str, data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    def _normalize(self, release: str, data: dict[str, Any]) -> dict[str, dict[str, Any]]:  # noqa: C901
         """
         Normalize all the sec db entries into vulnerability payload records
         :param release:
@@ -95,10 +101,10 @@ class Parser:
             pkg_el = el["pkg"]
 
             pkg = pkg_el["name"]
-            for pkg_version in pkg_el["secfixes"]:
+            for fix_version in pkg_el["secfixes"]:
                 vids = []
-                if pkg_el["secfixes"][pkg_version]:
-                    for rawvid in pkg_el["secfixes"][pkg_version]:
+                if pkg_el["secfixes"][fix_version]:
+                    for rawvid in pkg_el["secfixes"][fix_version]:
                         tmp = rawvid.split()
                         for newvid in tmp:
                             if newvid not in vids:
@@ -124,12 +130,29 @@ class Parser:
                         vuln_record = vuln_dict[vid]
 
                     # SET UP fixedins
+                    ecosystem = self.namespace + ":" + str(release)
                     fixed_el = {
                         "Name": pkg,
-                        "Version": pkg_version,
+                        "Version": fix_version,
                         "VersionFormat": "apk",
-                        "NamespaceName": self.namespace + ":" + str(release),
+                        "NamespaceName": ecosystem,
                     }
+
+                    if fix_version and self.fixdater:
+                        dates = self.fixdater.find(
+                            vuln_id=str(vid),
+                            cpe_or_package=pkg,
+                            fix_version=fix_version,
+                            ecosystem=ecosystem,
+                        )
+                        if dates:
+                            result = dates[0]
+                            available = {
+                                "Date": result.date.isoformat(),
+                                "Kind": result.kind,
+                            }
+
+                            fixed_el["Available"] = available
 
                     vuln_record["Vulnerability"]["FixedIn"].append(fixed_el)  # type: ignore[union-attr]
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -379,6 +379,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   minimos:
+    add_fix_dates: false
     request_timeout: 125
     runtime:
       existing_input: keep

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2016-2781.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2016-2781.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "coreutils",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2017-8806.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2017-8806.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "postgresql-15",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-1000156.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-1000156.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "patch",
           "NamespaceName": "minimos:rolling",
           "Version": "2.7.6-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-20969.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-20969.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "patch",
           "NamespaceName": "minimos:rolling",
           "Version": "2.7.6-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-25032.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-25032.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zlib",
           "NamespaceName": "minimos:rolling",
           "Version": "1.2.12-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-6951.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-6951.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "patch",
           "NamespaceName": "minimos:rolling",
           "Version": "2.7.6-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-6952.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2018-6952.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "patch",
           "NamespaceName": "minimos:rolling",
           "Version": "2.7.6-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-13636.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-13636.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "patch",
           "NamespaceName": "minimos:rolling",
           "Version": "2.7.6-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-13638.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-13638.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "patch",
           "NamespaceName": "minimos:rolling",
           "Version": "2.7.6-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-20633.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-20633.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "patch",
           "NamespaceName": "minimos:rolling",
           "Version": "2.7.6-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-6293.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-6293.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "flex",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2020-10735.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2020-10735.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "python3",
           "NamespaceName": "minimos:rolling",
           "Version": "3.0.7-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2020-8927.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2020-8927.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "brotli",
           "NamespaceName": "minimos:rolling",
           "Version": "1.0.9-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2021-30218.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2021-30218.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "samurai",
           "NamespaceName": "minimos:rolling",
           "Version": "1.2-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2021-30219.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2021-30219.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "samurai",
           "NamespaceName": "minimos:rolling",
           "Version": "1.2-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2021-43618.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2021-43618.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "gmp",
           "NamespaceName": "minimos:rolling",
           "Version": "6.2.1-r4",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-1586.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-1586.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "pcre2",
           "NamespaceName": "minimos:rolling",
           "Version": "10.40-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-1587.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-1587.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "pcre2",
           "NamespaceName": "minimos:rolling",
           "Version": "10.40-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-26691.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-26691.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "cups",
           "NamespaceName": "minimos:rolling",
           "Version": "2.4.2-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-27404.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-27404.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "freetype",
           "NamespaceName": "minimos:rolling",
           "Version": "2.12.1-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-27405.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-27405.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "freetype",
           "NamespaceName": "minimos:rolling",
           "Version": "2.12.1-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-27406.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-27406.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "freetype",
           "NamespaceName": "minimos:rolling",
           "Version": "2.12.1-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-28391.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-28391.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "busybox",
           "NamespaceName": "minimos:rolling",
           "Version": "1.35.0-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-28506.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-28506.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "giflib",
           "NamespaceName": "minimos:rolling",
           "Version": "5.2.1-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-29458.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-29458.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "ncurses",
           "NamespaceName": "minimos:rolling",
           "Version": "6.3-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-30065.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-30065.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "busybox",
           "NamespaceName": "minimos:rolling",
           "Version": "1.35.0-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-32221.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-32221.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "curl",
           "NamespaceName": "minimos:rolling",
           "Version": "7.86.0-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-3358.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-3358.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "openssl",
           "NamespaceName": "minimos:rolling",
           "Version": "3.0.7-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-3602.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-3602.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "openssl",
           "NamespaceName": "minimos:rolling",
           "Version": "3.0.7-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-36227.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-36227.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "libarchive",
           "NamespaceName": "minimos:rolling",
           "Version": "3.6.1-r2",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-37434.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-37434.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "zlib",
           "NamespaceName": "minimos:rolling",
           "Version": "1.2.12-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-3786.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-3786.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "openssl",
           "NamespaceName": "minimos:rolling",
           "Version": "3.0.7-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-38126.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-38126.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "binutils",
           "NamespaceName": "minimos:rolling",
           "Version": "2.39-r1",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-38128.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-38128.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "binutils",
           "NamespaceName": "minimos:rolling",
           "Version": "2.39-r3",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-38533.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-38533.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "binutils",
           "NamespaceName": "minimos:rolling",
           "Version": "2.39-r2",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-39046.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-39046.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "glibc",
           "NamespaceName": "minimos:rolling",
           "Version": "2.36-r1",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-39253.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-39253.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "git",
           "NamespaceName": "minimos:rolling",
           "Version": "2.38.1-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-39260.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-39260.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "git",
           "NamespaceName": "minimos:rolling",
           "Version": "2.38.1-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-40303.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-40303.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "libxml2",
           "NamespaceName": "minimos:rolling",
           "Version": "2.10.3-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-40304.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-40304.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "libxml2",
           "NamespaceName": "minimos:rolling",
           "Version": "2.10.3-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-40674.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-40674.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "expat",
           "NamespaceName": "minimos:rolling",
           "Version": "2.4.9-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-41716.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-41716.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "go",
           "NamespaceName": "minimos:rolling",
           "Version": "1.19.3-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-41717.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-41717.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "go",
           "NamespaceName": "minimos:rolling",
           "Version": "1.19.4-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-41720.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-41720.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "go",
           "NamespaceName": "minimos:rolling",
           "Version": "1.19.4-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42010.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42010.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "dbus",
           "NamespaceName": "minimos:rolling",
           "Version": "1.14.4-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42011.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42011.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "dbus",
           "NamespaceName": "minimos:rolling",
           "Version": "1.14.4-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42012.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42012.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "dbus",
           "NamespaceName": "minimos:rolling",
           "Version": "1.14.4-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42916.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-42916.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "curl",
           "NamespaceName": "minimos:rolling",
           "Version": "7.86.0-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-43680.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-43680.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "expat",
           "NamespaceName": "minimos:rolling",
           "Version": "2.5.0-r0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-46908.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2022-46908.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "sqlite",
           "NamespaceName": "minimos:rolling",
           "Version": "3.40.0-r1",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-28840.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-28840.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0.7.3-r1",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-28841.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-28841.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0.7.3-r1",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-28842.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-28842.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0.7.3-r1",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-30551.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-30551.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0.8.0-r1",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-39325.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-39325.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0.10.0-r6",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-3978.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-3978.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0.10.0-r6",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45283.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45283.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45284.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45284.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/GHSA-jq35-85cj-fj4p.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/GHSA-jq35-85cj-fj4p.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test_minimos.py
+++ b/tests/unit/providers/minimos/test_minimos.py
@@ -210,7 +210,7 @@ class TestParser:
         )
 
 
-def test_provider_schema(helpers, disable_get_requests):
+def test_provider_schema(helpers, disable_get_requests, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/input",
@@ -225,7 +225,7 @@ def test_provider_schema(helpers, disable_get_requests):
     assert workspace.result_schemas_valid(require_entries=True)
 
 
-def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch):
+def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/input",


### PR DESCRIPTION
This adds adding fix-date information based on first-observed fix information to records for the minimos provider.

Partially implements #742 

## PR Stack
- #852