### PR TITLE
Add nocase statements to schema (remove from queries)

### DIFF
--- a/src/vunnel/tool/fixdate/first_observed.py
+++ b/src/vunnel/tool/fixdate/first_observed.py
@@ -111,18 +111,17 @@ class Store(Strategy):
 
         # build query - if cpe_or_package looks like a CPE, search by full_cpe, otherwise by package_name
         query = table.select().where(
-            (table.c.vuln_id.collate("NOCASE") == vuln_id) & (table.c.provider.collate("NOCASE") == self.provider),
+            (table.c.vuln_id == vuln_id) & (table.c.provider == self.provider),
         )
 
         if cpe_or_package.lower().startswith("cpe:"):
-            query = query.where(table.c.full_cpe.collate("NOCASE") == cpe_or_package)
+            query = query.where(table.c.full_cpe == cpe_or_package)
         else:
             query = query.where(
-                (table.c.package_name.collate("NOCASE") == normalize_package_name(cpe_or_package, ecosystem))
-                & (table.c.full_cpe.collate("NOCASE") == ""),
+                (table.c.package_name == normalize_package_name(cpe_or_package, ecosystem)) & (table.c.full_cpe == ""),
             )
             if ecosystem:
-                query = query.where(table.c.ecosystem.collate("NOCASE") == ecosystem)
+                query = query.where(table.c.ecosystem == ecosystem)
 
         if fix_version:
             query = query.where(table.c.fix_version == fix_version)

--- a/tests/unit/tool/test_first_observed.py
+++ b/tests/unit/tool/test_first_observed.py
@@ -55,15 +55,15 @@ class DatabaseFixture:
             # Create fixdates table
             conn.execute("""
                 CREATE TABLE fixdates (
-                    vuln_id TEXT,
-                    provider TEXT,
+                    vuln_id TEXT COLLATE NOCASE,
+                    provider TEXT COLLATE NOCASE,
                     package_name TEXT COLLATE NOCASE,
-                    full_cpe TEXT,
-                    ecosystem TEXT,
-                    fix_version TEXT,
-                    first_observed_date TEXT,
-                    resolution TEXT,
-                    source TEXT,
+                    full_cpe TEXT COLLATE NOCASE,
+                    ecosystem TEXT COLLATE NOCASE,
+                    fix_version TEXT COLLATE NOCASE,
+                    first_observed_date TEXT COLLATE NOCASE,
+                    resolution TEXT COLLATE NOCASE,
+                    source TEXT COLLATE NOCASE,
                     run_id INTEGER,
                     database_id INTEGER
                 )


### PR DESCRIPTION
The underlying tables now have collate nocase for most columns now, thus the query can be simplified (this makes no functional change).