### PR TITLE
Finalize fixdater object pattern

### DIFF
--- a/src/vunnel/providers/alpine/__init__.py
+++ b/src/vunnel/providers/alpine/__init__.py
@@ -21,7 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -37,7 +37,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {self.config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/alpine/__init__.py
+++ b/src/vunnel/providers/alpine/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -21,7 +20,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -36,13 +34,8 @@ class Provider(provider.Provider):
         self.config = config
         self.logger.debug(f"config: {self.config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             download_timeout=self.config.request_timeout,
             logger=self.logger,
         )

--- a/src/vunnel/providers/amazon/parser.py
+++ b/src/vunnel/providers/amazon/parser.py
@@ -8,8 +8,9 @@ from html.parser import HTMLParser
 
 import defusedxml.ElementTree as ET
 
-from vunnel.utils import date, rpm
+from vunnel.tool import fixdate
 from vunnel.utils import http_wrapper as http
+from vunnel.utils import rpm
 
 namespace = "amzn"
 
@@ -37,20 +38,23 @@ class Parser:
     _rss_file_name_ = "{}_rss.xml"
     _html_dir_name_ = "{}_html"
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         workspace,
+        fixdater: fixdate.Finder | None = None,
         download_timeout=125,
         security_advisories=None,
         logger=None,
         max_allowed_alas_http_403=25,
     ):
+        if not fixdater:
+            fixdater = fixdate.default_finder(workspace)
+        self.fixdater = fixdater
         self.workspace = workspace
         self.version_url_map = security_advisories if security_advisories else amazon_security_advisories
         self.download_timeout = download_timeout
         self.max_allowed_alas_http_403 = max_allowed_alas_http_403
         self.urls = []
-
         self.alas_403s = []
 
         if not logger:
@@ -155,6 +159,8 @@ class Parser:
                     self.logger.warning(f" - {url}")
 
     def _get(self, skip_if_exists):
+        self.fixdater.download()
+
         for version, url in self.version_url_map.items():
             rss_file = os.path.join(self.workspace.input_path, self._rss_file_name_.format(version))
             html_dir = os.path.join(self.workspace.input_path, self._html_dir_name_.format(version))
@@ -190,7 +196,7 @@ class Parser:
                 description = "".join(parser.issue_overview_text)
 
                 # construct a vulnerability object and yield it
-                yield map_to_vulnerability(version, alas, fixed_in, description)
+                yield map_to_vulnerability(version, alas, fixed_in, description, self.fixdater)
 
 
 class JsonifierMixin:
@@ -245,6 +251,15 @@ class FixAvailable(JsonifierMixin):
     def __init__(self):
         self.Date = None
         self.Kind = None
+
+    @staticmethod
+    def from_result(result: fixdate.Result | None) -> FixAvailable | None:
+        if not result:
+            return None
+        fa = FixAvailable()
+        fa.Date = result.date
+        fa.Kind = result.kind
+        return fa
 
 
 class PackagesHTMLParser(HTMLParser):
@@ -303,13 +318,14 @@ class PackagesHTMLParser(HTMLParser):
         #     print('Ignoring data: {}'.format(data.strip()))
 
 
-def map_to_vulnerability(version, alas, fixed_in, description):
+def map_to_vulnerability(version, alas, fixed_in, description, fixdater: fixdate.Finder):
     if not alas:
         raise ValueError("Invalid reference to AlasSummary")
 
     v = Vulnerability()
     v.Name = alas.id
-    v.NamespaceName = namespace + ":" + version
+    ecosystem = namespace + ":" + version
+    v.NamespaceName = ecosystem
     v.Description = description
     v.Severity = severity_map.get(alas.sev, "Unknown")
     v.Metadata = {
@@ -326,13 +342,23 @@ def map_to_vulnerability(version, alas, fixed_in, description):
         f.NamespaceName = v.NamespaceName
         f.VersionFormat = "rpm"
         f.Version = item.ver
-        # populate Available object only if there is a fix version available
-        fix_date = None
-        if fixed_in:
-            fix_date = date.normalize_date(alas.pubDate)
-        if fix_date:
-            f.Available.Date = fix_date
-            f.Available.Kind = "advisory"
+        f.Available = FixAvailable.from_result(
+            fixdater.best(
+                vuln_id=alas.id,
+                cpe_or_package=item.pkg,
+                fix_version=fixed_in,
+                ecosystem=ecosystem,
+                candidates=[
+                    # take the pubDate as default fix date candidate if no better date is found
+                    fixdate.Result(
+                        date=alas.pubDate,
+                        kind="advisory",
+                        accurate=True,
+                    ),
+                ],
+            ),
+        )
+
         v.FixedIn.append(f)
 
     return v

--- a/src/vunnel/providers/amazon/parser.py
+++ b/src/vunnel/providers/amazon/parser.py
@@ -346,7 +346,7 @@ def map_to_vulnerability(version, alas, fixed_in, description, fixdater: fixdate
             fixdater.best(
                 vuln_id=alas.id,
                 cpe_or_package=item.pkg,
-                fix_version=fixed_in,
+                fix_version=item.ver,
                 ecosystem=ecosystem,
                 candidates=[
                     # take the pubDate as default fix date candidate if no better date is found

--- a/src/vunnel/providers/bitnami/__init__.py
+++ b/src/vunnel/providers/bitnami/__init__.py
@@ -20,7 +20,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -37,7 +37,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.schema = self.__schema__

--- a/src/vunnel/providers/bitnami/__init__.py
+++ b/src/vunnel/providers/bitnami/__init__.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -20,7 +19,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -36,14 +34,9 @@ class Provider(provider.Provider):
         self.config = config
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.schema = self.__schema__
         self.parser = Parser(
             ws=self.workspace,
-            fixdater=fixdater,
             logger=self.logger,
         )
 

--- a/src/vunnel/providers/bitnami/parser.py
+++ b/src/vunnel/providers/bitnami/parser.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 
+from vunnel.tool import fixdate
 from vunnel.utils import osv
 
 from .git import GitWrapper
@@ -13,7 +14,6 @@ from .git import GitWrapper
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from vunnel.tool import fixdate
     from vunnel.workspace import Workspace
 
 
@@ -30,6 +30,8 @@ class Parser:
         fixdater: fixdate.Finder | None = None,
         logger: logging.Logger | None = None,
     ):
+        if not fixdater:
+            fixdater = fixdate.default_finder(ws)
         self.fixdater = fixdater
         self.workspace = ws
         self.git_url = self._git_src_url_
@@ -72,8 +74,7 @@ class Parser:
         self.git_wrapper.delete_repo()
         self.git_wrapper.clone_repo()
 
-        if self.fixdater:
-            self.fixdater.download()
+        self.fixdater.download()
 
         # Load the data from the git repository
         for vuln_entry in self._load():

--- a/src/vunnel/providers/chainguard/__init__.py
+++ b/src/vunnel/providers/chainguard/__init__.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
 from vunnel.providers.wolfi.parser import Parser
-from vunnel.tool import fixdate
 
 if TYPE_CHECKING:
     import datetime
@@ -20,7 +19,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -39,13 +37,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             url=self._url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,

--- a/src/vunnel/providers/chainguard/__init__.py
+++ b/src/vunnel/providers/chainguard/__init__.py
@@ -20,7 +20,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -40,7 +40,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/debian/__init__.py
+++ b/src/vunnel/providers/debian/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from vunnel import provider, result, schema
+from vunnel.tool import fixdate
 
 from .parser import Parser, debian_distro_map
 
@@ -21,6 +22,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
+    add_fix_dates: bool = True
     request_timeout: int = 125
 
     def __post_init__(self) -> None:
@@ -39,8 +41,13 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
+        fixdater = None
+        if config.add_fix_dates:
+            fixdater = fixdate.default_finder(self.workspace, self.name())
+
         self.parser = Parser(
             workspace=self.workspace,
+            fixdater=fixdater,
             download_timeout=self.config.request_timeout,
             distro_map=self.config.releases,
             logger=self.logger,

--- a/src/vunnel/providers/debian/__init__.py
+++ b/src/vunnel/providers/debian/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser, debian_distro_map
 
@@ -22,7 +21,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
     def __post_init__(self) -> None:
@@ -41,13 +39,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             download_timeout=self.config.request_timeout,
             distro_map=self.config.releases,
             logger=self.logger,

--- a/src/vunnel/providers/debian/__init__.py
+++ b/src/vunnel/providers/debian/__init__.py
@@ -22,7 +22,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
     def __post_init__(self) -> None:
@@ -42,7 +42,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/debian/parser.py
+++ b/src/vunnel/providers/debian/parser.py
@@ -446,7 +446,7 @@ class Parser:
                                             kind="advisory",
                                             accurate=True,
                                         ),
-                                    ]
+                                    ],
                                 )
                                 if result:
                                     fixed_el["Available"] = {

--- a/src/vunnel/providers/debian/parser.py
+++ b/src/vunnel/providers/debian/parser.py
@@ -6,13 +6,16 @@ import logging
 import os
 import re
 from collections import namedtuple
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import orjson
 
 from vunnel.result import SQLiteReader
 from vunnel.utils import date, vulnerability
 from vunnel.utils import http_wrapper as http
+
+if TYPE_CHECKING:
+    from vunnel.tool import fixdate
 
 DSAFixedInTuple = namedtuple("DSAFixedInTuple", ["dsa", "link", "distro", "pkg", "ver", "date"])
 DSACollection = namedtuple("DSACollection", ["cves", "nocves"])
@@ -47,8 +50,9 @@ class Parser:
     _fixed_in_note_regex_ = re.compile(r"^\s+NOTE:\s+\[(.*)\][-\s]+([^\s]*)(.*)")
     _base_dsa_id_regex_ = re.compile(r"(DSA-[^-]+).*")
 
-    def __init__(self, workspace, download_timeout=125, logger=None, distro_map=None):
+    def __init__(self, workspace, download_timeout=125, logger=None, distro_map=None, fixdater: fixdate.Finder | None = None):
         self.workspace = workspace
+        self.fixdater = fixdater
         self.download_timeout = download_timeout
         if not distro_map:
             distro_map = debian_distro_map
@@ -318,6 +322,8 @@ class Parser:
                         if distro_record.get("status", "") == "undetermined":
                             complete = False
 
+                        ecosystem = "debian:" + str(relno)
+
                         if complete:
                             if vid not in vuln_records[relno]:
                                 # create a new record
@@ -327,7 +333,7 @@ class Parser:
                                 # populate the static information about the new vuln record
                                 vuln_record["Vulnerability"]["Description"] = vulnerability_data.get("description", "")
                                 vuln_record["Vulnerability"]["Name"] = str(vid)
-                                vuln_record["Vulnerability"]["NamespaceName"] = "debian:" + str(relno)
+                                vuln_record["Vulnerability"]["NamespaceName"] = ecosystem
                                 vuln_record["Vulnerability"]["Link"] = "https://security-tracker.debian.org/tracker/" + str(vid)
                                 vuln_record["Vulnerability"]["Severity"] = "Unknown"
                             else:
@@ -422,11 +428,35 @@ class Parser:
                                     adv_mets[met_ns][met_sev]["neither"]["notfixed" if fixed_el["Version"] == "None" else "fixed"] += 1
 
                                 # add Available object if fix version exists and DSA date is available
-                                if fixed_el["Version"] != "None" and matched_dsas:
-                                    # get the date from the first matched DSA (all should have same date for same advisory)
-                                    dsa_date = date.normalize_date(matched_dsas[0].date)
-                                    if dsa_date:
-                                        fixed_el["Available"] = {"Date": dsa_date, "Kind": "advisory"}
+                                if fixed_el["Version"] != "None":
+                                    found_date = False
+                                    if matched_dsas:
+                                        # get the date from the first matched DSA (all should have same date for same advisory)
+                                        dsa_date = date.normalize_date(matched_dsas[0].date)
+                                        if dsa_date:
+                                            fixed_el["Available"] = {
+                                                "Date": dsa_date,
+                                                "Kind": "advisory",
+                                            }
+                                            found_date = True
+
+                                    # getting the date information from the DSA is preferred, but is not reliable;
+                                    # we should fallback to other methods in these cases.
+                                    if not found_date and self.fixdater:
+                                        dates = self.fixdater.find(
+                                            vuln_id=str(vid),
+                                            cpe_or_package=pkg,
+                                            fix_version=fixed_el["Version"],
+                                            ecosystem=ecosystem,
+                                        )
+                                        if dates:
+                                            result = dates[0]
+                                            available = {
+                                                "Date": result.date.isoformat(),
+                                                "Kind": result.kind,
+                                            }
+
+                                            fixed_el["Available"] = available
 
                                 # append fixed in record to vulnerability
                                 vuln_record["Vulnerability"]["FixedIn"].append(fixed_el)
@@ -457,7 +487,8 @@ class Parser:
         for relno, vuln_dict in fs_legacy_records.items():
             if relno not in legacy_records:
                 legacy_records[relno] = {}
-            legacy_records[relno].update(vuln_dict)
+            for vid, vuln_record in vuln_dict.items():
+                legacy_records[relno][vid] = self._patch_fix_date(vuln_record)
 
         if legacy_records:
             self.logger.info(f"found existing legacy data for the following releases: {list(legacy_records.keys())}")
@@ -465,6 +496,37 @@ class Parser:
             self.logger.info("no existing legacy data found")
 
         return legacy_records
+
+    def _patch_fix_date(self, vuln_record: dict[str, Any]) -> dict[str, Any]:
+        if not self.fixdater:
+            return vuln_record
+
+        vid = vuln_record.get("Vulnerability", {}).get("Name", "")
+        if not vid:
+            return vuln_record
+
+        fixed_in_list = vuln_record.get("Vulnerability", {}).get("FixedIn", [])
+        for fixedin in fixed_in_list:
+            if "Available" in fixedin and "Date" in fixedin["Available"]:
+                continue
+            if "Version" not in fixedin or fixedin["Version"] in ("None", "0"):
+                continue
+
+            dates = self.fixdater.find(
+                vuln_id=vid,
+                cpe_or_package=fixedin.get("Name", ""),
+                fix_version=fixedin["Version"],
+                ecosystem=fixedin.get("NamespaceName", "").lower(),
+            )
+            if dates:
+                result = dates[0]
+                available = {
+                    "Date": result.date.isoformat(),
+                    "Kind": result.kind,
+                }
+
+                fixedin["Available"] = available
+        return vuln_record
 
     def _get_legacy_records_from_results_db(self) -> dict[str, dict[str, Any]]:
         legacy_records = {}
@@ -484,7 +546,7 @@ class Parser:
                         legacy_records[relno] = {}
 
                     records += 1
-                    legacy_records[relno][vid] = envelope.item
+                    legacy_records[relno][vid] = self._patch_fix_date(envelope.item)
 
             self.logger.debug(f"legacy dataset {file_path} contains {len(releases)} releases with {records} records")
 
@@ -531,6 +593,9 @@ class Parser:
         # download the files
         self._download_json()
         self._download_dsa()
+
+        if self.fixdater:
+            self.fixdater.download()
 
         # normalize dsa list first
         ns_cve_dsalist = self._normalize_dsa_list()

--- a/src/vunnel/providers/echo/__init__.py
+++ b/src/vunnel/providers/echo/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -21,7 +20,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -40,13 +38,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             url=self._url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,

--- a/src/vunnel/providers/echo/__init__.py
+++ b/src/vunnel/providers/echo/__init__.py
@@ -21,7 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -41,7 +41,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/echo/parser.py
+++ b/src/vunnel/providers/echo/parser.py
@@ -108,7 +108,7 @@ class Parser:
                     # we might be able to use the date on the aports commit that added the fix.
                     # candidates=[],
                 )
