### PR TITLE
Add fix date processing for redhat

### DIFF
--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
+from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -20,6 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
+    add_fix_dates: bool = True
     request_timeout: int = 125
     parallelism: int = 4
     full_sync_interval: int = 2  # in days
@@ -40,8 +42,13 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
+        fixdater = None
+        if config.add_fix_dates:
+            fixdater = fixdate.default_finder(self.workspace, self.name())
+
         self.parser = Parser(
             workspace=self.workspace,
+            fixdater=fixdater,
             download_timeout=self.config.request_timeout,
             max_workers=self.config.parallelism,
             full_sync_interval=self.config.full_sync_interval,

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -434,6 +434,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   rhel:
+    add_fix_dates: false
     full_sync_interval: 2
     ignore_hydra_errors: false
     parallelism: 4

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3509.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -45,7 +53,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3509",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3511.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3511",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3526.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -45,7 +53,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3526",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3533.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -45,7 +53,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3533",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3539.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -45,7 +53,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3539",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3544.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -45,7 +53,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3544",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3509.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-0.b11.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3509",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3511.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-0.b11.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3511",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3526.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-0.b11.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3526",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3533.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-0.b11.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3533",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3539.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-0.b11.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3539",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3544.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-0.b11.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el6_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3544",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16587.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2020-16587",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16588.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2020-16588",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20298.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2021-20298",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20299.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2021-20299",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1921.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1921",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1922.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1922",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1923.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1923",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1924.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1924",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1925.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1925",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-4863.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-4863",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5129.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5129",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5217.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5217",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3509.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-2.b11.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3509",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3511.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-2.b11.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3511",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3526.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-2.b11.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3526",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3533.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-2.b11.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3533",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3539.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-2.b11.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3539",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3544.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.8.0.131-2.b11.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "1:1.7.0.141-2.6.10.1.el7_3",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2017-3544",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16587.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2020-16587",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16588.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2020-16588",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20298.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2021-20298",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20299.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2021-20299",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1921.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1921",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1922.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1922",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1923.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1923",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1924.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1924",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1925.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -35,7 +39,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1925",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el7_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el7_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-4863",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el7_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el7_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5129",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el7_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el7_9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5217",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-4863.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.0.0-7.el8_6.1",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_6",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_6",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-4863",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5129.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.0.0-7.el8_6.1",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_6",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_6",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5129",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5217.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el8_6",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el8_6",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.7.0-10.el8_6",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5217",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2019-25059.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2019-25059",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16587.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2020-16587",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20298.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2021-20298",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20299.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2021-20299",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1921.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1921",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1922.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1922",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1923.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1923",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1924.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1924",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1925.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1925",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-4863.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_8",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_8",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.0.0-8.el8_8.1",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-4863",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5129.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_8",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el8_8",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.0.0-8.el8_8.1",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5129",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5217.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el8_8",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el8_8",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.7.0-10.el8_8",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5217",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-4863.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.2.0-6.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-4863",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5129.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.2.0-6.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5129",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5217.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.9.0-7.el9_0",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5217",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2019-25059.json
@@ -25,7 +25,11 @@
             "NoAdvisory": true
           },
           "Version": "None",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2019-25059",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1921.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.18.4-6.el9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1921",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1922.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.18.4-6.el9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1922",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1923.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.18.4-6.el9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1923",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1924.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.18.4-6.el9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1924",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1925.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.18.4-6.el9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-1925",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-2309.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-2309.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:4.6.5-3.el9",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2022-2309",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-4863.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.2.0-7.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-4863",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5129.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.2.0-7.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:102.15.1-1.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5129",

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5217.json
@@ -31,7 +31,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -47,7 +51,11 @@
             "NoAdvisory": false
           },
           "Version": "0:115.3.1-1.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         },
         {
           "Module": null,
@@ -63,7 +71,11 @@
             "NoAdvisory": false
           },
           "Version": "0:1.9.0-7.el9_2",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "available": {
+            "date": "2024-01-01",
+            "kind": "first-observed"
+          }
         }
       ],
       "Link": "https://access.redhat.com/security/cve/CVE-2023-5217",

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -750,7 +750,7 @@ class TestParser:
         assert Parser._get_name_version(package) == (name, version)
 
 
-def test_provider_schema(helpers, disable_get_requests, monkeypatch):
+def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/oval/input",
@@ -854,7 +854,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch):
     assert workspace.result_schemas_valid(require_entries=True)
 
 
-def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch):
+def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/oval/input",


### PR DESCRIPTION
This adds adding fix-date information based on first-observed fix information to records for the rhel provider.

Partially implements #742 
