### PR TITLE
Enable fix date processing

### DIFF
--- a/src/vunnel/cli/config.py
+++ b/src/vunnel/cli/config.py
@@ -68,10 +68,6 @@ class Providers:
         for name in self.provider_names():
             cfg = getattr(self, name)
 
-            # TODO: for the meantime, we will disable all usages of add_fix_dates (since data is still not ready yet)
-            if hasattr(cfg, "add_fix_dates"):
-                cfg.add_fix_dates = False
-
             runtime_cfg = getattr(cfg, "runtime", None)
             if runtime_cfg and isinstance(runtime_cfg, provider.RuntimeConfig):
                 if runtime_cfg.import_results_enabled is None:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -99,7 +99,7 @@ def test_run(mocker, monkeypatch) -> None:
             "./data",
             # note: this is the default config
             config=nvd.Config(
-                add_fix_dates=False,
+                add_fix_dates=True,
                 runtime=provider.RuntimeConfig(
                     on_error=provider.OnErrorConfig(
                         action=provider.OnErrorAction.FAIL,
@@ -178,7 +178,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   alpine:
-    add_fix_dates: false
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -218,7 +218,7 @@ providers:
       '2022': https://alas.aws.amazon.com/AL2022/alas.rss
       '2023': https://alas.aws.amazon.com/AL2023/alas.rss
   bitnami:
-    add_fix_dates: false
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -236,7 +236,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   chainguard:
-    add_fix_dates: false
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -288,7 +288,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   echo:
-    add_fix_dates: false
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -325,7 +325,7 @@ providers:
       skip_newer_archive_check: false
     url_template: https://epss.cyentia.com/epss_scores-{}.csv.gz
   github:
-    add_fix_dates: false
+    add_fix_dates: true
     api_url: https://api.github.com/graphql
     request_timeout: 125
     runtime:
@@ -384,7 +384,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   minimos:
-    add_fix_dates: false
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -402,7 +402,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   nvd:
-    add_fix_dates: false
+    add_fix_dates: true
     api_key: secret
     overrides_enabled: false
     overrides_url: https://github.com/anchore/nvd-data-overrides/archive/refs/heads/main.tar.gz
@@ -441,7 +441,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   rhel:
-    add_fix_dates: false
+    add_fix_dates: true
     full_sync_interval: 2
     ignore_hydra_errors: false
     parallelism: 4
@@ -466,7 +466,7 @@ providers:
       - rhel:3
       - rhel:4
   rocky:
-    add_fix_dates: false
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -505,7 +505,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   ubuntu:
-    add_fix_dates: false
+    add_fix_dates: true
     additional_versions: {}
     enable_rev_history: true
     git_branch: master
@@ -528,7 +528,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   wolfi:
-    add_fix_dates: false
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep


### PR DESCRIPTION
Now that the fix date processing has been implemented everywhere and spot checked, this enables  all supported providers by default. Note: providers that key off of a date from the internal advisories are always emitting fix date, this only changes the behavior of providers that are leaning on first-observed data from historical grype-dbs. 