-                if result:
+                if result and result.date:
                     fixed_in["Available"] = {
                         "Date": result.date.isoformat(),
                         "Kind": result.kind,

--- a/src/vunnel/providers/echo/parser.py
+++ b/src/vunnel/providers/echo/parser.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 
+from vunnel.tool import fixdate
 from vunnel.utils import http_wrapper as http
 from vunnel.utils import vulnerability
 
@@ -15,7 +16,6 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from vunnel import workspace
-    from vunnel.tool import fixdate
 
 
 class Parser:
@@ -32,6 +32,8 @@ class Parser:
         download_timeout: int = 125,
         logger: logging.Logger | None = None,
     ):
+        if not fixdater:
+            fixdater = fixdate.default_finder(workspace)
         self.fixdater = fixdater
         self.download_timeout = download_timeout
         self.advisories_dir_path = Path(workspace.input_path) / self._advisories_dir
@@ -50,8 +52,7 @@ class Parser:
         if not os.path.exists(self.advisories_dir_path):
             os.makedirs(self.advisories_dir_path, exist_ok=True)
 
-        if self.fixdater:
-            self.fixdater.download()
+        self.fixdater.download()
 
         try:
             self.logger.info(f"downloading {self.namespace} advisories {self.url}")
@@ -98,23 +99,20 @@ class Parser:
                     "NamespaceName": ecosystem,
                 }
 
-                available = None
-                if fix_version and self.fixdater:
-                    dates = self.fixdater.find(
-                        vuln_id=cve_id,
-                        cpe_or_package=package,
-                        fix_version=fix_version,
-                        ecosystem=ecosystem,
-                    )
-                    if dates:
-                        result = dates[0]
-                        available = {
-                            "Date": result.date.isoformat(),
-                            "Kind": result.kind,
-                        }
-
-                if available:
-                    fixed_in["Available"] = available
+                result = self.fixdater.best(
+                    vuln_id=cve_id,
+                    cpe_or_package=package,
+                    fix_version=fix_version,
+                    ecosystem=ecosystem,
+                    # as of today, there isn't any good candidate for a fix date. In the future
+                    # we might be able to use the date on the aports commit that added the fix.
+                    # candidates=[],
+                )
+                if result:
+                    fixed_in["Available"] = {
+                        "Date": result.date.isoformat(),
+                        "Kind": result.kind,
+                    }
 
                 cve_record["Vulnerability"]["FixedIn"].append(fixed_in)  # type: ignore[union-attr]
 

--- a/src/vunnel/providers/github/__init__.py
+++ b/src/vunnel/providers/github/__init__.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -25,7 +24,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
     def __post_init__(self) -> None:
@@ -53,13 +51,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             token=config.token,
             api_url=config.api_url,
             download_timeout=config.request_timeout,

--- a/src/vunnel/providers/github/__init__.py
+++ b/src/vunnel/providers/github/__init__.py
@@ -25,7 +25,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
     def __post_init__(self) -> None:
@@ -54,7 +54,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/minimos/__init__.py
+++ b/src/vunnel/providers/minimos/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -21,7 +20,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -40,13 +38,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             url=self._url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,

--- a/src/vunnel/providers/minimos/__init__.py
+++ b/src/vunnel/providers/minimos/__init__.py
@@ -21,7 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -41,7 +41,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/minimos/parser.py
+++ b/src/vunnel/providers/minimos/parser.py
@@ -143,7 +143,7 @@ class Parser:
                         fix_version=fix_version,
                         ecosystem=ecosystem,
                     )
-                    if result:
+                    if result and result.date:
                         fixed_el["Available"] = {
                             "Date": result.date.isoformat(),
                             "Kind": result.kind,

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Optional
 
 from vunnel import provider, result, schema
 from vunnel.providers.nvd.manager import Manager
-from vunnel.tool import fixdate
 
 if TYPE_CHECKING:
     import datetime
@@ -20,7 +19,6 @@ class Config:
             existing_results=result.ResultStatePolicy.KEEP,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
     request_retry_count: int = 10
     api_key: Optional[str] = "env:NVD_API_KEY"  # noqa: UP007
@@ -69,14 +67,9 @@ class Provider(provider.Provider):
                 "if 'overrides_enabled' is set then 'overrides_url' must be set",
             )
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.manager = Manager(
             workspace=self.workspace,
             schema=self.__schema__,
-            fixdater=fixdater,
             download_timeout=self.config.request_timeout,
             download_retry_count=self.config.request_retry_count,
             api_key=self.config.api_key,

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -20,7 +20,7 @@ class Config:
             existing_results=result.ResultStatePolicy.KEEP,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
     request_retry_count: int = 10
     api_key: Optional[str] = "env:NVD_API_KEY"  # noqa: UP007
@@ -70,7 +70,7 @@ class Provider(provider.Provider):
             )
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.manager = Manager(

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -83,7 +83,7 @@ class Manager:
         changed_cve_ids = set()
         if self.fixdater and last_updated:
             changed_vuln_ids = self.fixdater.get_changed_vuln_ids_since(last_updated)
-            changed_cve_ids = {id_to_cve(vid) for vid in changed_vuln_ids}
+            changed_cve_ids = set(changed_vuln_ids)
 
         # main NVD data download and processing
         cves_processed = set()

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -200,7 +200,7 @@ class Manager:
         """
         override = self.overrides.cve(cve_id)
         if override:
-            self.logger.debug(f"applying override for {cve_id}")
+            self.logger.trace(f"applying override for {cve_id}")  # type: ignore[attr-defined]
             # ignore empty overrides
             if override is None or "cve" not in override:
                 return record

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -8,12 +8,12 @@ from typing import TYPE_CHECKING, Any
 from vunnel import result
 from vunnel.providers.nvd.api import NvdAPI
 from vunnel.providers.nvd.overrides import NVDOverrides
+from vunnel.tool import fixdate
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
     from vunnel import schema as schema_def
-    from vunnel.tool import fixdate
     from vunnel.workspace import Workspace
 
 
@@ -33,6 +33,9 @@ class Manager:
         overrides_enabled: bool = False,
     ) -> None:
         self.workspace = workspace
+
+        if not fixdater:
+            fixdater = fixdate.default_finder(workspace)
         self.fixdater = fixdater
 
         if not logger:
@@ -76,12 +79,12 @@ class Manager:
         # download dependencies
         if self.overrides.enabled:
             self.overrides.download()
-        if self.fixdater:
-            self.fixdater.download()
+
+        self.fixdater.download()
 
         # track CVEs with changed fix dates that need reprocessing
         changed_cve_ids = set()
-        if self.fixdater and last_updated:
+        if last_updated:
             changed_vuln_ids = self.fixdater.get_changed_vuln_ids_since(last_updated)
             changed_cve_ids = set(changed_vuln_ids)
 
@@ -253,16 +256,14 @@ class Manager:
 
                     # look up fix dates for this CPE and CVE
                     # get the underlying FixDate objects with version info
-                    fix_dates = self.fixdater.find(
+                    fix_date = self.fixdater.best(
                         vuln_id=cve_id,
                         cpe_or_package=criteria,
                         fix_version=fix_version,
                         ecosystem=None,  # nvd has no ecosystem
                     )
 
-                    if fix_dates:
-                        # use the first result (could be enhanced to pick best match)
-                        fix_date = fix_dates[0]
+                    if fix_date:
                         cpe_match["fix"] = {
                             "version": fix_date.version or "",
                             "date": fix_date.date.isoformat(),

--- a/src/vunnel/providers/nvd/manager.py
+++ b/src/vunnel/providers/nvd/manager.py
@@ -263,7 +263,7 @@ class Manager:
                         ecosystem=None,  # nvd has no ecosystem
                     )
 
-                    if fix_date:
+                    if fix_date and fix_date.date:
                         cpe_match["fix"] = {
                             "version": fix_date.version or "",
                             "date": fix_date.date.isoformat(),

--- a/src/vunnel/providers/oracle/__init__.py
+++ b/src/vunnel/providers/oracle/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser, ol_config
 
@@ -21,7 +20,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -37,13 +35,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             config=ol_config,
             download_timeout=self.config.request_timeout,
             logger=self.logger,

--- a/src/vunnel/providers/oracle/__init__.py
+++ b/src/vunnel/providers/oracle/__init__.py
@@ -21,7 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -38,7 +38,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/oracle/parser.py
+++ b/src/vunnel/providers/oracle/parser.py
@@ -4,10 +4,16 @@ import bz2
 import logging
 import os
 import re
+from typing import TYPE_CHECKING, Any
 
 from vunnel.utils import http_wrapper as http
 from vunnel.utils import rpm
 from vunnel.utils.oval_parser import Config, parse
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from vunnel.tool import fixdate
 
 # One time initialization of driver specific configuration
 ol_config = Config()
@@ -50,7 +56,8 @@ class Parser:
     _url_ = "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
     _xml_file_ = "com.oracle.elsa-all.xml"
 
-    def __init__(self, workspace, config=None, download_timeout=125, logger=None):
+    def __init__(self, workspace, config=None, download_timeout=125, logger=None, fixdater: fixdate.Finder | None = None):
+        self.fixdater = fixdater
         self.config = config if config else ol_config
         self.download_timeout = download_timeout
         self.xml_file_path = os.path.join(workspace.input_path, self._xml_file_)
@@ -64,6 +71,9 @@ class Parser:
         return [self._url_]
 
     def _download(self):
+        if self.fixdater:
+            self.fixdater.download()
+
         try:
             self.logger.info(f"downloading ELSA from {self._url_}")
             r = http.get(self._url_, self.logger, stream=True, timeout=self.download_timeout)
@@ -91,10 +101,42 @@ class Parser:
         filterer = KspliceFilterer(logger=self.logger)
         return filterer.filter(raw_results)
 
-    def get(self):
+    def get(self) -> Generator[tuple[tuple[str, str], tuple[str, dict[str, Any]]], None, None]:
         # download
         self._download()
-        return self._parse_oval_data(self.xml_file_path, self.config)
+        for (vuln_id, namespace), (version, record) in self._parse_oval_data(self.xml_file_path, self.config).items():
+            yield (vuln_id, namespace), (version, self._patch_fix_date(record))
+
+    def _patch_fix_date(self, vuln_record: dict[str, Any]) -> dict[str, Any]:
+        if not self.fixdater:
+            return vuln_record
+
+        vid = vuln_record.get("Vulnerability", {}).get("Name", "")
+        if not vid:
+            return vuln_record
+
+        fixed_in_list = vuln_record.get("Vulnerability", {}).get("FixedIn", [])
+        for fixedin in fixed_in_list:
+            if "Available" in fixedin and "Date" in fixedin["Available"]:
+                continue
+            if "Version" not in fixedin or fixedin["Version"] in ("None", "0"):
+                continue
+
+            dates = self.fixdater.find(
+                vuln_id=vid,
+                cpe_or_package=fixedin.get("Name", ""),
+                fix_version=fixedin["Version"],
+                ecosystem=fixedin.get("NamespaceName", "").lower(),
+            )
+            if dates:
+                result = dates[0]
+                available = {
+                    "Date": result.date.isoformat(),
+                    "Kind": result.kind,
+                }
+
+                fixedin["Available"] = available
+        return vuln_record
 
 
 class KspliceFilterer:

--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -21,7 +20,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
     parallelism: int = 4
     full_sync_interval: int = 2  # in days
@@ -42,13 +40,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             download_timeout=self.config.request_timeout,
             max_workers=self.config.parallelism,
             full_sync_interval=self.config.full_sync_interval,

--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -21,7 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
     parallelism: int = 4
     full_sync_interval: int = 2  # in days
@@ -43,7 +43,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/rocky/__init__.py
+++ b/src/vunnel/providers/rocky/__init__.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -20,7 +19,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -36,14 +34,9 @@ class Provider(provider.Provider):
         self.config = config
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.schema = self.__schema__
         self.parser = Parser(
             ws=self.workspace,
-            fixdater=fixdater,
             logger=self.logger,
             skip_download=config.runtime.skip_download,
         )

--- a/src/vunnel/providers/rocky/__init__.py
+++ b/src/vunnel/providers/rocky/__init__.py
@@ -20,7 +20,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -37,7 +37,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.schema = self.__schema__

--- a/src/vunnel/providers/rocky/client.py
+++ b/src/vunnel/providers/rocky/client.py
@@ -15,7 +15,7 @@ class Client:
     def __init__(  # noqa: PLR0913
         self,
         download_path: str,
-        fixdater: fixdate.Finder | None = None,
+        fixdater: fixdate.Finder,
         logger: logging.Logger | None = None,
         rocky_versions: list[str] | None = None,
         api_host: str = "https://apollo.build.resf.org",
@@ -34,8 +34,7 @@ class Client:
         self._skip_download = skip_download
 
     def _download(self) -> None:
-        if self.fixdater:
-            self.fixdater.download()
+        self.fixdater.download()
 
         next_page = self._default_api_path_
         while next_page:

--- a/src/vunnel/providers/rocky/parser.py
+++ b/src/vunnel/providers/rocky/parser.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 
+from vunnel.tool import fixdate
 from vunnel.utils import osv
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from vunnel.tool import fixdate
     from vunnel.workspace import Workspace
 
 from .client import Client
@@ -25,6 +25,8 @@ class Parser:
         logger: logging.Logger | None = None,
         skip_download: bool = False,
     ):
+        if not fixdater:
+            fixdater = fixdate.default_finder(ws)
         self.fixdater = fixdater
         self.workspace = ws
         if not logger:

--- a/src/vunnel/providers/sles/__init__.py
+++ b/src/vunnel/providers/sles/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -21,7 +20,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
+    add_fix_dates: bool = True
     request_timeout: int = 125
     allow_versions: list[Any] = field(default_factory=lambda: [11, 12, 15])  # corresponds to major versions
 
@@ -42,13 +41,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             allow_versions=self.config.allow_versions,
             download_timeout=self.config.request_timeout,
             logger=self.logger,

--- a/src/vunnel/providers/sles/__init__.py
+++ b/src/vunnel/providers/sles/__init__.py
@@ -20,7 +20,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
     request_timeout: int = 125
     allow_versions: list[Any] = field(default_factory=lambda: [11, 12, 15])  # corresponds to major versions
 

--- a/src/vunnel/providers/sles/__init__.py
+++ b/src/vunnel/providers/sles/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from vunnel import provider, result, schema
+from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -20,6 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
     allow_versions: list[Any] = field(default_factory=lambda: [11, 12, 15])  # corresponds to major versions
 
@@ -40,8 +42,13 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
+        fixdater = None
+        if config.add_first_observed_fix_dates:
+            fixdater = fixdate.default_finder(self.workspace, self.name())
+
         self.parser = Parser(
             workspace=self.workspace,
+            fixdater=fixdater,
             allow_versions=self.config.allow_versions,
             download_timeout=self.config.request_timeout,
             logger=self.logger,

--- a/src/vunnel/providers/ubuntu/__init__.py
+++ b/src/vunnel/providers/ubuntu/__init__.py
@@ -21,7 +21,7 @@ class Config:
             existing_input=provider.InputStatePolicy.KEEP,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
     additional_versions: dict[str, str] = field(default_factory=dict)
     enable_rev_history: bool = True
@@ -46,7 +46,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/ubuntu/__init__.py
+++ b/src/vunnel/providers/ubuntu/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser, default_git_branch, default_git_url, default_max_workers
 
@@ -21,7 +20,6 @@ class Config:
             existing_input=provider.InputStatePolicy.KEEP,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
     additional_versions: dict[str, str] = field(default_factory=dict)
     enable_rev_history: bool = True
@@ -45,13 +43,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             logger=self.logger,
             additional_versions=self.config.additional_versions,
             enable_rev_history=self.config.enable_rev_history,

--- a/src/vunnel/providers/wolfi/__init__.py
+++ b/src/vunnel/providers/wolfi/__init__.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from vunnel import provider, result, schema
-from vunnel.tool import fixdate
 
 from .parser import Parser
 
@@ -21,7 +20,6 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -40,13 +38,8 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        fixdater = None
-        if config.add_first_observed_fix_dates:
-            fixdater = fixdate.default_finder(self.workspace, self.name())
-
         self.parser = Parser(
             workspace=self.workspace,
-            fixdater=fixdater,
             url=self._url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,

--- a/src/vunnel/providers/wolfi/__init__.py
+++ b/src/vunnel/providers/wolfi/__init__.py
@@ -21,7 +21,7 @@ class Config:
             existing_results=result.ResultStatePolicy.DELETE_BEFORE_WRITE,
         ),
     )
-    add_fix_dates: bool = True
+    add_first_observed_fix_dates: bool = True
     request_timeout: int = 125
 
 
@@ -41,7 +41,7 @@ class Provider(provider.Provider):
         self.logger.debug(f"config: {config}")
 
         fixdater = None
-        if config.add_fix_dates:
+        if config.add_first_observed_fix_dates:
             fixdater = fixdate.default_finder(self.workspace, self.name())
 
         self.parser = Parser(

--- a/src/vunnel/providers/wolfi/parser.py
+++ b/src/vunnel/providers/wolfi/parser.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 import copy
 import logging
 import os
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import orjson
 
+from vunnel.tool import fixdate
 from vunnel.utils import http_wrapper as http
 from vunnel.utils import vulnerability
-
-if TYPE_CHECKING:
-    from vunnel.tool import fixdate
 
 
 class Parser:
@@ -30,6 +27,8 @@ class Parser:
         logger: logging.Logger | None = None,
         security_reference_url: str | None = None,
     ):
+        if not fixdater:
+            fixdater = fixdate.default_finder(workspace)
         self.fixdater = fixdater
         self.download_timeout = download_timeout
         self.secdb_dir_path = os.path.join(workspace.input_path, self._secdb_dir_)
@@ -61,8 +60,7 @@ class Parser:
         if not os.path.exists(self.secdb_dir_path):
             os.makedirs(self.secdb_dir_path, exist_ok=True)
 
-        if self.fixdater:
-            self.fixdater.download()
+        self.fixdater.download()
 
         try:
             self.logger.info(f"downloading {self.namespace} secdb {self.url}")
@@ -79,8 +77,6 @@ class Parser:
         Loads all db json and yields it
         :return:
         """
-        dbtype_data_dict = {}
-
         # parse and transform the json
         try:
             with open(f"{self.secdb_dir_path}/{self._db_filename}") as fh:
@@ -144,21 +140,20 @@ class Parser:
                         "NamespaceName": ecosystem,
                     }
 
