### PR TITLE
Do not require date and kind fields for fix available object

### DIFF
--- a/schema/vulnerability/github-security-advisory/schema-1.0.2.json
+++ b/schema/vulnerability/github-security-advisory/schema-1.0.2.json
@@ -91,11 +91,7 @@
                     "kind": {
                       "type": "string"
                     }
-                  },
-                  "required": [
-                    "date",
-                    "kind"
-                  ]
+                  }
                 }
               },
               "required": [


### PR DESCRIPTION
Downstream of this should not expect these fields to be well formed based on the various handlers in providers today (defensive measures downstream should be taken). The schema now reflects this.