### PR TITLE
ci: drop vunel-specific qg runner

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -30,22 +30,6 @@ runners:
     spot: false
     extras: s3-cache
 
-  # quality-gate: beefy runners for vulnerability data processing
-  # - downloading and processing large vulnerability databases
-  # - running provider validation against real-world data sets
-  # - 2 CPUs sufficient (Python I/O-bound workloads)
-  # disk: 40GB (default)
-  quality-gate:
-    cpu: 2
-    ram: [16, 32]
-    family:
-      - "r7*"   # memory-optimized gen 7 (* = all sizes)
-      - "r6i*"  # memory-optimized gen 6 Intel
-      - "m7*"   # general-purpose gen 7
-      - "m6i*"  # general-purpose gen 6 Intel
-    spot: false
-    extras: s3-cache
-
   # release: reliable on-demand runners for production deployments
   # - tagging releases
   # - publishing to PyPI


### PR DESCRIPTION
There is a central definition of this runner over in the workflows repo. Drop the vunnel-specific runner of this name in favor of the central config.

The definition in vunnel is shadowing this one:

https://github.com/anchore/workflows/blob/1c6568eb1e45456271570411baedc438930b6d83/.github/runs-on.yml#L31-L45

Which had more space added. Use the one with more space.

Note that this change will have no effect until it's on `main` since that's how runs-on works.