### PR TITLE
Add mariner first-observed fix date support

### DIFF
--- a/src/vunnel/providers/mariner/__init__.py
+++ b/src/vunnel/providers/mariner/__init__.py
@@ -47,7 +47,7 @@ class Provider(provider.Provider):
         return "mariner"
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
-        with self.results_writer() as writer:
+        with self.results_writer() as writer, self.parser:
             for namespace, vuln_id, record in self.parser.get():
                 writer.write(
                     identifier=os.path.join(namespace, vuln_id),

--- a/src/vunnel/providers/mariner/parser.py
+++ b/src/vunnel/providers/mariner/parser.py
@@ -8,12 +8,14 @@ from xsdata.formats.dataclass.parsers import XmlParser
 from xsdata.formats.dataclass.parsers.config import ParserConfig
 
 from vunnel.providers.mariner.model import Definition, RpminfoObject, RpminfoState, RpminfoTest
+from vunnel.tool import fixdate
 from vunnel.utils import http_wrapper as http
 from vunnel.utils.vulnerability import FixAvailability, FixedIn, Vulnerability
 
 if TYPE_CHECKING:
     import logging
     from collections.abc import Generator
+    from types import TracebackType
 
     from vunnel.workspace import Workspace
 
@@ -25,7 +27,8 @@ IGNORED_PATCHABLE_VALUES = ["Not Applicable"]
 
 
 class MarinerXmlFile:
-    def __init__(self, oval_file_path: str, logger: logging.Logger):
+    def __init__(self, oval_file_path: str, logger: logging.Logger, fixdater: fixdate.Finder):
+        self.fixdater = fixdater
         parser_config = ParserConfig(
             fail_on_converter_warnings=False,
             fail_on_unknown_attributes=False,
@@ -119,7 +122,7 @@ class MarinerXmlFile:
                     objects.append(obj)
         return objects
 
-    def make_fixed_in(self, definition: Definition) -> FixedIn | None:  # noqa: C901
+    def make_fixed_in(self, definition: Definition, vulnerability_id: str) -> FixedIn | None:  # noqa: C901
         tests = self.get_tests(definition)
         states = self.get_states(tests)
         objects = self.get_objects(tests)
@@ -159,9 +162,27 @@ class MarinerXmlFile:
         vulnerability_range_str = ", ".join(vulnerability_range)
 
         # create availability info when a fix exists
-        available = None
+        candidates = []
         if fixed_version != "None" and definition.metadata and definition.metadata.advisory_date:
-            available = FixAvailability(Date=str(definition.metadata.advisory_date.to_datetime().date()), Kind="advisory")
+            candidates.append(
+                fixdate.Result(
+                    date=definition.metadata.advisory_date.to_datetime().date(),
+                    kind="advisory",
+                    accurate=True,
+                ),
+            )
+
+        result = self.fixdater.best(
+            vuln_id=vulnerability_id,
+            cpe_or_package=name,
+            fix_version=fixed_version,
+            ecosystem=self.namespace_name(),
+            candidates=candidates,
+        )
+
+        available = None
+        if result and result.date:
+            available = FixAvailability(Date=result.date.isoformat(), Kind=result.kind)
 
         return FixedIn(
             Name=name,
@@ -194,12 +215,15 @@ class MarinerXmlFile:
             link = ""
             if d.metadata.reference and d.metadata.reference.ref_url:
                 link = d.metadata.reference.ref_url
-            fixed_in = self.make_fixed_in(d)
-            if not fixed_in:
-                continue
+
             vulnerability_id = self.vulnerability_id(d)
             if not vulnerability_id:
                 continue
+
+            fixed_in = self.make_fixed_in(d, vulnerability_id)
+            if not fixed_in:
+                continue
+
             yield Vulnerability(
                 Name=vulnerability_id,  # intentional; legacy API uses Name as field for vulnerability ID.
                 NamespaceName=self.namespace_name(),
@@ -230,14 +254,34 @@ VERSION_TO_FILENAME = {
 
 
 class Parser:
-    def __init__(self, workspace: Workspace, download_timeout: int, allow_versions: list[Any], logger: logging.Logger):
+    def __init__(
+        self,
+        workspace: Workspace,
+        download_timeout: int,
+        allow_versions: list[Any],
+        logger: logging.Logger,
+        fixdater: fixdate.Finder | None = None,
+    ):
         self.workspace = workspace
         self.download_timeout = download_timeout
         self.allow_versions = allow_versions
         self._urls: set[str] = set()
         self.logger = logger
 
+        if not fixdater:
+            fixdater = fixdate.default_finder(workspace)
+        self.fixdater = fixdater
+
+    def __enter__(self) -> Parser:
+        self.fixdater.__enter__()
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None) -> None:
+        self.fixdater.__exit__(exc_type, exc_val, exc_tb)
+
     def _download(self) -> list[str]:
+        self.fixdater.download()
+
         return [self._download_version(v) for v in self.allow_versions]
 
     def _download_version(self, version: str) -> str:
@@ -260,6 +304,6 @@ class Parser:
 
     def get(self) -> Generator[tuple[str, str, dict[str, dict[str, Any]]], None, None]:
         for oval_file_path in self._download():
-            parsed_file = MarinerXmlFile(oval_file_path, self.logger)
+            parsed_file = MarinerXmlFile(oval_file_path, self.logger, self.fixdater)
             for v in parsed_file.vulnerabilities():
                 yield v.NamespaceName, v.Name, v.to_payload()

--- a/tests/unit/providers/mariner/test-fixtures/snapshots/mariner:2.0/CVE-2023-29404.json
+++ b/tests/unit/providers/mariner/test-fixtures/snapshots/mariner:2.0/CVE-2023-29404.json
@@ -6,7 +6,10 @@
       "Description": "CVE-2023-29404 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available.",
       "FixedIn": [
         {
-          "Available": null,
+          "Available": {
+            "Date": "2024-01-01",
+            "Kind": "first-observed"
+          },
           "Module": "",
           "Name": "golang",
           "NamespaceName": "mariner:2.0",

--- a/tests/unit/providers/mariner/test_mariner.py
+++ b/tests/unit/providers/mariner/test_mariner.py
@@ -34,7 +34,10 @@ from datetime import datetime, timezone
                             Module=None,
                             VendorAdvisory=None,
                             VulnerableRange="> 0:1.19.0.cm2, < 0:1.20.7-1.cm2",
-                            Available=None,
+                            Available=FixAvailability(
+                                Date=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                                Kind="first-observed"
+                            ),
                         )
                     ],
                     Metadata={},
@@ -188,16 +191,16 @@ from datetime import datetime, timezone
         ),
     ],
 )
-def test_parse(tmpdir, helpers, input_file, expected):
+def test_parse(tmpdir, helpers, input_file, expected, auto_fake_fixdate_finder):
     mock_data_path = helpers.local_dir(input_file)
-    subject = MarinerXmlFile(mock_data_path, logger=logging.getLogger("test_pariner"))
+    subject = MarinerXmlFile(mock_data_path, logger=logging.getLogger("test_pariner"), fixdater=auto_fake_fixdate_finder)
 
     vulnerabilities = [v for v in subject.vulnerabilities()]
     assert len(vulnerabilities) == len(expected)
     assert vulnerabilities == expected
 
 
-def test_provider_schema(helpers, disable_get_requests, monkeypatch):
+def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 
     c = Config(allow_versions=["2.0"])
@@ -218,7 +221,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch):
     assert workspace.result_schemas_valid(require_entries=True)
 
 
-def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch):
+def test_provider_via_snapshot(helpers, disable_get_requests, monkeypatch, auto_fake_fixdate_finder):
     workspace = helpers.provider_workspace_helper(name=Provider.name())
 
     c = Config(allow_versions=["2.0"])


### PR DESCRIPTION
It appears that not all mariner records have fix date information attached; in these cases we will now associate a first-observed value.