### PR TITLE
fix: stop emitting ELS records for RHEL

### DIFF
--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -815,6 +815,8 @@ class Parser:
                 platform_artifacts[base_platform] = records
 
             for platform, artifacts in platform_artifacts.items():
+                if "+els" in platform:
+                    continue
                 ns = f"{namespace}:{platform}"
 
                 # if len(artifacts) == 1 and artifacts[0].advisory.severity and artifacts[0].advisory.severity != sev:

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -1031,3 +1031,11 @@ class TestExtendedSupportInference:
             "Expected bind package in rhel:6 FixedIn list. "
             "The package is fixed in RHEL 6 ELS Extension, so it should be marked as affected in regular RHEL 6."
         )
+
+        # Verify that ELS namespaces are NOT emitted (they cause unique constraint
+        # violations in older clients that strip the +els suffix)
+        els_results = [r for r in results if "+els" in r.namespace]
+        assert len(els_results) == 0, (
+            f"ELS namespaces should not be emitted, but found: {[r.namespace for r in els_results]}. "
+            "Old clients strip +els and get unique constraint violations with the base namespace."
+        )


### PR DESCRIPTION
A recent fix (572c538) added the inference of missing RHEL records. Essentially, if Red Hat claim that RHEL 6 ELS fixes package foo for CVE-1234, infer that package foo was vulnerable to CVE-1234 in non-ELS RHEL 6. As a side effect of this change, a fix version scoped to RHEL 6 ELS was emitted. However, versions of Grype before 0.97.0, when the channel column was added to the OS table, fail to import the resulting grype db due to a uniqueness constraint on the OS table, since for example RHEL 8 and RHEL 8 ELS look identical if there is no channel column to put the ELS value in.

Therefore, instead of emitting both the inferred wont-fix value and the ELS-only fixed version, emit only the inferred wont-fix value, so that false negatives are fixed but the uniqueness constraint in old versions of Grype is preserved.

See also:
- https://github.com/anchore/vunnel/pull/958
- https://github.com/anchore/grype/issues/3133