### PR TITLE
chore: deduplicate references in nvd provider

### DIFF
--- a/src/vunnel/providers/nvd/dedupe.py
+++ b/src/vunnel/providers/nvd/dedupe.py
@@ -32,7 +32,7 @@ def deduplicate_references(references: list[dict[str, Any]]) -> list[dict[str, A
     if not references:
         return []
 
-    seen_urls: set[str] = set()
+    seen_refs: set[tuple[str, str, tuple[str, ...]]] = set()
     deduplicated: list[dict[str, Any]] = []
 
     for ref in references:
@@ -41,8 +41,15 @@ def deduplicate_references(references: list[dict[str, Any]]) -> list[dict[str, A
             # Skip references without a URL (malformed data)
             continue
 
-        if url not in seen_urls:
-            seen_urls.add(url)
+        # Create a hashable key from the entire reference
+        # References have: url (required), source (optional), tags (optional list)
+        source = ref.get("source", "")
+        tags = tuple(sorted(ref.get("tags", [])))  # Sort tags for consistent comparison
+
+        ref_key = (url, source, tags)
+
+        if ref_key not in seen_refs:
+            seen_refs.add(ref_key)
             deduplicated.append(ref)
 
     return deduplicated

--- a/tests/unit/providers/nvd/test-fixtures/snapshots/single-entry/2022/cve-2022-1576.json
+++ b/tests/unit/providers/nvd/test-fixtures/snapshots/single-entry/2022/cve-2022-1576.json
@@ -95,6 +95,14 @@
             "Third Party Advisory"
           ],
           "url": "https://wpscan.com/vulnerability/68deab46-1c16-46ae-a912-a104958ca4cf"
+        },
+        {
+          "source": "af854a3a-2127-422b-91ae-364da2661108",
+          "tags": [
+            "Exploit",
+            "Third Party Advisory"
+          ],
+          "url": "https://wpscan.com/vulnerability/68deab46-1c16-46ae-a912-a104958ca4cf"
         }
       ],
       "sourceIdentifier": "contact@wpscan.com",


### PR DESCRIPTION
Some NVD records have the same record over 400 times. Often, data has been fixed upstream but because the NVD provider only processes changed records, these fixes to old data aren't necessarily picked up. Therefore, deduplicate all references in NVD provider during finalization.

Note that the duplicates will still be present in the nvd-input.db in the cached workspaces.

Fixes https://github.com/anchore/grype-db/issues/742