### PR TITLE
Use crane auth login

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -60,6 +60,10 @@ runs:
       shell: bash
       run: make bootstrap
 
+    - name: Add tools dir to PATH
+      shell: bash
+      run: echo "$(pwd)/.tool" >> $GITHUB_PATH
+
     - name: Install apt packages
       if: inputs.bootstrap-apt-packages != ''
       shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -161,7 +161,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          echo "$GITHUB_TOKEN" | oras login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          echo "$GITHUB_TOKEN" | crane auth login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
           echo "$GITHUB_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
 
       - name: Promote commit image to release


### PR DESCRIPTION
From https://github.com/anchore/vunnel/actions/runs/19827981779

```
Run echo "$GITHUB_TOKEN" | oras login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
/home/runner/work/_temp/570f4754-8c88-4037-ac3e-0b03d7329842.sh: line 1: oras: command not found
```

But we are not using oras here at all (crane needs to be logged in)