-                    if fix_version and self.fixdater:
-                        dates = self.fixdater.find(
-                            vuln_id=str(vid),
-                            cpe_or_package=pkg,
-                            fix_version=fix_version,
-                            ecosystem=ecosystem,
-                        )
-                        if dates:
-                            result = dates[0]
-                            available = {
-                                "Date": result.date.isoformat(),
-                                "Kind": result.kind,
-                            }
-
-                            fixed_el["Available"] = available
+                    result = self.fixdater.best(
+                        vuln_id=str(vid),
+                        cpe_or_package=pkg,
+                        fix_version=fix_version,
+                        ecosystem=ecosystem,
+                        # as of today, there isn't any good candidate for a fix date. In the future
+                        # we might be able to use the date on the aports commit that added the fix.
+                        # candidates=[],
+                    )
+                    if result:
+                        fixed_el["Available"] = {
+                            "Date": result.date.isoformat(),
+                            "Kind": result.kind,
+                        }
 
                     vuln_record["Vulnerability"]["FixedIn"].append(fixed_el)
 

--- a/src/vunnel/tool/fixdate/__init__.py
+++ b/src/vunnel/tool/fixdate/__init__.py
@@ -1,12 +1,12 @@
 from vunnel import workspace
 
 from . import first_observed
-from .finder import Finder
+from .finder import Finder, Result
 
-__all__ = ["Finder", "default_finder"]
+__all__ = ["Finder", "Result", "default_finder"]
 
 
-def default_finder(ws: workspace.Workspace, name: str) -> Finder:
+def default_finder(ws: workspace.Workspace) -> Finder:
     # TODO: we can add others as we implement them
 
-    return first_observed.Store(ws, name)
+    return Finder(strategies=[], first_observed=first_observed.Store(ws))

--- a/src/vunnel/tool/fixdate/finder.py
+++ b/src/vunnel/tool/fixdate/finder.py
@@ -7,6 +7,26 @@ from vunnel.utils import date
 
 logger = logging.getLogger(__name__)
 
+# mapping from GHSA ecosystems (or similar candidates) to syft package types
+ecosystem_mapping = {
+    "composer": "php-composer",
+    "php": "php-composer",
+    "rust": "rust-crate",
+    "cargo": "rust-crate",
+    "dart": "dart-pub",
+    "nuget": "dotnet",
+    ".net": "dotnet",
+    "go": "go-module",
+    "golang": "go-module",
+    "maven": "java-archive",
+    "java": "java-archive",
+    "javascript": "npm",
+    "pypi": "python",
+    "pip": "python",
+    "rubygems": "gem",
+    "ruby": "gem",
+}
+
 
 @dataclass
 class Result:
@@ -62,6 +82,14 @@ class Finder:
         self.first_observed.download()
         for s in self.strategies:
             s.download()
+
+    def _normalize_ecosystem(self, ecosystem: str | None) -> str | None:
+        if not ecosystem:
+            return ecosystem
+
+        ecosystem = ecosystem.lower()
+
+        return ecosystem_mapping.get(ecosystem, ecosystem)
 
     def best(
         self,

--- a/src/vunnel/tool/fixdate/finder.py
+++ b/src/vunnel/tool/fixdate/finder.py
@@ -1,20 +1,37 @@
 import abc
 import datetime
+import logging
 from dataclasses import dataclass
+
+from vunnel.utils import date
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class Result:
-    date: datetime.date
+    date: datetime.date | None
     kind: str
     version: str | None = None
+    accurate: bool | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.date, datetime.datetime):
+            self.date = self.date.date()
+        elif isinstance(self.date, str):
+            try:
+                self.date = datetime.date.fromisoformat(date.normalize_date(self.date))
+            except Exception:
+                # shouldn't happen due to date normalization, but just in case
+                logger.warning(f"failed to parse fixdater date candidate string '{self.date}', ignoring candidate")
+                self.date = None
 
 
-class Finder(abc.ABC):
+class Strategy(abc.ABC):
     @abc.abstractmethod
     def download(self) -> None:
         raise NotImplementedError(
-            "Finder subclasses must implement the download method to fetch data.",
+            "Strategy subclasses must implement the download method to fetch data.",
         )
 
     @abc.abstractmethod
@@ -36,28 +53,81 @@ class Finder(abc.ABC):
         )
 
 
-class CombinedFinder(Finder):
-    def __init__(self, finders: list[Finder]):
-        self.finders = finders
+class Finder:
+    def __init__(self, strategies: list[Strategy], first_observed: Strategy):
+        self.strategies = strategies
+        self.first_observed = first_observed
 
     def download(self) -> None:
-        for finder in self.finders:
-            finder.download()
+        self.first_observed.download()
+        for s in self.strategies:
+            s.download()
 
-    def find(
+    def best(
         self,
         vuln_id: str,
         cpe_or_package: str,
         fix_version: str | None,
         ecosystem: str | None = None,
-    ) -> list[Result]:
+        candidates: list[Result] | None = None,
+    ) -> Result | None:
         results = []
-        for finder in self.finders:
-            results.extend(finder.find(vuln_id, cpe_or_package, fix_version, ecosystem))
-        return results
+
+        if not fix_version or fix_version in ("None", "0"):
+            # if we don't have a fix version, we can't determine a fix date
+            return None
+
+        # add high quality candidates first
+        if candidates:
+            results.extend([c for c in candidates if c.accurate and c.date])
+
+        # add results from finders in order of priority (set by the constructor)
+        for s in self.strategies:
+            results.extend(s.find(vuln_id, cpe_or_package, fix_version, ecosystem))
+
+        # add low quality candidates last
+        if candidates:
+            results.extend([c for c in candidates if not c.accurate and c.date])
+
+        first_observed_results = self.first_observed.find(vuln_id, cpe_or_package, fix_version, ecosystem)
+
+        # we should select the date from the set of finders that is the highest quality (earlier in the s
+        # results list) but should never be after the first observed date. However, first observed dates are not always
+        # accurate, so we should only enforce this if we have an accurate first observed date (not part of the
+        # first group of observed fixes).
+        #
+        # ...If the first observed date is accurate, then follow these rules:
+        # - If a s date is after the first observed date, we should discard it.
+        # - If no s candidates are before the first observed date, we should return the first observed dates.
+        # - If there is no first observed dates, we should return the best s candidates we have.
+
+        accurate_first_observed = [r for r in first_observed_results if r.accurate]
+
+        if accurate_first_observed:
+            # select the best first observed date as a point of reference
+            first_accurate_observed_date = accurate_first_observed[0].date
+
+            if first_accurate_observed_date is not None:
+                filtered_results = [r for r in results if r.date is not None and r.date <= first_accurate_observed_date]
+            else:
+                filtered_results = []
+            if filtered_results:
+                # return the best/first valid candidates relative to the best first observed date
+                return filtered_results[0]
+            # return the first observed date instead of any other candidate
+            return accurate_first_observed[0]
+
+        # ... If we don't have an accurate first observed date, then treat that as a last resort option
+        results.extend(first_observed_results)
+
+        if results:
+            # return the best/first candidate we have
+            return results[0]
+
+        return None
 
     def get_changed_vuln_ids_since(self, since_date: datetime.datetime) -> set[str]:
         changed_ids = set()
