### PR TITLE
perf: replace per-call I/O with in-memory indexes for overrides and fix-date lookups

### DIFF
--- a/NVD-PERF-ANALYSIS.md
+++ b/NVD-PERF-ANALYSIS.md
@@ -1,0 +1,70 @@
+# NVD Fix-Date Performance Analysis
+
+## Problem Summary
+
+Two related bottlenecks cause NVD provider syncs to run slowly, both sharing the same root cause: per-item I/O inside a hot loop.
+
+---
+
+## Bottleneck 1: `NVDOverrides.cve()` — Per-CVE File Reads
+
+**Location:** `src/vunnel/providers/nvd/overrides.py`
+
+**Root cause:** `cve()` maintained a filepath index (CVE ID → path on disk) but opened, read, and JSON-parsed the file on every single call. With ~250k CVEs in a full sync, that is ~250k `open()` + `json.loads()` calls — one per CVE lookup.
+
+A `# TODO: implement in-memory index` comment already marked the problem in the original code.
+
+**Fix:** Replace the filepath index with a fully parsed in-memory dict built once on first access. All subsequent `cve()` calls become O(1) dict lookups with zero I/O.
+
+---
+
+## Bottleneck 2: `GrypeDBStore.get()` — Per-CPE SQLite Queries
+
+**Location:** `src/vunnel/tool/fixdate/grype_db_first_observed.py`
+
+**Root cause:** `get()` executed an individual `SELECT` against the SQLite fix-date database for every `(vuln_id, cpe_or_package)` pair during NVD processing. Each CVE can have 5–20 CPE matches, and a full NVD sync processes ~250k CVEs, yielding:
+
+```
+250,000 CVEs × 5–20 CPE matches = 1,250,000 – 5,000,000 SQLite queries per sync
+```
+
+Each query incurred:
+- Python → SQLAlchemy → SQLite3 driver overhead
+- A full query plan execution (even with indexes)
+- Result deserialization
+
+At even 0.1 ms per query, 2.5M queries = ~4 minutes of pure SQLite overhead.
+
+**Scale of the problem:** The fix-date database typically contains tens of thousands of rows (one per CVE/package combination where a fix date was observed). The entire table fits comfortably in memory.
+
+---
+
+## Fix: Bulk-Load Both into Memory at Startup
+
+The fix for both bottlenecks is the same pattern: **load once, look up in O(1)**.
+
+### NVDOverrides fix
+
+`_build_data_by_cve()` globs all `CVE-*.json` files, reads and parses each once, and stores the result in `__data_by_cve__: dict[str, Any]`. The dict is populated lazily on first call and reused for all subsequent `cve()` calls.
+
+### GrypeDBStore fix
+
+`_build_index()` executes a single `SELECT * FROM fixdates` after the ORAS download completes, then splits the results into two in-memory dicts:
+
+- `_cpe_index`: keyed by `(vuln_id.lower(), full_cpe.lower())`
+- `_pkg_index`: keyed by `(vuln_id.lower(), package_name.lower(), ecosystem.lower())`
+
+`get()` is replaced with dict lookups against these indexes. The index is built lazily on first `get()` call, ensuring it works correctly whether or not the download was a no-op (digest cache hit).
+
+The SQLAlchemy connection infrastructure (`_get_connection`, `cleanup_thread_connections`) is retained — it is still required by `get_changed_vuln_ids_since()`, which queries the `runs` table separately.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/vunnel/providers/nvd/overrides.py` | In-memory JSON dict; remove per-call file reads |
+| `src/vunnel/tool/fixdate/grype_db_first_observed.py` | Add `_build_index()`, replace `get()` with dict lookup |
+| `tests/unit/providers/nvd/test_overrides.py` | Update field name, add in-memory assertion |
+| `tests/unit/tool/test_grype_db_first_observed.py` | Add index-based test |

--- a/tests/unit/providers/nvd/test_overrides.py
+++ b/tests/unit/providers/nvd/test_overrides.py
@@ -35,7 +35,7 @@ def test_overrides_disabled(mock_requests, tmpdir):
         url="http://localhost:8080/failed",
         workspace=workspace.Workspace(tmpdir, "test", create=True),
     )
-    subject.__filepaths_by_cve__ = {"CVE-2020-0000": '{"fail": true}'}
+    subject.__data_by_cve__ = {"CVE-2020-0000": {"fail": True}}
 
     # ensure requests.get is not called
     subject.download()
@@ -59,3 +59,10 @@ def test_overrides_enabled(mock_requests, overrides_tar, tmpdir):
 
     assert subject.cve("CVE-2011-0022") is not None
     assert subject.cves() == ["CVE-2011-0022"]
+
+    # verify the data is cached in memory — subsequent calls must not re-read files
+    assert subject.__data_by_cve__ is not None
+    assert "CVE-2011-0022" in subject.__data_by_cve__
+    first_call_data = subject.cve("CVE-2011-0022")
+    second_call_data = subject.cve("CVE-2011-0022")
+    assert first_call_data is second_call_data  # same object, no re-parse


### PR DESCRIPTION
## What and why

Two separate code paths were doing per-item I/O inside hot loops, causing several minutes of avoidable overhead per sync.

- **`GrypeDBStore.get()`** affects all providers (every provider calls `default_finder` which uses `GrypeDBStore`)
- **`NVDOverrides.cve()`** is NVD-specific

---

## Changes

### 1. `GrypeDBStore.get()` — 1–5M SQLite queries eliminated (all providers)

**Before:** one `SELECT` per `(vuln_id, cpe_or_package)` pair. Each CVE can have 5–20 CPE matches:

```
250,000 CVEs × 5–20 CPE matches ≈ 1.25M–5M queries per sync
```

**After:** `_build_index()` bulk-loads the entire fixdates table once into two in-memory dicts keyed by `(vuln_id, cpe)` and `(vuln_id, package, ecosystem)`. Subsequent `get()` calls are two dict lookups via `_ensure_index()`, which uses `threading.Lock()` with double-checked locking (both index vars checked to prevent partial-init reads under concurrency).

> No `WHERE provider = ...` filter is applied: each `Store` downloads from a provider-scoped OCI image (`ghcr.io/anchore/grype-db-observed-fix-date/{provider}`), so the database only ever contains rows for one provider.

### 2. `NVDOverrides.cve()` — per-CVE file reads eliminated (NVD only)

**Before:** a filepath index (CVE ID → path) was built once, but the file was opened, read, and JSON-parsed on every call. A `# TODO: implement in-memory index` comment already flagged this.

**After:** `_build_data_by_cve()` globs and parses all `CVE-*.json` files once on first access via `_ensure_loaded()`, which also uses `threading.Lock()` with double-checked locking for safe concurrent access.

---

## Test plan

- [x] `test_overrides_enabled` — cache populated; repeated calls return the same object (no re-parse)
- [x] `test_get_uses_in_memory_index` — `_build_index()` called exactly once regardless of call count
- [x] Full unit suite: `uv run pytest tests/unit/` (779 passed)
- [x] Linting: `uv run ruff check src/` (clean)