### PR TITLE
fix: commit sqlalchemy read operations

### DIFF
--- a/src/vunnel/tool/fixdate/vunnel_first_observed.py
+++ b/src/vunnel/tool/fixdate/vunnel_first_observed.py
@@ -127,6 +127,13 @@ class Store:
 
         results = conn.execute(query).fetchall()
 
+        # Commit to release any locks from the implicit transaction.
+        # This prevents "database is locked" errors when multiple threads
+        # read concurrently (e.g., RHEL provider's ThreadPoolExecutor).
+        # Note: this also commits any pending writes, which is safe since
+        # writes happen during download() before concurrent reads begin.
+        conn.commit()
+
         if not results:
             return []
 


### PR DESCRIPTION
Otherwise, these operations hold a lock, which in the RHEL provider causes the database to be locked for other threadpool threads trying to add fix dates to CVEs.

This takes only the fix out of https://github.com/anchore/vunnel/pull/970, and leaves behind workflow and other CI changes.

The reason is that these changes are being incredibly slow to validate, and I don't want to delay the. CI on #970 has already gotten past where I would expect it to fail if this fix is incorrect.

Note that this PR doesn't have the CI checks I want it to. Those are in #970, but that PR isn't going to get in before the weekend due to very slow CI issues over there unrelated to this change. So I'm tryin to get "just the fix" in via this PR and then I'll backfill tests and things next week.