### PR TITLE
chore: track chronicle config

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,0 +1,2 @@
+enforce-v0: true # don't make breaking-change label bump major version before 1.0.
+title: ""


### PR DESCRIPTION
Track a chronicle config that instructs chronicle not to  bump major versions on a breaking change, since this repo is pre 1.0.