### PR TITLE
ci: run highly concurrent providers (ubuntu) on big runner

### DIFF
--- a/.github/workflows/nightly-quality-gate.yaml
+++ b/.github/workflows/nightly-quality-gate.yaml
@@ -5,13 +5,12 @@ on:
 
   # run 5 AM (UTC) daily
   schedule:
-    - cron:  '0 5 * * *'
+    - cron: "0 5 * * *"
 
 permissions:
   contents: read
 
 jobs:
-
   select-providers:
     runs-on: runs-on=${{ github.run_id }}/runner=small
     outputs:
@@ -40,6 +39,9 @@ jobs:
 
       - name: Split providers by concurrency needs
         id: split-providers
+        # TODO: stop splitting providers based on a hard coded value. Maybe
+        # in the future something like `vunnel list --only-concurrent` could
+        # supply the values here. Hard code for now.
         run: |
           all_providers='${{ steps.determine-providers.outputs.providers }}'
           multicore_providers=$(echo "$all_providers" | jq -c '[.[] | select(. == "ubuntu")]')

--- a/.github/workflows/pr-quality-gate.yaml
+++ b/.github/workflows/pr-quality-gate.yaml
@@ -13,7 +13,6 @@ permissions:
   contents: read
 
 jobs:
-
   select-providers:
     runs-on: runs-on=${{ github.run_id }}/runner=small
     outputs:
@@ -46,6 +45,9 @@ jobs:
 
       - name: Split providers by concurrency needs
         id: split-providers
+        # TODO: stop splitting providers based on a hard coded value. Maybe
+        # in the future something like `vunnel list --only-concurrent` could
+        # supply the values here. Hard code for now.
         run: |
           all_providers='${{ steps.determine-providers.outputs.providers }}'
           multicore_providers=$(echo "$all_providers" | jq -c '[.[] | select(. == "ubuntu")]')
@@ -130,9 +132,9 @@ jobs:
   evaluate-quality-gate:
     runs-on: runs-on=${{ github.run_id }}/runner=small
     needs:
-     - validate-provider
-     - validate-provider-multicore
-     - select-providers
+      - validate-provider
+      - validate-provider-multicore
+      - select-providers
     if: ${{ always() }}
     steps:
       - env:


### PR DESCRIPTION
The ubuntu provider does a ton of local file I/O and can be meaningfully sped up by using the a large multi core runner and a higher number of workers. However many providers are essentially single threaded and do not benefit from the multicore runner.

Therfore, rearrange some yaml to put highly concurrent providers (today just Ubuntu) on a bit multi core runner without paying to put the rest of them on the big multi core runner.

Requires: https://github.com/anchore/vunnel/pull/940