### PR TITLE
Development guide, uv sync requires python 3.11 or newer.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -3,7 +3,7 @@
 ## Getting Started
 
 This project requires:
-- python (>= 3.7)
+- python (>= 3.11)
 - pip (>= 22.2)
 - uv
 - docker


### PR DESCRIPTION
With python 3.10, uv sync results in this error:

```
Failed to build `untokenize==0.1.1`
```