### PR TITLE
fix: track alpine rejections

### DIFF
--- a/src/vunnel/providers/alpine/rejections.py
+++ b/src/vunnel/providers/alpine/rejections.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import yaml
+
+from vunnel.utils import http_wrapper as http
+
+if TYPE_CHECKING:
+    from vunnel import workspace
+
+
+class SecurityRejections:
+    """
+    Handles fetching and parsing security-rejections data from GitLab.
+
+    The security-rejections repository contains CVEs that Alpine has determined
+    do not affect Alpine packages (false positives). These are emitted as NAK
+    entries with Version: "0" to filter NVD CPE matches.
+    """
+
+    _db_types = ("main", "community")
+
+    def __init__(
+        self,
+        url: str,
+        workspace: workspace.Workspace,
+        logger: logging.Logger | None = None,
+        download_timeout: int = 125,
+    ):
+        self.url = url.rstrip("/")
+        self.workspace = workspace
+        self.download_timeout = download_timeout
+        if logger is None:
+            logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logger
+        self._rejections_dir = os.path.join(workspace.input_path, "security-rejections")
+        self._data: dict[str, dict[str, list[str]]] = {}  # {db_type: {package: [cve_ids]}}
+
+    def download(self) -> None:
+        """Download main.yaml and community.yaml from the security-rejections GitLab repo."""
+        os.makedirs(self._rejections_dir, exist_ok=True)
+
+        for db_type in self._db_types:
+            file_name = f"{db_type}.yaml"
+            download_url = f"{self.url}/{file_name}"
+            file_path = os.path.join(self._rejections_dir, file_name)
+
+            try:
+                self.logger.info(f"downloading security-rejections {db_type} from: {download_url}")
+                r = http.get(download_url, self.logger, stream=True, timeout=self.download_timeout)
+
+                with open(file_path, "wb") as fp:
+                    for chunk in r.iter_content():
+                        fp.write(chunk)
+
+            except Exception:
+                self.logger.warning(f"failed to download security-rejections {db_type}, continuing without it", exc_info=True)
+
+    def _load(self) -> None:
+        """Load downloaded YAML files into memory."""
+        self._data = {}
+
+        for db_type in self._db_types:
+            file_path = os.path.join(self._rejections_dir, f"{db_type}.yaml")
+            if not os.path.exists(file_path):
+                self.logger.debug(f"security-rejections file not found: {file_path}")
+                continue
+
+            try:
+                with open(file_path) as fp:
+                    yaml_data = yaml.safe_load(fp)
+
+                if not yaml_data:
+                    continue
+
+                # The YAML structure is: {package_name: [cve_ids]}
+                # e.g., {"dnsmasq": ["CVE-2021-45951", "CVE-2021-45952"]}
+                rejections: dict[str, list[str]] = {}
+                for package, cve_list in yaml_data.items():
+                    if isinstance(cve_list, list):
+                        rejections[package] = cve_list
+                    else:
+                        self.logger.warning(f"unexpected format for package {package} in {db_type}.yaml")
+
+                self._data[db_type] = rejections
+                self.logger.debug(f"loaded {len(rejections)} packages with rejections from {db_type}.yaml")
+
+            except Exception:
+                self.logger.warning(f"failed to parse security-rejections {db_type}.yaml, continuing without it", exc_info=True)
+
+    def get(self, db_type: str) -> dict[str, list[str]]:
+        """
+        Return rejections for the given db_type as {package: [cve_ids]}.
+
+        Args:
+            db_type: The database type ("main" or "community")
+
+        Returns:
+            Dictionary mapping package names to lists of rejected CVE IDs
+        """
+        # Lazy-load data on first access
+        if not self._data:
+            self._load()
+
+        return self._data.get(db_type, {})

