### PR TITLE
feat(rhel): handle "Not affected" status

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -4,7 +4,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.25.x"
+    default: "1.26.x"
   python-version:
     description: "Python version to install"
     required: true

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -650,9 +650,18 @@ class Parser:
                             advisory=Advisory(wont_fix=True, rhsa_id=None, link=None, severity=None),
                         ),
                     )
+                elif state in ["Not affected"]:
+                    affected.append(
+                        FixedIn(
+                            platform=platform,
+                            package=package_name,
+                            version="0",
+                            module=module,
+                            advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        ),
+                    )
                 elif state in [
                     "New",
-                    "Not affected",
                     "Under investigation",
                 ]:
                     continue

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from datetime import UTC
 from datetime import datetime as dt
 from decimal import Decimal as D
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import orjson
 from cvss import CVSS3
@@ -598,9 +598,21 @@ class Parser:
 
         return package_name, module
 
+    # Maps fix_state values to (version, wont_fix, target_list_key) where target_list_key
+    # selects which list the FixedIn is appended to ("affected" or "out_of_support").
+    # States not present here are skipped.
+    _fix_state_map_: ClassVar[dict[str, tuple[str, bool, str]]] = {
+        "Affected": ("None", False, "affected"),
+        "Fix deferred": ("None", False, "affected"),
+        "Will not fix": ("None", True, "affected"),
+        "Out of support scope": ("None", True, "out_of_support"),
+        "Not affected": ("0", False, "affected"),
+    }
+
     def _parse_package_state(self, cve_id: str, content) -> list[FixedIn]:
         affected: list[FixedIn] = []
         out_of_support: list[FixedIn] = []  # Track items out of support to be able to add them if others are affected
+        lists = {"affected": affected, "out_of_support": out_of_support}
         pss = content.get("package_state", [])
 
         for item in pss:
@@ -620,54 +632,20 @@ class Parser:
                     continue
 
                 state = item.get("fix_state", None)
