### PR TITLE
ci: log ORAS pull progress

### DIFF
--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -904,7 +904,7 @@ def test_rhel_provider_supports_skip_download(mock_sync_cves, helpers, auto_fake
     assert mock_sync_cves.call_count == 0
 
 @patch("vunnel.providers.rhel.parser.http.get")
-def test_rhel_provider_supports_ignore_hydra_errors(mock_http_get, helpers):
+def test_rhel_provider_supports_ignore_hydra_errors(mock_http_get, helpers, auto_fake_fixdate_finder):
 
     workspace = helpers.provider_workspace_helper(
         name=Provider.name(),

--- a/tests/unit/tool/test_grype_db_first_observed.py
+++ b/tests/unit/tool/test_grype_db_first_observed.py
@@ -224,7 +224,7 @@ class TestStore:
         )
         assert len(results) == 1
 
-    @patch("oras.client.OrasClient")
+    @patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient")
     def test_download_success(self, mock_oras_client_class, tmpdir):
         # create workspace and store
         ws = workspace.Workspace(tmpdir, "test-db", create=True)
@@ -254,7 +254,7 @@ class TestStore:
         # verify the file was moved to the correct location
         assert store.db_path.exists()
 
-    @patch("oras.client.OrasClient")
+    @patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient")
     def test_download_failure(self, mock_oras_client_class, tmpdir):
         # create workspace and store
         ws = workspace.Workspace(tmpdir, "test-db", create=True)
@@ -269,7 +269,7 @@ class TestStore:
         with pytest.raises(Exception, match="Download failed"):
             store.download()
 
-    @patch("oras.client.OrasClient")
+    @patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient")
     def test_download_not_found(self, mock_oras_client_class, tmpdir):
         # create workspace and store
         ws = workspace.Workspace(tmpdir, "test-db", create=True)
@@ -299,7 +299,7 @@ class TestStore:
         # ensure directory doesn't exist initially
         assert not store.db_path.parent.exists()
 
-        with patch("oras.client.OrasClient") as mock_oras_client_class:
+        with patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient") as mock_oras_client_class:
             mock_client = Mock()
             mock_oras_client_class.return_value = mock_client
 
@@ -316,7 +316,7 @@ class TestStore:
             # verify directory was created
             assert store.db_path.parent.exists()
 
-    @patch("oras.client.OrasClient")
+    @patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient")
     def test_get_after_not_found_download(self, mock_oras_client_class, tmpdir):
         # create workspace and store
         ws = workspace.Workspace(tmpdir, "test-db", create=True)
@@ -338,7 +338,7 @@ class TestStore:
         )
         assert results == []
 
-    @patch("oras.client.OrasClient")
+    @patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient")
     def test_find_after_not_found_download(self, mock_oras_client_class, tmpdir):
         # create workspace and store
         ws = workspace.Workspace(tmpdir, "test-db", create=True)
@@ -360,7 +360,7 @@ class TestStore:
         )
         assert results == []
 
-    @patch("oras.client.OrasClient")
+    @patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient")
     def test_get_changed_vuln_ids_since_after_not_found(self, mock_oras_client_class, tmpdir):
         # create workspace and store
         ws = workspace.Workspace(tmpdir, "test-db", create=True)
@@ -393,7 +393,7 @@ class TestStore:
             )
 
     @patch.dict('os.environ', {'GITHUB_TOKEN': 'test-token'})
-    @patch("oras.client.OrasClient")
+    @patch("vunnel.tool.fixdate.grype_db_first_observed._ProgressLoggingOrasClient")
     def test_download_with_github_token(self, mock_oras_client_class, tmpdir):
         # create workspace and store
         ws = workspace.Workspace(tmpdir, "test-db", create=True)


### PR DESCRIPTION
Otherwise, CI appears to just sit there while downloading 10GB databases.

Output looks like this:

```
❯ GITHUB_TOKEN=$(gh auth token) vunnel -v run nvd
[DEBUG] discovered plugins: 0
[INFO ] running nvd provider
[DEBUG] config: Config(runtime=RuntimeConfig(on_error=OnErrorConfig(action=fail, retry_count=3, retry_delay=5, input=keep, results=keep), existing_input=keep, existing_results=keep, result_store=sqlite, skip_newer_archive_check=False, skip_download=False, import_results_host='', import_results_path='providers/{provider_name}/listing.json', import_results_enabled=False), request_timeout=125, request_retry_count=10, api_key='', overrides_url='https://github.com/anchore/nvd-data-overrides/archive/refs/heads/main.tar.gz', overrides_enabled=False)
[DEBUG] using './data/nvd' as workspace
[DEBUG] using existing input workspace './data/nvd/input'
[DEBUG] using existing results workspace './data/nvd/results'
[DEBUG] authenticated with GitHub Container Registry using GITHUB_TOKEN
[INFO ] pulling fix date database from ghcr.io/anchore/grype-db-observed-fix-date/nvd:latest
[DEBUG] downloaded 461.4 MB of 9227.4 MB (5.0%)
[DEBUG] downloaded 922.7 MB of 9227.4 MB (10.0%)
[DEBUG] downloaded 1384.1 MB of 9227.4 MB (15.0%)
...
```