-        for finder in self.finders:
-            changed_ids.update(finder.get_changed_vuln_ids_since(since_date))
+        for s in self.strategies:
+            changed_ids.update(s.get_changed_vuln_ids_since(since_date))
         return changed_ids

--- a/src/vunnel/tool/fixdate/first_observed.py
+++ b/src/vunnel/tool/fixdate/first_observed.py
@@ -251,12 +251,12 @@ class Store(Finder):
                 if hasattr(self._thread_local, "table"):
                     delattr(self._thread_local, "table")
 
-    def __enter__(self):
+    def __enter__(self) -> "Store":
         """context manager entry - ensure connection is ready"""
         self._get_connection()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[no-untyped-def]
         """context manager exit - cleanup thread connections"""
         self.cleanup_thread_connections()
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -99,7 +99,6 @@ def test_run(mocker, monkeypatch) -> None:
             "./data",
             # note: this is the default config
             config=nvd.Config(
-                add_first_observed_fix_dates=True,
                 runtime=provider.RuntimeConfig(
                     on_error=provider.OnErrorConfig(
                         action=provider.OnErrorAction.FAIL,
@@ -178,7 +177,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   alpine:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -218,7 +216,6 @@ providers:
       '2022': https://alas.aws.amazon.com/AL2022/alas.rss
       '2023': https://alas.aws.amazon.com/AL2023/alas.rss
   bitnami:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -236,7 +233,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   chainguard:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -260,7 +256,6 @@ providers:
       path: providers/{provider_name}/listing.json
       skip_newer_archive_check: false
   debian:
-    add_first_observed_fix_dates: true
     releases:
       bookworm: '12'
       bullseye: '11'
@@ -289,7 +284,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   echo:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -326,7 +320,6 @@ providers:
       skip_newer_archive_check: false
     url_template: https://epss.cyentia.com/epss_scores-{}.csv.gz
   github:
-    add_first_observed_fix_dates: true
     api_url: https://api.github.com/graphql
     request_timeout: 125
     runtime:
@@ -385,7 +378,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   minimos:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -403,7 +395,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   nvd:
-    add_first_observed_fix_dates: true
     api_key: secret
     overrides_enabled: false
     overrides_url: https://github.com/anchore/nvd-data-overrides/archive/refs/heads/main.tar.gz
@@ -425,7 +416,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   oracle:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -443,7 +433,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   rhel:
-    add_first_observed_fix_dates: true
     full_sync_interval: 2
     ignore_hydra_errors: false
     parallelism: 4
@@ -468,7 +457,6 @@ providers:
       - rhel:3
       - rhel:4
   rocky:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -486,7 +474,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   sles:
-    add_first_observed_fix_dates: true
     allow_versions:
       - '11'
       - '12'
@@ -508,7 +495,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   ubuntu:
-    add_first_observed_fix_dates: true
     additional_versions: {}
     enable_rev_history: true
     git_branch: master
@@ -531,7 +517,6 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   wolfi:
-    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -260,6 +260,7 @@ providers:
       path: providers/{provider_name}/listing.json
       skip_newer_archive_check: false
   debian:
+    add_fix_dates: true
     releases:
       bookworm: '12'
       bullseye: '11'
@@ -424,6 +425,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   oracle:
+    add_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -99,7 +99,7 @@ def test_run(mocker, monkeypatch) -> None:
             "./data",
             # note: this is the default config
             config=nvd.Config(
-                add_fix_dates=True,
+                add_first_observed_fix_dates=True,
                 runtime=provider.RuntimeConfig(
                     on_error=provider.OnErrorConfig(
                         action=provider.OnErrorAction.FAIL,
@@ -178,7 +178,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   alpine:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -218,7 +218,7 @@ providers:
       '2022': https://alas.aws.amazon.com/AL2022/alas.rss
       '2023': https://alas.aws.amazon.com/AL2023/alas.rss
   bitnami:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -236,7 +236,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   chainguard:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -260,7 +260,7 @@ providers:
       path: providers/{provider_name}/listing.json
       skip_newer_archive_check: false
   debian:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     releases:
       bookworm: '12'
       bullseye: '11'
@@ -289,7 +289,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   echo:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -326,7 +326,7 @@ providers:
       skip_newer_archive_check: false
     url_template: https://epss.cyentia.com/epss_scores-{}.csv.gz
   github:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     api_url: https://api.github.com/graphql
     request_timeout: 125
     runtime:
@@ -385,7 +385,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   minimos:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -403,7 +403,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   nvd:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     api_key: secret
     overrides_enabled: false
     overrides_url: https://github.com/anchore/nvd-data-overrides/archive/refs/heads/main.tar.gz
@@ -425,7 +425,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   oracle:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -443,7 +443,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   rhel:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     full_sync_interval: 2
     ignore_hydra_errors: false
     parallelism: 4
@@ -468,7 +468,7 @@ providers:
       - rhel:3
       - rhel:4
   rocky:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep
@@ -486,6 +486,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   sles:
+    add_first_observed_fix_dates: true
     allow_versions:
       - '11'
       - '12'
@@ -507,7 +508,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   ubuntu:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     additional_versions: {}
     enable_rev_history: true
     git_branch: master
@@ -530,7 +531,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
   wolfi:
-    add_fix_dates: true
+    add_first_observed_fix_dates: true
     request_timeout: 125
     runtime:
       existing_input: keep

--- a/tests/unit/providers/alpine/test_alpine.py
+++ b/tests/unit/providers/alpine/test_alpine.py
@@ -133,7 +133,7 @@ class TestAlpineProvider:
 
         assert counter == 1
 
-    def test_normalize(self, mock_parsed_data, tmpdir):
+    def test_normalize(self, mock_parsed_data, tmpdir, auto_fake_fixdate_finder):
         p = Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
         release = mock_parsed_data[0]
         dbtype_data_dict = mock_parsed_data[1]

--- a/tests/unit/providers/amazon/test_amazon.py
+++ b/tests/unit/providers/amazon/test_amazon.py
@@ -117,7 +117,7 @@ class TestParser:
         assert p.alas_403s == ["something", url, url]
 
 
-def test_provider_schema(helpers, disable_get_requests, monkeypatch):
+def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 
     c = Config()
@@ -138,7 +138,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch):
     assert workspace.result_schemas_valid(require_entries=True)
 
 
-def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch):
+def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/input",

--- a/tests/unit/providers/bitnami/test-fixtures/snapshots/bit-brotli-2020-8927.json
+++ b/tests/unit/providers/bitnami/test-fixtures/snapshots/bit-brotli-2020-8927.json
@@ -14,8 +14,8 @@
               "anchore": {
                 "fixes": [
                   {
-                    "date": "2024-01-01",
-                    "kind": "first-observed",
+                    "date": "2024-03-06",
+                    "kind": "advisory",
                     "version": "1.0.8"
                   }
                 ]

--- a/tests/unit/providers/bitnami/test-fixtures/snapshots/bit-consul-2021-37219.json
+++ b/tests/unit/providers/bitnami/test-fixtures/snapshots/bit-consul-2021-37219.json
@@ -14,18 +14,18 @@
               "anchore": {
                 "fixes": [
                   {
-                    "date": "2024-01-01",
-                    "kind": "first-observed",
+                    "date": "2024-03-06",
+                    "kind": "advisory",
                     "version": "1.8.15"
                   },
                   {
-                    "date": "2024-01-01",
-                    "kind": "first-observed",
+                    "date": "2024-03-06",
+                    "kind": "advisory",
                     "version": "1.9.9"
                   },
                   {
-                    "date": "2024-01-01",
-                    "kind": "first-observed",
+                    "date": "2024-03-06",
+                    "kind": "advisory",
                     "version": "1.10.2"
                   }
                 ]

--- a/tests/unit/providers/bitnami/test_bitnami.py
+++ b/tests/unit/providers/bitnami/test_bitnami.py
@@ -27,7 +27,7 @@ def test_provider_schema(mock_git_delete, mock_git_clone, helpers, auto_fake_fix
 
 @patch("vunnel.providers.bitnami.git.GitWrapper.clone_repo")
 @patch("vunnel.providers.bitnami.git.GitWrapper.delete_repo")
-def test_parser(mock_git_delete, mock_git_clone, helpers, disable_get_requests):
+def test_parser(mock_git_delete, mock_git_clone, helpers, disable_get_requests, auto_fake_fixdate_finder):
     mock_git_clone.return_value = None
     mock_git_delete.return_value = None
     workspace = helpers.provider_workspace_helper(name=Provider.name())

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-2728.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-2728.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "php",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-3205.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-3205.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "php",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4559.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4559.json
@@ -6,30 +6,18 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "python-3.10",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",
           "VersionFormat": "apk"
         },
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "python-3.11",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",
           "VersionFormat": "apk"
         },
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "python-3.12",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4596.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2007-4596.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "php",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2010-4756.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2010-4756.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "glibc",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2102.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2102.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "haproxy",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2781.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2016-2781.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "coreutils",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-8806.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2017-8806.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "postgresql-15",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010022.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010022.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "glibc",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010023.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010023.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "glibc",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010024.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010024.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "glibc",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010025.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-1010025.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "glibc",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6293.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2019-6293.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "flex",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29509.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29509.json
@@ -6,20 +6,12 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "go-1.19",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",
           "VersionFormat": "apk"
         },
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "go-1.20",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29511.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2020-29511.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "go-1.20",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22743.json
+++ b/tests/unit/providers/chainguard/test-fixtures/snapshots/chainguard:rolling/CVE-2023-22743.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "git",
           "NamespaceName": "chainguard:rolling",
           "Version": "0",

--- a/tests/unit/providers/chainguard/test_chainguard.py
+++ b/tests/unit/providers/chainguard/test_chainguard.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import json
-import os
 import shutil
 
-import pytest
-from vunnel import result, workspace
+from vunnel import result
 from vunnel.providers.chainguard import Config, Provider
-from vunnel.providers.wolfi import parser
 
 
 def test_provider_schema(helpers, disable_get_requests, auto_fake_fixdate_finder):

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2005-3111.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2005-3111.json
@@ -6,6 +6,10 @@
       "Description": "The handler code for backupninja 0.8 and earlier creates temporary files with predictable filenames, which allows local users to modify arbitrary files via a symlink attack.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "backupninja",
           "NamespaceName": "debian:10",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2008-7220.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2008-7220.json
@@ -6,6 +6,10 @@
       "Description": "Unspecified vulnerability in Prototype JavaScript framework (prototypejs) before 1.6.0.2 allows attackers to make \"cross-site ajax requests\" via unknown vectors.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "prototypejs",
           "NamespaceName": "debian:10",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2012-0833.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2012-0833.json
@@ -4,7 +4,22 @@
     "Vulnerability": {
       "CVSS": [],
       "Description": "The acllas__handle_group_entry function in servers/plugins/acl/acllas.c in 389 Directory Server before 1.2.10 does not properly handled access control instructions (ACIs) that use certificate groups, which allows remote authenticated LDAP users with a certificate group to cause a denial of service (infinite loop and CPU consumption) by binding to the server.",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
+          "Name": "389_directory_server",
+          "NamespaceName": "debian:10",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "1.2.1",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://security-tracker.debian.org/tracker/CVE-2012-0833",
       "Metadata": {},
       "Name": "CVE-2012-0833",

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2013-1444.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2013-1444.json
@@ -6,6 +6,10 @@
       "Description": "A certain Debian patch for txt2man 1.5.5, as used in txt2man 1.5.5-2, 1.5.5-4, and others, allows local users to overwrite arbitrary files via a symlink attack on /tmp/2222.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "txt2man",
           "NamespaceName": "debian:10",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:11/cve-2022-0456.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:11/cve-2022-0456.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "chromium",
           "NamespaceName": "debian:11",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:11/cve-2025-53603.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:11/cve-2025-53603.json
@@ -6,6 +6,10 @@
       "Description": "In Alinto SOPE SOGo 2.0.2 through 5.12.2, sope-core/NGExtensions/NGHashMap.m allows a NULL pointer dereference and SOGo crash via a request in which a parameter in the query string is a duplicate of a parameter in the POST body.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "sope",
           "NamespaceName": "debian:11",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:12/cve-2022-0456.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:12/cve-2022-0456.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "chromium",
           "NamespaceName": "debian:12",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:13/cve-2025-53603.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:13/cve-2025-53603.json
@@ -6,6 +6,10 @@
       "Description": "In Alinto SOPE SOGo 2.0.2 through 5.12.2, sope-core/NGExtensions/NGHashMap.m allows a NULL pointer dereference and SOGo crash via a request in which a parameter in the query string is a duplicate of a parameter in the POST body.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "sope",
           "NamespaceName": "debian:13",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2005-3111.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2005-3111.json
@@ -6,6 +6,10 @@
       "Description": "The handler code for backupninja 0.8 and earlier creates temporary files with predictable filenames, which allows local users to modify arbitrary files via a symlink attack.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "backupninja",
           "NamespaceName": "debian:8",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2008-7220.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2008-7220.json
@@ -6,6 +6,10 @@
       "Description": "Unspecified vulnerability in Prototype JavaScript framework (prototypejs) before 1.6.0.2 allows attackers to make \"cross-site ajax requests\" via unknown vectors.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "prototypejs",
           "NamespaceName": "debian:8",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2013-1444.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2013-1444.json
@@ -6,6 +6,10 @@
       "Description": "A certain Debian patch for txt2man 1.5.5, as used in txt2man 1.5.5-2, 1.5.5-4, and others, allows local users to overwrite arbitrary files via a symlink attack on /tmp/2222.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "txt2man",
           "NamespaceName": "debian:8",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2005-3111.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2005-3111.json
@@ -6,6 +6,10 @@
       "Description": "The handler code for backupninja 0.8 and earlier creates temporary files with predictable filenames, which allows local users to modify arbitrary files via a symlink attack.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "backupninja",
           "NamespaceName": "debian:9",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2008-7220.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2008-7220.json
@@ -6,6 +6,10 @@
       "Description": "Unspecified vulnerability in Prototype JavaScript framework (prototypejs) before 1.6.0.2 allows attackers to make \"cross-site ajax requests\" via unknown vectors.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "prototypejs",
           "NamespaceName": "debian:9",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2013-1444.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2013-1444.json
@@ -6,6 +6,10 @@
       "Description": "A certain Debian patch for txt2man 1.5.5, as used in txt2man 1.5.5-2, 1.5.5-4, and others, allows local users to overwrite arbitrary files via a symlink attack on /tmp/2222.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "txt2man",
           "NamespaceName": "debian:9",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2005-3111.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2005-3111.json
@@ -6,6 +6,10 @@
       "Description": "The handler code for backupninja 0.8 and earlier creates temporary files with predictable filenames, which allows local users to modify arbitrary files via a symlink attack.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "backupninja",
           "NamespaceName": "debian:unstable",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2008-7220.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2008-7220.json
@@ -6,6 +6,10 @@
       "Description": "Unspecified vulnerability in Prototype JavaScript framework (prototypejs) before 1.6.0.2 allows attackers to make \"cross-site ajax requests\" via unknown vectors.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "prototypejs",
           "NamespaceName": "debian:unstable",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2013-1444.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2013-1444.json
@@ -6,6 +6,10 @@
       "Description": "A certain Debian patch for txt2man 1.5.5, as used in txt2man 1.5.5-2, 1.5.5-4, and others, allows local users to overwrite arbitrary files via a symlink attack on /tmp/2222.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "txt2man",
           "NamespaceName": "debian:unstable",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2022-0456.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2022-0456.json
@@ -6,6 +6,10 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "chromium",
           "NamespaceName": "debian:unstable",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2025-53603.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2025-53603.json
@@ -6,6 +6,10 @@
       "Description": "In Alinto SOPE SOGo 2.0.2 through 5.12.2, sope-core/NGExtensions/NGHashMap.m allows a NULL pointer dereference and SOGo crash via a request in which a parameter in the query string is a duplicate of a parameter in the POST body.",
       "FixedIn": [
         {
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Name": "sope",
           "NamespaceName": "debian:unstable",
           "VendorAdvisory": {

--- a/tests/unit/providers/debian/test_debian.py
+++ b/tests/unit/providers/debian/test_debian.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from vunnel import result, workspace
 from vunnel.providers.debian import Config, Provider, parser
+from vunnel.tool import fixdate
 
 
 @pytest.fixture()
@@ -18,7 +19,18 @@ def mock_legacy_db(mocker):
             "Vulnerability": {
                 "Severity": "Negligible",
                 "NamespaceName": "debian:10",
-                "FixedIn": [],
+                "FixedIn": [
+                    {
+                        "Name": "389_directory_server",
+                        "NamespaceName": "debian:10",
+                        "VersionFormat": "dpkg",
+                        "Version": "1.2.1",
+                        "VendorAdvisory": {
+                            "NoAdvisory": False,
+                            "AdvisorySummary": []
+                        },
+                    }
+                ],
                 "Link": "https://security-tracker.debian.org/tracker/CVE-2012-0833",
                 "Description": "The acllas__handle_group_entry function in servers/plugins/acl/acllas.c in 389 Directory Server before 1.2.10 does not properly handled access control instructions (ACIs) that use certificate groups, which allows remote authenticated LDAP users with a certificate group to cause a denial of service (infinite loop and CPU consumption) by binding to the server.",
                 "Metadata": {},
@@ -107,8 +119,9 @@ class TestParser:
             assert all(x.get("Vulnerability", {}).get("Description") is not None for x in vuln_dict.values())
         assert not subject.logger.exception.called, "no exceptions should be logged"
 
-    def test_get_legacy_records(self, tmpdir, helpers, disable_get_requests, mock_legacy_db):
-        subject = parser.Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
+    def test_get_legacy_records(self, tmpdir, helpers, disable_get_requests, mock_legacy_db, auto_fake_fixdate_finder):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        subject = parser.Parser(workspace=ws, fixdater=fixdate.default_finder(ws, "debian"))
 
         mock_data_path = helpers.local_dir("test-fixtures/input")
         shutil.copytree(mock_data_path, subject.workspace.input_path, dirs_exist_ok=True)
@@ -130,6 +143,9 @@ class TestParser:
         assert "CVE-2012-0833" in legacy_records["10"].keys()
         assert len(legacy_records["10"]["CVE-2012-0833"]) > 0
 
+        # ensure the DB record has a fixed in date added by the mock fixdate finder
+        assert legacy_records["10"]["CVE-2012-0833"]["Vulnerability"]["FixedIn"][0]["Available"]["Date"] == "2024-01-01"
+
         for _rel, vuln_dict in legacy_records.items():
             assert isinstance(vuln_dict, dict)
             assert len(vuln_dict) > 0
@@ -140,7 +156,8 @@ class TestParser:
             assert all(x.get("Vulnerability", {}).get("Description") is not None for x in vuln_dict.values())
 
 
-def test_provider_schema(helpers, disable_get_requests, monkeypatch, mock_legacy_db):
+
+def test_provider_schema(helpers, disable_get_requests, monkeypatch, mock_legacy_db, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/input",
@@ -168,7 +185,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch, mock_legacy
     assert workspace.result_schemas_valid(require_entries=True)
 
 
-def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, mock_legacy_db):
+def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, mock_legacy_db, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),
         input_fixture="test-fixtures/input",

--- a/tests/unit/providers/debian/test_debian.py
+++ b/tests/unit/providers/debian/test_debian.py
@@ -94,7 +94,7 @@ class TestParser:
         # print("Number of DSAs with fixes and no CVEs: {}".format(len(no_cve_dsas)))
         assert len(no_cve_dsas) == 2
 
-    def test_normalize_json(self, tmpdir, helpers, disable_get_requests):
+    def test_normalize_json(self, tmpdir, helpers, disable_get_requests, auto_fake_fixdate_finder):
         subject = parser.Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
         subject.logger = MagicMock()
 
@@ -121,7 +121,7 @@ class TestParser:
 
     def test_get_legacy_records(self, tmpdir, helpers, disable_get_requests, mock_legacy_db, auto_fake_fixdate_finder):
         ws = workspace.Workspace(tmpdir, "test", create=True)
-        subject = parser.Parser(workspace=ws, fixdater=fixdate.default_finder(ws, "debian"))
+        subject = parser.Parser(workspace=ws)
 
         mock_data_path = helpers.local_dir("test-fixtures/input")
         shutil.copytree(mock_data_path, subject.workspace.input_path, dirs_exist_ok=True)

--- a/tests/unit/providers/echo/test_echo.py
+++ b/tests/unit/providers/echo/test_echo.py
@@ -93,7 +93,7 @@ class TestParser:
         }
         return release, data
 
-    def test_normalize(self, mock_parsed_data, tmpdir):
+    def test_normalize(self, mock_parsed_data, tmpdir, auto_fake_fixdate_finder):
         p = Parser(
             workspace=workspace.Workspace(tmpdir, "test", create=True),
             url="https://advisory.echohq.com/data.json",

--- a/tests/unit/providers/github/test_github.py
+++ b/tests/unit/providers/github/test_github.py
@@ -411,13 +411,13 @@ class TestGetNestedVulnerabilities:
 
 
 class TestParser:
-    def test_get_with_no_cursor_no_timestamp(self, fake_get_query, tmpdir, empty_response):
+    def test_get_with_no_cursor_no_timestamp(self, fake_get_query, tmpdir, empty_response, auto_fake_fixdate_finder):
         fake_get_query([empty_response])
         p = parser.Parser(workspace.Workspace(root=tmpdir.strpath, name="test", create=True), "secret")
         result = list(p.get())
         assert result == []
 
-    def test_get_commits_timestamp(self, fake_get_query, tmpdir, empty_response):
+    def test_get_commits_timestamp(self, fake_get_query, tmpdir, empty_response, auto_fake_fixdate_finder):
         fake_get_query([empty_response])
         ws = workspace.Workspace(root=tmpdir.strpath, name="test", create=True)
         p = parser.Parser(ws, "secret")
@@ -429,7 +429,7 @@ class TestParser:
         assert isinstance(timestamp, str)
         assert timestamp.endswith("Z") or timestamp.endswith("+00:00")
 
-    def test_get_commits_timestamp_with_cursors(self, advisories, fake_get_query, tmpdir, empty_response):
+    def test_get_commits_timestamp_with_cursors(self, advisories, fake_get_query, tmpdir, empty_response, auto_fake_fixdate_finder):
         fake_get_query([empty_response, advisories(has_next_page=True)])
         ws = workspace.Workspace(root=tmpdir.strpath, name="test", create=True)
         p = parser.Parser(ws, "secret")
@@ -441,13 +441,13 @@ class TestParser:
         assert isinstance(timestamp, str)
         assert timestamp.endswith("Z") or timestamp.endswith("+00:00")
 
-    def test_has_next_page(self, advisories, fake_get_query, tmpdir, empty_response):
+    def test_has_next_page(self, advisories, fake_get_query, tmpdir, empty_response, auto_fake_fixdate_finder):
         fake_get_query([empty_response, advisories(has_next_page=True)])
         p = parser.Parser(workspace.Workspace(root=tmpdir.strpath, name="test", create=True), "secret")
         result = list(p.get())
         assert len(result) == 1
 
-    def test_has_next_page_with_advisories(self, advisories, fake_get_query, tmpdir):
+    def test_has_next_page_with_advisories(self, advisories, fake_get_query, tmpdir, auto_fake_fixdate_finder):
         fake_get_query([advisories(), advisories(has_next_page=True)])
         p = parser.Parser(workspace.Workspace(root=tmpdir.strpath, name="test", create=True), "secret")
         result = list(p.get())

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2016-2781.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2016-2781.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "coreutils",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2017-8806.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2017-8806.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "postgresql-15",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-6293.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2019-6293.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "flex",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45283.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45283.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45284.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/CVE-2023-45284.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/GHSA-jq35-85cj-fj4p.json
+++ b/tests/unit/providers/minimos/test-fixtures/snapshots/minimos:rolling/GHSA-jq35-85cj-fj4p.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "apko",
           "NamespaceName": "minimos:rolling",
           "Version": "0",

--- a/tests/unit/providers/minimos/test_minimos.py
+++ b/tests/unit/providers/minimos/test_minimos.py
@@ -172,7 +172,7 @@ class TestParser:
 
         assert counter == 1
 
-    def test_normalize(self, mock_parsed_data, tmpdir):
+    def test_normalize(self, mock_parsed_data, tmpdir, auto_fake_fixdate_finder):
         p = Parser(
             workspace=workspace.Workspace(tmpdir, "test", create=True),
             url="https://packages.mini.dev/advisories/secdb/security.json",

--- a/tests/unit/providers/nvd/test_manager.py
+++ b/tests/unit/providers/nvd/test_manager.py
@@ -490,7 +490,7 @@ def test_apply_fix_dates(tmpdir, fake_fixdate_finder, fixdater_config, record, e
 
     # create manager instance
     if fixdater_config is None:
-        fixdater_instance = None
+        fixdater_instance = fake_fixdate_finder()
     else:
         fixdater_instance = fake_fixdate_finder(fixdater_config)
 

--- a/tests/unit/providers/oracle/test_oracle.py
+++ b/tests/unit/providers/oracle/test_oracle.py
@@ -431,7 +431,7 @@ class TestKspliceFilterer:
         assert f.filter(input_vulnerability) == expected_output
 
 
-def test_provider_schema(helpers, disable_get_requests, monkeypatch):
+def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 
     c = Config()
@@ -452,7 +452,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch):
     assert workspace.result_schemas_valid(require_entries=True)
 
 
-def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch):
+def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 
     c = Config()

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -690,7 +690,7 @@ class TestParser:
         assert fixed_in.version == "None"
         assert fixed_in.advisory.wont_fix is True
 
-    def test_parse_cve(self, tmpdir, mock_cve):
+    def test_parse_cve(self, tmpdir, mock_cve, auto_fake_fixdate_finder):
         driver = Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
         driver.rhsa_provider = OVALRHSAProvider.from_rhsa_dict({})
 
@@ -701,7 +701,7 @@ class TestParser:
         assert all(payload.get("Name") == mock_cve.get("name") for payload in payloads)
         assert all(payload.get("Severity") == "Low" for payload in payloads)
 
-    def test_parse_cve_partial_fix(self, tmpdir, mock_cve_partial_fix):
+    def test_parse_cve_partial_fix(self, tmpdir, mock_cve_partial_fix, auto_fake_fixdate_finder):
         driver = Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
         driver.rhsa_provider = OVALRHSAProvider.from_rhsa_dict({})
 

--- a/tests/unit/providers/rocky/test_rocky.py
+++ b/tests/unit/providers/rocky/test_rocky.py
@@ -55,7 +55,7 @@ def test_provider_skip_download_error_on_empty():
 
 
 @patch("vunnel.providers.rocky.client.Client._download")
-def test_parser(mock_download, helpers):
+def test_parser(mock_download, helpers, auto_fake_fixdate_finder):
     mock_download.return_value = None
     workspace = helpers.provider_workspace_helper(name=Provider.name())
     mock_data_path = helpers.local_dir("test-fixtures")
@@ -71,7 +71,7 @@ def test_parser(mock_download, helpers):
     assert vuln_tuples[2][1] == "1.3.1"
 
 @patch("vunnel.utils.http_wrapper.get")
-def test_client(mock_http_get, helpers):
+def test_client(mock_http_get, helpers, auto_fake_fixdate_finder):
     page1 = MagicMock()
     page1.json.return_value = {
         "links": {"next": "/api/v3/osv/?page=2"},
@@ -85,7 +85,7 @@ def test_client(mock_http_get, helpers):
     mock_http_get.side_effect = [page1, page2]
     mock_host = "https://apollo.example.com"
     logger = MagicMock()
-    client = Client(download_path=helpers.local_dir("test-fixtures"), logger=logger, api_host=mock_host)
+    client = Client(download_path=helpers.local_dir("test-fixtures"), logger=logger, api_host=mock_host, fixdater=auto_fake_fixdate_finder)
     client._download()
     assert mock_http_get.call_count == 2
     expected_calls = [

--- a/tests/unit/providers/sles/test_sles.py
+++ b/tests/unit/providers/sles/test_sles.py
@@ -380,7 +380,7 @@ class TestSLESParser:
             parser_factory=parser_factory,
         )
 
-        p = Parser(workspace=workspace, allow_versions=["15"], logger=None, fixdater=fixdate.default_finder(workspace, "sles"))
+        p = Parser(workspace=workspace, allow_versions=["15"], logger=None)
 
         actual = p._transform_oval_vulnerabilities("15", parsed_dict)
         actual.sort(key=lambda x: x.NamespaceName)

--- a/tests/unit/providers/ubuntu/test_ubuntu.py
+++ b/tests/unit/providers/ubuntu/test_ubuntu.py
@@ -281,12 +281,12 @@ class TestUbuntuParser:
             got = parse_multiline_keyvalue(header, split_lines)
             assert got == result
 
-    def test_mapper(self):
+    def test_mapper(self, fake_fixdate_finder):
         with open(self._data_) as f:
             parsed = parse_cve_file("CVE-2017-9996", f.readlines())
 
         parsed.name = "CVE-TEST-123"
-        vulns = map_parsed(parsed)
+        vulns = map_parsed(parsed, fixdater=fake_fixdate_finder())
         for i in vulns:
             j = i.json()
             print(json.dumps(j))

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2016-2781.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2016-2781.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "coreutils",
           "NamespaceName": "wolfi:rolling",
           "Version": "0",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2017-8806.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2017-8806.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "postgresql-15",
           "NamespaceName": "wolfi:rolling",
           "Version": "0",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-6293.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2019-6293.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "flex",
           "NamespaceName": "wolfi:rolling",
           "Version": "0",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45283.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45283.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "apko",
           "NamespaceName": "wolfi:rolling",
           "Version": "0",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45284.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/CVE-2023-45284.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "apko",
           "NamespaceName": "wolfi:rolling",
           "Version": "0",

--- a/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/GHSA-jq35-85cj-fj4p.json
+++ b/tests/unit/providers/wolfi/test-fixtures/snapshots/wolfi:rolling/GHSA-jq35-85cj-fj4p.json
@@ -6,10 +6,6 @@
       "Description": "",
       "FixedIn": [
         {
-          "Available": {
-            "Date": "2024-01-01",
-            "Kind": "first-observed"
-          },
           "Name": "apko",
           "NamespaceName": "wolfi:rolling",
           "Version": "0",

--- a/tests/unit/providers/wolfi/test_wolfi.py
+++ b/tests/unit/providers/wolfi/test_wolfi.py
@@ -172,7 +172,7 @@ class TestParser:
 
         assert counter == 1
 
-    def test_normalize(self, mock_parsed_data, tmpdir):
+    def test_normalize(self, mock_parsed_data, tmpdir, auto_fake_fixdate_finder):
         p = Parser(
             workspace=workspace.Workspace(tmpdir, "test", create=True),
             url="https://packages.wolfi.dev/os/security.json",

--- a/tests/unit/tool/test_finder.py
+++ b/tests/unit/tool/test_finder.py
@@ -263,3 +263,88 @@ class TestFinder:
 
         # should return the candidate with a date
         assert result == high_quality_with_date
+
+    def test_normalize_ecosystem_returns_none_for_none_input(self):
+        """Test that _normalize_ecosystem returns None when input is None."""
+        finder = Finder([], Mock(spec=Strategy))
+        result = finder._normalize_ecosystem(None)
+        assert result is None
+
+    def test_normalize_ecosystem_returns_empty_string_for_empty_input(self):
+        """Test that _normalize_ecosystem returns empty string when input is empty."""
+        finder = Finder([], Mock(spec=Strategy))
+        result = finder._normalize_ecosystem("")
+        assert result == ""
+
+    def test_normalize_ecosystem_maps_known_ecosystems(self):
+        """Test that _normalize_ecosystem correctly maps known ecosystem names."""
+        finder = Finder([], Mock(spec=Strategy))
+
+        test_cases = [
+            ("composer", "php-composer"),
+            ("php", "php-composer"),
+            ("rust", "rust-crate"),
+            ("cargo", "rust-crate"),
+            ("dart", "dart-pub"),
+            ("nuget", "dotnet"),
+            (".net", "dotnet"),
+            ("go", "go-module"),
+            ("golang", "go-module"),
+            ("maven", "java-archive"),
+            ("java", "java-archive"),
+            ("npm", "npm"),
+            ("javascript", "npm"),
+            ("pypi", "python"),
+            ("python", "python"),
+            ("pip", "python"),
+            ("swift", "swift"),
+            ("rubygems", "gem"),
+            ("ruby", "gem"),
+            ("gem", "gem"),
+            ("apk", "apk"),
+            ("rpm", "rpm"),
+            ("deb", "deb"),
+            ("github-action", "github-action"),
+        ]
+
+        for input_ecosystem, expected_output in test_cases:
+            result = finder._normalize_ecosystem(input_ecosystem)
+            assert result == expected_output, f"Expected {expected_output} for {input_ecosystem}, got {result}"
+
+    def test_normalize_ecosystem_handles_case_insensitive_input(self):
+        """Test that _normalize_ecosystem handles case insensitive input."""
+        finder = Finder([], Mock(spec=Strategy))
+
+        test_cases = [
+            ("COMPOSER", "php-composer"),
+            ("Rust", "rust-crate"),
+            ("CARGO", "rust-crate"),
+            ("Go", "go-module"),
+            ("NPM", "npm"),
+            ("PyPI", "python"),
+        ]
+
+        for input_ecosystem, expected_output in test_cases:
+            result = finder._normalize_ecosystem(input_ecosystem)
+            assert result == expected_output, f"Expected {expected_output} for {input_ecosystem}, got {result}"
+
+    def test_normalize_ecosystem_returns_unknown_ecosystems_unchanged(self):
+        """Test that _normalize_ecosystem returns unknown ecosystem names unchanged."""
+        finder = Finder([], Mock(spec=Strategy))
+
+        unknown_ecosystems = ["unknown", "custom-package", "proprietary"]
+
+        for ecosystem in unknown_ecosystems:
+            result = finder._normalize_ecosystem(ecosystem)
+            assert result == ecosystem, f"Expected {ecosystem} to be unchanged, got {result}"
+
+    def test_normalize_ecosystem_preserves_case_for_unknown_ecosystems(self):
+        """Test that _normalize_ecosystem preserves original case for unknown ecosystems."""
+        finder = Finder([], Mock(spec=Strategy))
+
+        test_cases = ["UnknownEcosystem", "CUSTOM", "Mixed-Case"]
+
+        for ecosystem in test_cases:
+            result = finder._normalize_ecosystem(ecosystem)
+            # unknown ecosystems should be lowercased since we call .lower() first
+            assert result == ecosystem.lower(), f"Expected {ecosystem.lower()} for {ecosystem}, got {result}"

--- a/tests/unit/tool/test_finder.py
+++ b/tests/unit/tool/test_finder.py
@@ -1,0 +1,265 @@
+import datetime
+from unittest.mock import Mock, MagicMock
+import pytest
+from vunnel.tool.fixdate.finder import Finder, Result, Strategy
+
+
+class TestFinder:
+    """Test class for the Finder.best() method."""
+
+    def create_mock_strategy(self, results):
+        """helper to create a mock strategy that returns specified results."""
+        mock_strategy = Mock(spec=Strategy)
+        mock_strategy.find.return_value = results
+        return mock_strategy
+
+    def create_result(self, date_str=None, kind="test", version=None, accurate=None):
+        """helper to create Result objects with specified parameters."""
+        date_obj = None
+        if date_str:
+            date_obj = datetime.date.fromisoformat(date_str)
+        return Result(date=date_obj, kind=kind, version=version, accurate=accurate)
+
+    def test_best_returns_none_when_no_fix_version(self):
+        """Test that best() returns None when fix_version is missing or invalid."""
+        strategy = self.create_mock_strategy([])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        # test None fix_version
+        result = finder.best("CVE-2023-0001", "package", None)
+        assert result is None
+
+        # test empty string fix_version
+        result = finder.best("CVE-2023-0001", "package", "")
+        assert result is None
+
+        # test "None" string fix_version
+        result = finder.best("CVE-2023-0001", "package", "None")
+        assert result is None
+
+        # test "0" fix_version (nak conditions... these by definition are NOT fixes)
+        result = finder.best("CVE-2023-0001", "package", "0")
+        assert result is None
+
+    def test_best_with_high_quality_candidates(self):
+        """Test that high quality candidates (accurate=True) are prioritized first."""
+        strategy = self.create_mock_strategy([])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        high_quality = self.create_result("2023-01-01", "candidate", accurate=True)
+        low_quality = self.create_result("2023-01-02", "candidate", accurate=False)
+        candidates = [low_quality, high_quality]  # intentionally out of order
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0", candidates=candidates)
+
+        assert result == high_quality
+        assert result.date == datetime.date(2023, 1, 1)
+
+    def test_best_with_low_quality_candidates_as_fallback(self):
+        """Test that low quality candidates are used when no high quality ones exist."""
+        strategy = self.create_mock_strategy([])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        low_quality = self.create_result("2023-01-02", "candidate", accurate=False)
+        candidates = [low_quality]
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0", candidates=candidates)
+
+        assert result == low_quality
+        assert result.date == datetime.date(2023, 1, 2)
+
+    def test_best_with_strategy_results(self):
+        """Test that strategy results are included in the prioritization."""
+        strategy_result = self.create_result("2023-01-03", "strategy")
+        strategy = self.create_mock_strategy([strategy_result])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        assert result == strategy_result
+        strategy.find.assert_called_once_with("CVE-2023-0001", "package", "1.0.0", None)
+
+    def test_best_prioritization_order(self):
+        """Test the full prioritization order: high quality candidates → strategies → low quality candidates."""
+        strategy_result = self.create_result("2023-01-05", "strategy")
+        strategy = self.create_mock_strategy([strategy_result])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        high_quality = self.create_result("2023-01-01", "candidate", accurate=True)
+        low_quality = self.create_result("2023-01-02", "candidate", accurate=False)
+        candidates = [low_quality, high_quality]
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0", candidates=candidates)
+
+        # should return high quality candidate first
+        assert result == high_quality
+
+    def test_best_with_accurate_first_observed_filters_results(self):
+        """Test that accurate first observed date filters out later results."""
+        strategy_result = self.create_result("2023-01-10", "strategy")  # after first observed
+        strategy = self.create_mock_strategy([strategy_result])
+
+        first_observed_result = self.create_result("2023-01-05", "first_observed", accurate=True)
+        first_observed = self.create_mock_strategy([first_observed_result])
+
+        finder = Finder([strategy], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        # should return first observed since strategy result is after it
+        assert result == first_observed_result
+
+    def test_best_with_accurate_first_observed_allows_earlier_results(self):
+        """Test that results before accurate first observed date are allowed."""
+        strategy_result = self.create_result("2023-01-03", "strategy")  # before first observed
+        strategy = self.create_mock_strategy([strategy_result])
+
+        first_observed_result = self.create_result("2023-01-05", "first_observed", accurate=True)
+        first_observed = self.create_mock_strategy([first_observed_result])
+
+        finder = Finder([strategy], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        # should return strategy result since it's before first observed
+        assert result == strategy_result
+
+    def test_best_returns_first_observed_when_no_valid_candidates(self):
+        """Test fallback to first observed when all other results are filtered out."""
+        strategy_result = self.create_result("2023-01-10", "strategy")  # after first observed
+        strategy = self.create_mock_strategy([strategy_result])
+
+        first_observed_result = self.create_result("2023-01-05", "first_observed", accurate=True)
+        first_observed = self.create_mock_strategy([first_observed_result])
+
+        finder = Finder([strategy], first_observed)
+
+        high_quality = self.create_result("2023-01-15", "candidate", accurate=True)  # after first observed
+        candidates = [high_quality]
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0", candidates=candidates)
+
+        # should return first observed since all other candidates are after it
+        assert result == first_observed_result
+
+    def test_best_with_inaccurate_first_observed_as_last_resort(self):
+        """Test that inaccurate first observed dates are used as last resort."""
+        strategy_result = self.create_result("2023-01-03", "strategy")
+        strategy = self.create_mock_strategy([strategy_result])
+
+        first_observed_result = self.create_result("2023-01-05", "first_observed", accurate=False)
+        first_observed = self.create_mock_strategy([first_observed_result])
+
+        finder = Finder([strategy], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        # should return strategy result first, then first observed is added to results
+        assert result == strategy_result
+
+    def test_best_with_no_results(self):
+        """Test that None is returned when no results are available from any source."""
+        strategy = self.create_mock_strategy([])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        assert result is None
+
+    def test_best_with_empty_strategies(self):
+        """Test behavior when strategies list is empty."""
+        first_observed_result = self.create_result("2023-01-05", "first_observed", accurate=False)
+        first_observed = self.create_mock_strategy([first_observed_result])
+
+        finder = Finder([], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        assert result == first_observed_result
+
+    def test_best_with_none_dates_in_results(self):
+        """Test handling of Result objects with None dates."""
+        strategy_result_no_date = Result(date=None, kind="strategy")
+        strategy_result_with_date = self.create_result("2023-01-03", "strategy")
+        strategy = self.create_mock_strategy([strategy_result_no_date, strategy_result_with_date])
+
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        # the best() method returns the first result from strategies, even if it has None date
+        # this is the actual behavior - strategy results are not filtered for None dates
+        assert result == strategy_result_no_date
+
+    def test_best_with_mixed_accurate_and_inaccurate_results(self):
+        """Test proper ordering when mixing accurate and inaccurate results."""
+        strategy1_result = self.create_result("2023-01-10", "strategy1")
+        strategy1 = self.create_mock_strategy([strategy1_result])
+
+        strategy2_result = self.create_result("2023-01-08", "strategy2")
+        strategy2 = self.create_mock_strategy([strategy2_result])
+
+        first_observed = self.create_mock_strategy([])
+
+        # strategies are ordered by priority
+        finder = Finder([strategy1, strategy2], first_observed)
+
+        high_quality = self.create_result("2023-01-12", "candidate", accurate=True)
+        low_quality = self.create_result("2023-01-01", "candidate", accurate=False)
+        candidates = [low_quality, high_quality]
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0", candidates=candidates)
+
+        # should return high quality candidate first, regardless of date
+        assert result == high_quality
+
+    def test_best_multiple_strategies_priority_order(self):
+        """Test that strategies are called in order and results prioritized by strategy order."""
+        strategy1_result = self.create_result("2023-01-10", "strategy1")
+        strategy1 = self.create_mock_strategy([strategy1_result])
+
+        strategy2_result = self.create_result("2023-01-05", "strategy2")  # earlier date but lower priority
+        strategy2 = self.create_mock_strategy([strategy2_result])
+
+        first_observed = self.create_mock_strategy([])
+
+        # strategy1 has higher priority than strategy2
+        finder = Finder([strategy1, strategy2], first_observed)
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0")
+
+        # should return strategy1 result since it has higher priority
+        assert result == strategy1_result
+
+    def test_best_with_ecosystem_parameter(self):
+        """Test that ecosystem parameter is passed to strategies correctly."""
+        strategy = self.create_mock_strategy([self.create_result("2023-01-01", "strategy")])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        finder.best("CVE-2023-0001", "package", "1.0.0", ecosystem="npm")
+
+        strategy.find.assert_called_once_with("CVE-2023-0001", "package", "1.0.0", "npm")
+        first_observed.find.assert_called_once_with("CVE-2023-0001", "package", "1.0.0", "npm")
+
+    def test_best_candidates_with_no_date_are_filtered_out(self):
+        """Test that candidates without dates are filtered out during prioritization."""
+        strategy = self.create_mock_strategy([])
+        first_observed = self.create_mock_strategy([])
+        finder = Finder([strategy], first_observed)
+
+        high_quality_no_date = Result(date=None, kind="candidate", accurate=True)
+        high_quality_with_date = self.create_result("2023-01-01", "candidate", accurate=True)
+        candidates = [high_quality_no_date, high_quality_with_date]
+
+        result = finder.best("CVE-2023-0001", "package", "1.0.0", candidates=candidates)
+
+        # should return the candidate with a date
+        assert result == high_quality_with_date

--- a/tests/unit/tool/test_first_observed.py
+++ b/tests/unit/tool/test_first_observed.py
@@ -16,11 +16,11 @@ class TestStore:
 
     def test_store_initialization(self, tmpdir):
         # create a workspace
-        ws = workspace.Workspace(tmpdir, "test", create=True)
         name = "test-db"
+        ws = workspace.Workspace(tmpdir, name, create=True)
 
         # create store instance
-        store = Store(ws, name)
+        store = Store(ws)
 
         # verify initialization
         assert store.workspace == ws
@@ -30,8 +30,8 @@ class TestStore:
 
     def test_setup(self, tmpdir):
         # create a workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # ensure db directory exists
         store.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -53,8 +53,8 @@ class TestStore:
     @patch("oras.client.OrasClient")
     def test_download_success(self, mock_oras_client_class, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # mock the ORAS client
         mock_client = Mock()
@@ -76,8 +76,8 @@ class TestStore:
     @patch("oras.client.OrasClient")
     def test_download_failure(self, mock_oras_client_class, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # mock the ORAS client to raise an exception
         mock_client = Mock()
@@ -91,8 +91,8 @@ class TestStore:
     @patch("oras.client.OrasClient")
     def test_download_not_found(self, mock_oras_client_class, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # mock the ORAS client to raise a "not found" ValueError
         mock_client = Mock()
@@ -107,8 +107,8 @@ class TestStore:
 
     def test_download_creates_directories(self, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # ensure directory doesn't exist initially
         assert not store.db_path.parent.exists()
@@ -125,8 +125,8 @@ class TestStore:
     @patch("oras.client.OrasClient")
     def test_get_after_not_found_download(self, mock_oras_client_class, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # mock the ORAS client to raise a "not found" ValueError
         mock_client = Mock()
@@ -147,8 +147,8 @@ class TestStore:
     @patch("oras.client.OrasClient")
     def test_find_after_not_found_download(self, mock_oras_client_class, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # mock the ORAS client to raise a "not found" ValueError
         mock_client = Mock()
@@ -169,8 +169,8 @@ class TestStore:
     @patch("oras.client.OrasClient")
     def test_get_changed_vuln_ids_since_after_not_found(self, mock_oras_client_class, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # mock the ORAS client to raise a "not found" ValueError
         mock_client = Mock()
@@ -187,8 +187,8 @@ class TestStore:
 
     def test_get_without_download_raises_error(self, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # verify calling get without download raises RuntimeError
         with pytest.raises(RuntimeError, match="fix date database has not been downloaded"):
@@ -202,8 +202,8 @@ class TestStore:
     @patch("oras.client.OrasClient")
     def test_download_with_github_token(self, mock_oras_client_class, tmpdir):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # mock the ORAS client
         mock_client = Mock()
@@ -227,8 +227,8 @@ class TestStore:
 
     def test_get_by_cpe(self, tmpdir, helpers):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database
         self._create_test_database(store.db_path)
@@ -250,8 +250,8 @@ class TestStore:
 
     def test_get_by_package_name(self, tmpdir, helpers):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database
         self._create_test_database(store.db_path)
@@ -274,8 +274,8 @@ class TestStore:
 
     def test_get_with_ecosystem(self, tmpdir, helpers):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database
         self._create_test_database(store.db_path)
@@ -297,8 +297,8 @@ class TestStore:
 
     def test_find_returns_result_objects(self, tmpdir, helpers):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database
         self._create_test_database(store.db_path)
@@ -322,8 +322,8 @@ class TestStore:
 
     def test_find_empty_results(self, tmpdir, helpers):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database
         self._create_test_database(store.db_path)
@@ -340,8 +340,8 @@ class TestStore:
 
     def test_get_changed_vuln_ids_since(self, tmpdir, helpers):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database with runs table
         self._create_test_database_with_runs(store.db_path)
@@ -359,8 +359,8 @@ class TestStore:
 
     def test_get_changed_vuln_ids_since_no_results(self, tmpdir, helpers):
         # create workspace and store
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database with runs table
         self._create_test_database_with_runs(store.db_path)
@@ -375,8 +375,8 @@ class TestStore:
 
     def test_package_name_case_insensitive_matching(self, tmpdir, helpers):
         """test that package name matching is case insensitive"""
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database with mixed case package names
         self._create_test_database_with_case_variations(store.db_path)
@@ -401,8 +401,8 @@ class TestStore:
 
     def test_python_package_normalization_matching(self, tmpdir, helpers):
         """test that Python package name normalization works end-to-end"""
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database with python packages stored with underscores
         self._create_test_database_with_python_packages(store.db_path)
@@ -429,8 +429,8 @@ class TestStore:
 
     def test_cpe_queries_unaffected_by_normalization(self, tmpdir, helpers):
         """test that CPE-based queries are not affected by package name normalization"""
-        ws = workspace.Workspace(tmpdir, "test", create=True)
-        store = Store(ws, "test-db")
+        ws = workspace.Workspace(tmpdir, "test-db", create=True)
+        store = Store(ws)
 
         # create test database
         self._create_test_database(store.db_path)
@@ -454,6 +454,28 @@ class TestStore:
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
         with sqlite3.connect(db_path) as conn:
+            # create databases table
+            conn.execute("""
+                CREATE TABLE databases (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    url TEXT UNIQUE NOT NULL,
+                    schema_version INTEGER NOT NULL,
+                    build_date TEXT NOT NULL,
+                    filename TEXT NOT NULL,
+                    status TEXT DEFAULT 'pending',
+                    vulnerability_count INTEGER,
+                    run_id INTEGER,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT
+                )
+            """)
+
+            # insert default database record
+            conn.execute("""
+                INSERT INTO databases (id, url, schema_version, build_date, filename, status, vulnerability_count, created_at)
+                VALUES (1, 'test://db', 1, '2023-01-01', 'test.db', 'completed', 1, '2023-01-01T00:00:00')
+            """)
+
             # create table schema with COLLATE NOCASE
             conn.execute("""
                 CREATE TABLE fixdates (
@@ -465,7 +487,9 @@ class TestStore:
                     fix_version TEXT,
                     first_observed_date TEXT,
                     resolution TEXT,
-                    source TEXT
+                    source TEXT,
+                    run_id INTEGER,
+                    database_id INTEGER
                 )
             """)
 
@@ -474,12 +498,12 @@ class TestStore:
                 # package stored with lowercase
                 (
                     "CVE-2023-0002", "test-db", "curl", "", "debian:11",
-                    "7.68.0-1ubuntu2.15", "2023-02-20", "fixed", "grype-db",
+                    "7.68.0-1ubuntu2.15", "2023-02-20", "fixed", "grype-db", None, 1,
                 ),
             ]
 
             conn.executemany(
-                "INSERT INTO fixdates VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO fixdates VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 test_data,
             )
 
@@ -488,6 +512,28 @@ class TestStore:
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
         with sqlite3.connect(db_path) as conn:
+            # create databases table
+            conn.execute("""
+                CREATE TABLE databases (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    url TEXT UNIQUE NOT NULL,
+                    schema_version INTEGER NOT NULL,
+                    build_date TEXT NOT NULL,
+                    filename TEXT NOT NULL,
+                    status TEXT DEFAULT 'pending',
+                    vulnerability_count INTEGER,
+                    run_id INTEGER,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT
+                )
+            """)
+
+            # insert default database record
+            conn.execute("""
+                INSERT INTO databases (id, url, schema_version, build_date, filename, status, vulnerability_count, created_at)
+                VALUES (1, 'test://db', 1, '2023-01-01', 'test.db', 'completed', 3, '2023-01-01T00:00:00')
+            """)
+
             # create table schema with COLLATE NOCASE
             conn.execute("""
                 CREATE TABLE fixdates (
@@ -499,7 +545,9 @@ class TestStore:
                     fix_version TEXT,
                     first_observed_date TEXT,
                     resolution TEXT,
-                    source TEXT
+                    source TEXT,
+                    run_id INTEGER,
+                    database_id INTEGER
                 )
             """)
 
@@ -508,21 +556,21 @@ class TestStore:
                 # python package stored with normalized form (hyphens)
                 (
                     "CVE-2023-9001", "test-db", "my-package", "", "python",
-                    "1.0.0", "2023-02-20", "fixed", "grype-db",
+                    "1.0.0", "2023-02-20", "fixed", "grype-db", None, 1,
                 ),
                 (
                     "CVE-2023-9001", "test-db", "my-package", "", "pypi",
-                    "1.0.0", "2023-02-20", "fixed", "grype-db",
+                    "1.0.0", "2023-02-20", "fixed", "grype-db", None, 1,
                 ),
                 # another test package with mixed separators in storage (normalized)
                 (
                     "CVE-2023-9001", "test-db", "my-package-test", "", "python",
-                    "2.0.0", "2023-02-21", "fixed", "grype-db",
+                    "2.0.0", "2023-02-21", "fixed", "grype-db", None, 1,
                 ),
             ]
 
             conn.executemany(
-                "INSERT INTO fixdates VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO fixdates VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 test_data,
             )
 
@@ -531,6 +579,28 @@ class TestStore:
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
         with sqlite3.connect(db_path) as conn:
+            # create databases table
+            conn.execute("""
+                CREATE TABLE databases (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    url TEXT UNIQUE NOT NULL,
+                    schema_version INTEGER NOT NULL,
+                    build_date TEXT NOT NULL,
+                    filename TEXT NOT NULL,
+                    status TEXT DEFAULT 'pending',
+                    vulnerability_count INTEGER,
+                    run_id INTEGER,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT
+                )
+            """)
+
+            # insert default database record
+            conn.execute("""
+                INSERT INTO databases (id, url, schema_version, build_date, filename, status, vulnerability_count, created_at)
+                VALUES (1, 'test://db', 1, '2023-01-01', 'test.db', 'completed', 4, '2023-01-01T00:00:00')
+            """)
+
             # create table schema
             conn.execute("""
                 CREATE TABLE fixdates (
@@ -542,7 +612,9 @@ class TestStore:
                     fix_version TEXT,
                     first_observed_date TEXT,
                     resolution TEXT,
-                    source TEXT
+                    source TEXT,
+                    run_id INTEGER,
+                    database_id INTEGER
                 )
             """)
 
@@ -552,26 +624,26 @@ class TestStore:
                 (
                     "CVE-2023-0001", "test-db", "",
                     "cpe:2.3:a:apache:httpd:2.4.41:*:*:*:*:*:*:*", "",
-                    "2.4.42", "2023-01-15", "fixed", "grype-db",
+                    "2.4.42", "2023-01-15", "fixed", "grype-db", None, 1,
                 ),
                 # package name-based records
                 (
                     "CVE-2023-0002", "test-db", "curl", "", "debian:11",
-                    "7.68.0-1ubuntu2.15", "2023-02-20", "fixed", "grype-db",
+                    "7.68.0-1ubuntu2.15", "2023-02-20", "fixed", "grype-db", None, 1,
                 ),
                 (
                     "CVE-2023-0002", "test-db", "curl", "", "debian:11",
-                    None, "2023-02-18", "wont-fix", "grype-db",
+                    None, "2023-02-18", "wont-fix", "grype-db", None, 1,
                 ),
                 # additional test record
                 (
                     "CVE-2023-0003", "rhel", "openssl", "", "rhel:8",
-                    "1.1.1k-7.el8_6", "2023-03-10", "fixed", "grype-db",
+                    "1.1.1k-7.el8_6", "2023-03-10", "fixed", "grype-db", None, 1,
                 ),
             ]
 
             conn.executemany(
-                "INSERT INTO fixdates VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO fixdates VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 test_data,
             )
 
@@ -580,6 +652,28 @@ class TestStore:
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
         with sqlite3.connect(db_path) as conn:
+            # create databases table
+            conn.execute("""
+                CREATE TABLE databases (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    url TEXT UNIQUE NOT NULL,
+                    schema_version INTEGER NOT NULL,
+                    build_date TEXT NOT NULL,
+                    filename TEXT NOT NULL,
+                    status TEXT DEFAULT 'pending',
+                    vulnerability_count INTEGER,
+                    run_id INTEGER,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT
+                )
+            """)
+
+            # insert default database record
+            conn.execute("""
+                INSERT INTO databases (id, url, schema_version, build_date, filename, status, vulnerability_count, created_at)
+                VALUES (1, 'test://db', 1, '2023-01-01', 'test.db', 'completed', 4, '2023-01-01T00:00:00')
+            """)
+
             # create runs table
             conn.execute("""
                 CREATE TABLE runs (

--- a/tests/unit/utils/test_osv.py
+++ b/tests/unit/utils/test_osv.py
@@ -25,7 +25,7 @@ class TestPatchFixDate:
 
         # Should not crash and advisory should remain empty
         assert advisory == {}
-        fixdater.find.assert_not_called()
+        fixdater.best.assert_not_called()
 
     def test_advisory_without_affected_no_changes(self):
         """Test advisory without affected field is handled gracefully."""
@@ -35,7 +35,7 @@ class TestPatchFixDate:
         osv.patch_fix_date(advisory, fixdater)
 
         assert advisory == {"id": "test-vuln"}
-        fixdater.find.assert_not_called()
+        fixdater.best.assert_not_called()
 
     def test_affected_without_package_name_skipped(self):
         """Test that affected entries without package name are skipped."""
@@ -50,7 +50,7 @@ class TestPatchFixDate:
 
         osv.patch_fix_date(advisory, fixdater)
 
-        fixdater.find.assert_not_called()
+        fixdater.best.assert_not_called()
 
     def test_affected_without_ecosystem_skipped(self):
         """Test that affected entries without ecosystem are skipped."""
@@ -65,7 +65,7 @@ class TestPatchFixDate:
 
         osv.patch_fix_date(advisory, fixdater)
 
-        fixdater.find.assert_not_called()
+        fixdater.best.assert_not_called()
 
     def test_no_ranges_no_changes(self):
         """Test that affected entries without ranges are handled gracefully."""
@@ -82,7 +82,7 @@ class TestPatchFixDate:
 
         osv.patch_fix_date(advisory, fixdater)
 
-        fixdater.find.assert_not_called()
+        fixdater.best.assert_not_called()
 
     def test_no_events_no_changes(self):
         """Test that ranges without events are handled gracefully."""
@@ -102,7 +102,7 @@ class TestPatchFixDate:
 
         osv.patch_fix_date(advisory, fixdater)
 
-        fixdater.find.assert_not_called()
+        fixdater.best.assert_not_called()
 
     def test_events_without_fixed_version_skipped(self):
         """Test that events without 'fixed' field are skipped."""
@@ -127,7 +127,7 @@ class TestPatchFixDate:
 
         osv.patch_fix_date(advisory, fixdater)
 
-        fixdater.find.assert_not_called()
+        fixdater.best.assert_not_called()
 
     def test_fixdater_no_results_no_changes(self):
         """Test that when fixdater returns no results, no changes are made."""
@@ -146,16 +146,17 @@ class TestPatchFixDate:
             ]
         }
         fixdater = Mock()
-        fixdater.find.return_value = []  # No results
+        fixdater.best.return_value = None  # No results
 
         osv.patch_fix_date(advisory, fixdater)
 
         # Should have called find but made no changes to database_specific
-        fixdater.find.assert_called_once_with(
+        fixdater.best.assert_called_once_with(
             vuln_id="test-vuln",
             cpe_or_package="test-pkg",
             fix_version="1.0.1",
-            ecosystem="test-eco"
+            ecosystem="test-eco",
+            candidates=[],
         )
 
         # No database_specific should be added
@@ -184,16 +185,17 @@ class TestPatchFixDate:
         fix_result.kind = "release"
 
         fixdater = Mock()
-        fixdater.find.return_value = [fix_result]
+        fixdater.best.return_value = fix_result
 
         osv.patch_fix_date(advisory, fixdater)
 
         # Verify the call
-        fixdater.find.assert_called_once_with(
+        fixdater.best.assert_called_once_with(
             vuln_id="CVE-2023-1234",
             cpe_or_package="example-pkg",
             fix_version="2.1.0",
-            ecosystem="npm"
+            ecosystem="npm",
+            candidates=[],
         )
 
         # Verify the fix data was added
@@ -208,132 +210,6 @@ class TestPatchFixDate:
         assert "anchore" in range_obj["database_specific"]
         assert "fixes" in range_obj["database_specific"]["anchore"]
         assert range_obj["database_specific"]["anchore"]["fixes"] == [expected_fix]
-
-    def test_multiple_fix_events_in_range(self):
-        """Test handling of multiple fixed events in a single range."""
-        advisory = {
-            "id": "CVE-2023-5678",
-            "affected": [
-                {
-                    "package": {"name": "multi-pkg", "ecosystem": "pypi"},
-                    "ranges": [
-                        {
-                            "type": "ECOSYSTEM",
-                            "events": [
-                                {"introduced": "1.0.0"},
-                                {"fixed": "1.2.0"},
-                                {"introduced": "2.0.0"},
-                                {"fixed": "2.1.0"}
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
-
-        # Mock fixdater results for both versions
-        fix_result_1 = Mock(spec=FixResult)
-        fix_result_1.date = date(2023, 3, 10)
-        fix_result_1.kind = "patch"
-
-        fix_result_2 = Mock(spec=FixResult)
-        fix_result_2.date = date(2023, 5, 20)
-        fix_result_2.kind = "release"
-
-        fixdater = Mock()
-        fixdater.find.side_effect = [
-            [fix_result_1],  # For version 1.2.0
-            [fix_result_2],  # For version 2.1.0
-        ]
-
-        osv.patch_fix_date(advisory, fixdater)
-
-        # Verify both calls were made
-        assert fixdater.find.call_count == 2
-        fixdater.find.assert_any_call(
-            vuln_id="CVE-2023-5678",
-            cpe_or_package="multi-pkg",
-            fix_version="1.2.0",
-            ecosystem="pypi"
-        )
-        fixdater.find.assert_any_call(
-            vuln_id="CVE-2023-5678",
-            cpe_or_package="multi-pkg",
-            fix_version="2.1.0",
-            ecosystem="pypi"
-        )
-
-        # Verify both fixes were added
-        expected_fixes = [
-            {
-                "version": "1.2.0",
-                "date": "2023-03-10",
-                "kind": "patch"
-            },
-            {
-                "version": "2.1.0",
-                "date": "2023-05-20",
-                "kind": "release"
-            }
-        ]
-
-        range_obj = advisory["affected"][0]["ranges"][0]
-        assert range_obj["database_specific"]["anchore"]["fixes"] == expected_fixes
-
-    def test_multiple_affected_packages(self):
-        """Test handling of multiple affected packages."""
-        advisory = {
-            "id": "CVE-2023-9999",
-            "affected": [
-                {
-                    "package": {"name": "pkg-a", "ecosystem": "npm"},
-                    "ranges": [
-                        {
-                            "type": "ECOSYSTEM",
-                            "events": [{"fixed": "1.0.0"}]
-                        }
-                    ]
-                },
-                {
-                    "package": {"name": "pkg-b", "ecosystem": "pypi"},
-                    "ranges": [
-                        {
-                            "type": "ECOSYSTEM",
-                            "events": [{"fixed": "2.0.0"}]
-                        }
-                    ]
-                }
-            ]
-        }
-
-        # Mock results for both packages
-        fix_result_a = Mock(spec=FixResult)
-        fix_result_a.date = date(2023, 1, 15)
-        fix_result_a.kind = "release"
-
-        fix_result_b = Mock(spec=FixResult)
-        fix_result_b.date = date(2023, 2, 20)
-        fix_result_b.kind = "patch"
-
-        fixdater = Mock()
-        fixdater.find.side_effect = [
-            [fix_result_a],  # For pkg-a
-            [fix_result_b],  # For pkg-b
-        ]
-
-        osv.patch_fix_date(advisory, fixdater)
-
-        # Verify both packages got fix data
-        pkg_a_fixes = advisory["affected"][0]["ranges"][0]["database_specific"]["anchore"]["fixes"]
-        pkg_b_fixes = advisory["affected"][1]["ranges"][0]["database_specific"]["anchore"]["fixes"]
-
-        assert len(pkg_a_fixes) == 1
-        assert pkg_a_fixes[0]["version"] == "1.0.0"
-        assert pkg_a_fixes[0]["date"] == "2023-01-15"
-
-        assert len(pkg_b_fixes) == 1
-        assert pkg_b_fixes[0]["version"] == "2.0.0"
-        assert pkg_b_fixes[0]["date"] == "2023-02-20"
 
     def test_ecosystem_processor_called(self):
         """Test that ecosystem_processor is called when provided."""
@@ -357,7 +233,7 @@ class TestPatchFixDate:
         fix_result.kind = "release"
 
         fixdater = Mock()
-        fixdater.find.return_value = [fix_result]
+        fixdater.best.return_value = fix_result
 
         ecosystem_processor = Mock(return_value="processed-eco")
 
@@ -367,11 +243,12 @@ class TestPatchFixDate:
         ecosystem_processor.assert_called_once_with("original-eco")
 
         # Verify fixdater was called with processed ecosystem
-        fixdater.find.assert_called_once_with(
+        fixdater.best.assert_called_once_with(
             vuln_id="CVE-2023-0001",
             cpe_or_package="test-pkg",
             fix_version="1.0.0",
-            ecosystem="processed-eco"
+            ecosystem="processed-eco",
+            candidates=[],
         )
 
     def test_preserve_existing_database_specific(self):
@@ -400,7 +277,7 @@ class TestPatchFixDate:
         fix_result.kind = "release"
 
         fixdater = Mock()
-        fixdater.find.return_value = [fix_result]
+        fixdater.best.return_value = fix_result
 
         osv.patch_fix_date(advisory, fixdater)
 


### PR DESCRIPTION
This makes the following adjustments:
- some providers are multi-threaded, thus, the fixdater tool has been modified to be thread safe
- debian provider needs to additionally patch legacy records with fix date information
- oracle advisories have been found in some cases to be missing date information, thus the fixdater is used in fallback cases.
- github provider was downloading the fix date db for each github api request + the fixdater was not wired to the NodeParser for existing records
- Simplifies the pattern of creating the fixdater object for each provider
- Remove application level config to turn off fix date injection