--- a/tests/unit/providers/alpine/test_rejections.py
+++ b/tests/unit/providers/alpine/test_rejections.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from vunnel import workspace
+from vunnel.providers.alpine.rejections import SecurityRejections
+
+
+class TestSecurityRejections:
+    @pytest.fixture()
+    def mock_main_yaml(self):
+        """Sample main.yaml content for security-rejections."""
+        return """dnsmasq:
+  - CVE-2021-45951
+  - CVE-2021-45952
+  - CVE-2021-45953
+nginx:
+  - CVE-2020-12345
+"""
+
+    @pytest.fixture()
+    def mock_community_yaml(self):
+        """Sample community.yaml content for security-rejections."""
+        return """some-package:
+  - CVE-2022-11111
+  - CVE-2022-22222
+"""
+
+    def test_load_parses_yaml_correctly(self, tmpdir, mock_main_yaml, mock_community_yaml):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        # Create the rejections directory and files manually
+        os.makedirs(rejections._rejections_dir, exist_ok=True)
+        with open(os.path.join(rejections._rejections_dir, "main.yaml"), "w") as fp:
+            fp.write(mock_main_yaml)
+        with open(os.path.join(rejections._rejections_dir, "community.yaml"), "w") as fp:
+            fp.write(mock_community_yaml)
+
+        # Test get() which should lazy-load the data
+        main_rejections = rejections.get("main")
+        assert "dnsmasq" in main_rejections
+        assert main_rejections["dnsmasq"] == ["CVE-2021-45951", "CVE-2021-45952", "CVE-2021-45953"]
+        assert "nginx" in main_rejections
+        assert main_rejections["nginx"] == ["CVE-2020-12345"]
+
+        community_rejections = rejections.get("community")
+        assert "some-package" in community_rejections
+        assert community_rejections["some-package"] == ["CVE-2022-11111", "CVE-2022-22222"]
+
+    def test_get_returns_empty_for_missing_file(self, tmpdir):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        # Create the rejections directory but no files
+        os.makedirs(rejections._rejections_dir, exist_ok=True)
+
+        # Should return empty dicts when files don't exist
+        assert rejections.get("main") == {}
+        assert rejections.get("community") == {}
+
+    def test_get_returns_empty_for_unknown_dbtype(self, tmpdir, mock_main_yaml):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        os.makedirs(rejections._rejections_dir, exist_ok=True)
+        with open(os.path.join(rejections._rejections_dir, "main.yaml"), "w") as fp:
+            fp.write(mock_main_yaml)
+
+        # Unknown db_type should return empty dict
+        assert rejections.get("unknown") == {}
+
+    def test_load_handles_malformed_yaml_gracefully(self, tmpdir):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        os.makedirs(rejections._rejections_dir, exist_ok=True)
+        with open(os.path.join(rejections._rejections_dir, "main.yaml"), "w") as fp:
+            fp.write("invalid: yaml: content: [")
+
+        # Should not raise, just return empty
+        result = rejections.get("main")
+        assert result == {}
+
+    def test_load_handles_unexpected_format(self, tmpdir):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        # YAML with non-list value for a package
+        yaml_content = """dnsmasq: not-a-list
+nginx:
+  - CVE-2020-12345
+"""
+        os.makedirs(rejections._rejections_dir, exist_ok=True)
+        with open(os.path.join(rejections._rejections_dir, "main.yaml"), "w") as fp:
+            fp.write(yaml_content)
+
+        # Should handle gracefully - skip malformed entries but keep valid ones
+        result = rejections.get("main")
+        assert "dnsmasq" not in result  # skipped due to bad format
+        assert "nginx" in result
+        assert result["nginx"] == ["CVE-2020-12345"]
+
+    def test_load_handles_empty_yaml(self, tmpdir):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        os.makedirs(rejections._rejections_dir, exist_ok=True)
+        with open(os.path.join(rejections._rejections_dir, "main.yaml"), "w") as fp:
+            fp.write("")
+
+        result = rejections.get("main")
+        assert result == {}
+
+    def test_download_creates_directory(self, tmpdir, monkeypatch):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        # Mock the HTTP get to avoid actual network calls
+        class MockResponse:
+            def iter_content(self):
+                return [b"dnsmasq:\n  - CVE-2021-45951\n"]
+
+        def mock_get(*args, **kwargs):
+            return MockResponse()
+
+        from vunnel.utils import http_wrapper
+
+        monkeypatch.setattr(http_wrapper, "get", mock_get)
+
+        rejections.download()
+
+        assert os.path.exists(rejections._rejections_dir)
+        assert os.path.exists(os.path.join(rejections._rejections_dir, "main.yaml"))
+        assert os.path.exists(os.path.join(rejections._rejections_dir, "community.yaml"))
+
+    def test_download_failure_logs_warning_but_continues(self, tmpdir, monkeypatch, caplog):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com",
+            workspace=ws,
+        )
+
+        def mock_get_fail(*args, **kwargs):
+            raise Exception("Network error")
+
+        from vunnel.utils import http_wrapper
+
+        monkeypatch.setattr(http_wrapper, "get", mock_get_fail)
+
+        # Should not raise
+        rejections.download()
+
+        # Check that warning was logged
+        assert any("failed to download security-rejections" in record.message for record in caplog.records)
+
+    def test_url_trailing_slash_stripped(self, tmpdir):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        rejections = SecurityRejections(
+            url="https://example.com/path/",
+            workspace=ws,
+        )
+
+        assert rejections.url == "https://example.com/path"


### PR DESCRIPTION

Alpine Linux has a separate repo where they reject CVEs that don't merit
further investigation or being tagged in their build system, such as
CVEs that are disputed upstream, or affect a package that coincidentally
has the same name as an APK. Previously, these extra rejections were
missed by vunnel, resulting in false positives in Grype. Therefore, pull
in these packages and emit NAKs for them for every Alpine version.

Fixes #1012
