### PR TITLE
tag appropriate providers as incremental

### DIFF
--- a/src/vunnel/providers/amazon/__init__.py
+++ b/src/vunnel/providers/amazon/__init__.py
@@ -55,7 +55,7 @@ class Provider(provider.Provider):
 
     @classmethod
     def tags(cls) -> list[str]:
-        return ["vulnerability", "os"]
+        return ["vulnerability", "os", "incremental"]
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
         with timer(self.name(), self.logger):

--- a/src/vunnel/providers/github/__init__.py
+++ b/src/vunnel/providers/github/__init__.py
@@ -66,7 +66,7 @@ class Provider(provider.Provider):
 
     @classmethod
     def tags(cls) -> list[str]:
-        return ["vulnerability", "language"]
+        return ["vulnerability", "language", "incremental"]
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
         with timer(self.name(), self.logger):

--- a/src/vunnel/providers/nvd/__init__.py
+++ b/src/vunnel/providers/nvd/__init__.py
@@ -85,7 +85,7 @@ class Provider(provider.Provider):
 
     @classmethod
     def tags(cls) -> list[str]:
-        return ["vulnerability"]
+        return ["vulnerability", "incremental"]
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
         with timer(self.name(), self.logger):

--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -74,6 +74,7 @@ class Provider(provider.Provider):
         return [
             "vulnerability",
             "os",
+            "incremental",
         ]
 
     @classmethod

--- a/src/vunnel/providers/ubuntu/__init__.py
+++ b/src/vunnel/providers/ubuntu/__init__.py
@@ -70,6 +70,7 @@ class Provider(provider.Provider):
             # the increased resource usage to reduce overall runtime.
             # This is particularly important for the ubuntu provider (which can take hours to run).
             "multicore",
+            "incremental",
         ]
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:


### PR DESCRIPTION
Now users can run "vunnel list --tag incremental" to see which providers will likely see decreased runtimes if invoked more frequently, because they perform incremental updates. For example, the github provider uses an updatedSince graphQL parameter and is therefore "incremental", whereas the SLES provider downloads and processes a large OVAL XML file from scratch every time it runs, and its therefore not incremental.

The intent is to allow users to configure vunnel so that incremental providers run more frequently.

``` sh
❯ uv run vunnel list --tag incremental
amazon
github
nvd
rhel
ubuntu
❯ uv run vunnel list --tag '!incremental'
alma
alpine
bitnami
chainguard
chainguard-libraries
debian
echo
epss
kev
mariner
minimos
oracle
rocky
sles
wolfi
```