-                if state in ["Affected", "Fix deferred"]:
-                    affected.append(
+                mapping = self._fix_state_map_.get(state)
+                if mapping:
+                    version, wont_fix, target = mapping
+                    lists[target].append(
                         FixedIn(
                             platform=platform,
                             package=package_name,
-                            version="None",
+                            version=version,
                             module=module,
-                            advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                            advisory=Advisory(wont_fix=wont_fix, rhsa_id=None, link=None, severity=None),
                         ),
                     )
-                elif state in ["Will not fix"]:
-                    affected.append(
-                        FixedIn(
-                            platform=platform,
-                            package=package_name,
-                            version="None",
-                            module=module,
-                            advisory=Advisory(wont_fix=True, rhsa_id=None, link=None, severity=None),
-                        ),
-                    )
-                elif state in ["Out of support scope"]:
-                    out_of_support.append(
-                        FixedIn(
-                            platform=platform,
-                            package=package_name,
-                            version="None",
-                            module=module,
-                            advisory=Advisory(wont_fix=True, rhsa_id=None, link=None, severity=None),
-                        ),
-                    )
-                elif state in ["Not affected"]:
-                    affected.append(
-                        FixedIn(
-                            platform=platform,
-                            package=package_name,
-                            version="0",
-                            module=module,
-                            advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
-                        ),
-                    )
-                elif state in [
-                    "New",
-                    "Under investigation",
-                ]:
-                    continue
-                else:
+                elif state not in ("New", "Under investigation"):
                     self.logger.debug(f"{state!r} is an unknown state")
-                    continue
             except Exception:
                 self.logger.exception(f"error parsing {cve_id} package state entity: {item}")
 

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2019-25059.json
@@ -1,0 +1,40 @@
+{
+  "identifier": "rhel:6/cve-2019-25059",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [
+        {
+          "base_metrics": {
+            "base_score": 7.8,
+            "base_severity": "High",
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "status": "draft",
+          "vector_string": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "version": "3.1"
+        }
+      ],
+      "Description": "Artifex Ghostscript through 9.26 mishandles .completefont. NOTE: this issue exists because of an incomplete fix for CVE-2019-3839.",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "ghostscript",
+          "NamespaceName": "rhel:6",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2019-25059",
+      "Metadata": {},
+      "Name": "CVE-2019-25059",
+      "NamespaceName": "rhel:6",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2019-25059.json
@@ -1,0 +1,40 @@
+{
+  "identifier": "rhel:7/cve-2019-25059",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [
+        {
+          "base_metrics": {
+            "base_score": 7.8,
+            "base_severity": "High",
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "status": "draft",
+          "vector_string": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "version": "3.1"
+        }
+      ],
+      "Description": "Artifex Ghostscript through 9.26 mishandles .completefont. NOTE: this issue exists because of an incomplete fix for CVE-2019-3839.",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "ghostscript",
+          "NamespaceName": "rhel:7",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2019-25059",
+      "Metadata": {},
+      "Name": "CVE-2019-25059",
+      "NamespaceName": "rhel:7",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
@@ -18,6 +18,17 @@
       "Description": "A heap-based buffer flaw was found in the way libwebp, a library used to process \"WebP\" image format data, processes certain specially formatted WebP images. An attacker could use this flaw to crash or execute remotely arbitrary code in an application such as a web browser compiled with this library.",
       "FixedIn": [
         {
+          "Module": null,
+          "Name": "libwebp",
+          "NamespaceName": "rhel:7",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        },
+        {
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
@@ -18,6 +18,17 @@
       "Description": "This CVE ID has been rejected by its CVE Numbering Authority. Duplicate of CVE-2023-4863.",
       "FixedIn": [
         {
+          "Module": null,
+          "Name": "libwebp",
+          "NamespaceName": "rhel:7",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        },
+        {
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
@@ -18,6 +18,17 @@
       "Description": "A heap-based buffer overflow flaw was found in the way libvpx, a library used to process VP8 and VP9 video codecs data, processes certain specially formatted video data via a crafted HTML page. This flaw allows an attacker to crash or remotely execute arbitrary code in an application, such as a web browser that is compiled with this library.",
       "FixedIn": [
         {
+          "Module": null,
+          "Name": "libvpx",
+          "NamespaceName": "rhel:7",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        },
+        {
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16588.json
@@ -1,0 +1,40 @@
+{
+  "identifier": "rhel:8/cve-2020-16588",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [
+        {
+          "base_metrics": {
+            "base_score": 5.5,
+            "base_severity": "Medium",
+            "exploitability_score": 1.8,
+            "impact_score": 3.6
+          },
+          "status": "draft",
+          "vector_string": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+          "version": "3.1"
+        }
+      ],
+      "Description": "A Null Pointer Deference issue exists in Academy Software Foundation OpenEXR 2.3.0 in generatePreview in makePreview.cpp that can cause a denial of service via a crafted EXR file.",
+      "FixedIn": [
+        {
+          "Module": null,
+          "Name": "OpenEXR",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2020-16588",
+      "Metadata": {},
+      "Name": "CVE-2020-16588",
+      "NamespaceName": "rhel:8",
+      "Severity": "Low"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-2309.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-2309.json
@@ -1,0 +1,62 @@
+{
+  "identifier": "rhel:8/cve-2022-2309",
+  "item": {
+    "Vulnerability": {
+      "CVSS": [
+        {
+          "base_metrics": {
+            "base_score": 7.5,
+            "base_severity": "High",
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "status": "verified",
+          "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "version": "3.1"
+        }
+      ],
+      "Description": "A NULL Pointer dereference vulnerability found in lxml, caused by the iterwalk function (also used by the canonicalize function). This flaw can lead to a crash when the incorrect parser input occurs together with usages.",
+      "FixedIn": [
+        {
+          "Module": "python38:3.8",
+          "Name": "python-lxml",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        },
+        {
+          "Module": "python39:3.9",
+          "Name": "python-lxml",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        },
+        {
+          "Module": null,
+          "Name": "python-lxml",
+          "NamespaceName": "rhel:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "rpm"
+        }
+      ],
+      "Link": "https://access.redhat.com/security/cve/CVE-2022-2309",
+      "Metadata": {},
+      "Name": "CVE-2022-2309",
+      "NamespaceName": "rhel:8",
+      "Severity": "Medium"
+    }
+  },
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+}

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -771,7 +771,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_f
 
     p.update(None)
 
-    assert workspace.num_result_entries() == 70
+    assert workspace.num_result_entries() == 74
     # < test results directory >
     # ├── rhel:5
     # │   ├── cve-2017-3509.json
@@ -787,6 +787,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_f
     # │   ├── cve-2017-3533.json
     # │   ├── cve-2017-3539.json
     # │   ├── cve-2017-3544.json
+    # │   ├── cve-2019-25059.json
     # │   ├── cve-2020-16587.json
     # │   ├── cve-2020-16588.json
     # │   ├── cve-2021-20298.json
@@ -806,6 +807,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_f
     # │   ├── cve-2017-3533.json
     # │   ├── cve-2017-3539.json
     # │   ├── cve-2017-3544.json
+    # │   ├── cve-2019-25059.json
     # │   ├── cve-2020-16587.json
     # │   ├── cve-2020-16588.json
     # │   ├── cve-2021-20298.json
@@ -821,6 +823,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_f
     # ├── rhel:8
     # │   ├── cve-2019-25059.json
     # │   ├── cve-2020-16587.json
+    # │   ├── cve-2020-16588.json
     # │   ├── cve-2021-20298.json
     # │   ├── cve-2021-20299.json
     # │   ├── cve-2022-1921.json
@@ -828,6 +831,7 @@ def test_provider_schema(helpers, disable_get_requests, monkeypatch, auto_fake_f
     # │   ├── cve-2022-1923.json
     # │   ├── cve-2022-1924.json
     # │   ├── cve-2022-1925.json
+    # │   ├── cve-2022-2309.json
     # │   ├── cve-2023-4863.json
     # │   ├── cve-2023-5129.json
     # │   └── cve-2023-5217.json

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -690,6 +690,47 @@ class TestParser:
         assert fixed_in.version == "None"
         assert fixed_in.advisory.wont_fix is True
 
+    def test_parse_package_state_not_affected_with_module(self, tmpdir):
+        """A 'Not affected' entry with RPM modularity (e.g. python38:3.8/python-lxml)
+        should emit a FixedIn with version '0' and the module preserved."""
+        cve = {
+            "name": "CVE-2099-0001",
+            "package_state": [
+                {
+                    "product_name": "Red Hat Enterprise Linux 8",
+                    "fix_state": "Not affected",
+                    "package_name": "python38:3.8/python-lxml",
+                    "cpe": "cpe:/o:redhat:enterprise_linux:8",
+                },
+                {
+                    "product_name": "Red Hat Enterprise Linux 8",
+                    "fix_state": "Not affected",
+                    "package_name": "python-lxml",
+                    "cpe": "cpe:/o:redhat:enterprise_linux:8",
+                },
+            ],
+        }
+        driver = Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
+        results = driver._parse_package_state(cve["name"], cve)
+
+        assert len(results) == 2
+
+        # modular entry
+        modular = [r for r in results if r.module == "python38:3.8"]
+        assert len(modular) == 1
+        assert modular[0].package == "python-lxml"
+        assert modular[0].platform == "8"
+        assert modular[0].version == "0"
+        assert modular[0].advisory.wont_fix is False
+
+        # non-modular entry
+        bare = [r for r in results if r.module is None]
+        assert len(bare) == 1
+        assert bare[0].package == "python-lxml"
+        assert bare[0].platform == "8"
+        assert bare[0].version == "0"
+        assert bare[0].advisory.wont_fix is False
+
     def test_parse_cve(self, tmpdir, mock_cve, auto_fake_fixdate_finder):
         driver = Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
         driver.rhsa_provider = OVALRHSAProvider.from_rhsa_dict({})


### PR DESCRIPTION
Previously, these CVEs were dropped. However, downstream consumers might like to distinguish between a search miss and an explicit "Not affected" record, so emit a "fixed in version 0" record in cases where rhel says the package is "Not affected".