### PR TITLE
Use runs-on action for upload-artifact to function

### DIFF
--- a/.github/actions/quality-gate/action.yaml
+++ b/.github/actions/quality-gate/action.yaml
@@ -10,6 +10,10 @@ runs:
   steps:
     # assume we have python and uv installed
 
+    # required for magic-cache from runs-on to function with artifact upload/download (see https://runs-on.com/caching/magic-cache/#actionsupload-artifact-compatibility)
+    - uses: runs-on/action@v2
+      shell: bash
+
     - name: Capture vulnerability results
       shell: bash
       working-directory: tests/quality


### PR DESCRIPTION
Any workflow that uses runs-on runners as well as upload-artifact requires an action to function together correctly when using the magic cache feature (see [the docs](https://runs-on.com/caching/magic-cache/#actionsupload-artifact-compatibility)).