### PR TITLE
chore(quality-gate): fix hummingbird quality gate

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -248,6 +248,8 @@ tests:
     validations:
       - <<: *default-validations
         max_year: 2026 # hummingbird is new
+        max_unlabeled_percent: 25
+
 
   - provider: mariner
     use_cache: true


### PR DESCRIPTION
Because there are so few matches for hummingbird (because it is very new and minimal) any new match tends to push it over the 10% threshhold. Raise the threshhold to 25%. Also, bump labels to pull in new hummingbird data so that there's nothing unlabeled right now.