### PR TITLE
feat(ubuntu): emit fixed ins for Not Affected records

### DIFF
--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -556,18 +556,37 @@ def map_parsed(parsed_cve: CVEFile, fixdater: fixdate.Finder, logger: logging.Lo
             r.NamespaceName = namespace_name
             vulns[namespace_name] = r
 
+        # Emit an explicit "not affected" FixedIn (version "0") so downstream consumers
+        # can distinguish "confirmed not affected" from "no data available".
+        if p.status == "not-affected":
+            pkg = FixedIn()
+            pkg.Name = p.package
+            pkg.Version = "0"
+            pkg.VendorAdvisory = {"NoAdvisory": False}
+            pkg.VersionFormat = "dpkg"
+            pkg.NamespaceName = namespace_name
+            r.FixedIn.append(pkg)
+            continue
+
         # If the patch status is one we care about, make the FixedIn record, else skip it but create CVE records
         # We currently want to mark end-of-support records with no previously known fix as vulnerable, hence the
         # or check_merge step here.
         if check_state(p.status) or check_merge(p):
             # If the patch is needs-triage but a corresponding ESM entry confirms
-            # the package is not affected, skip emitting a FixedIn record. This
-            # prevents false-positive match-all constraints for packages where
-            # Ubuntu's ESM review determined the vulnerable code is not present.
+            # the package is not affected, emit an explicit "not affected" FixedIn
+            # (version "0") instead of the match-all constraint that needs-triage
+            # would normally produce.
             if p.status == "needs-triage" and (p.distro, p.package) in esm_not_affected:
                 logger.debug(
-                    f"skipping needs-triage entry for {parsed_cve.name} {p.distro}/{p.package}: ESM variant confirms not-affected",
+                    f"emitting not-affected for {parsed_cve.name} {p.distro}/{p.package}: ESM variant confirms not-affected",
                 )
+                pkg = FixedIn()
+                pkg.Name = p.package
+                pkg.Version = "0"
+                pkg.VendorAdvisory = {"NoAdvisory": False}
+                pkg.VersionFormat = "dpkg"
+                pkg.NamespaceName = namespace_name
+                r.FixedIn.append(pkg)
                 continue
 
             pkg = FixedIn()

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:18.04/cve-2021-4204.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:18.04/cve-2021-4204.json
@@ -6,6 +6,16 @@
       "FixedIn": [
         {
           "Available": null,
+          "Name": "linux",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-hwe",
           "NamespaceName": "ubuntu:18.04",
           "VendorAdvisory": {
@@ -16,12 +26,42 @@
         },
         {
           "Available": null,
+          "Name": "linux-hwe-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-hwe-edge",
           "NamespaceName": "ubuntu:18.04",
           "VendorAdvisory": {
             "NoAdvisory": true
           },
           "Version": "None",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-kvm",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-aws",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {
@@ -46,6 +86,16 @@
         },
         {
           "Available": null,
+          "Name": "linux-aws-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-azure",
           "NamespaceName": "ubuntu:18.04",
           "VendorAdvisory": {
@@ -56,12 +106,42 @@
         },
         {
           "Available": null,
+          "Name": "linux-azure-4.15",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-azure-5.3",
           "NamespaceName": "ubuntu:18.04",
           "VendorAdvisory": {
             "NoAdvisory": true
           },
           "Version": "None",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-azure-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-dell300x",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {
@@ -86,12 +166,62 @@
         },
         {
           "Available": null,
+          "Name": "linux-gcp-4.15",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-gcp-5.3",
           "NamespaceName": "ubuntu:18.04",
           "VendorAdvisory": {
             "NoAdvisory": true
           },
           "Version": "None",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gcp-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gke-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gkeop-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oracle",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {
@@ -112,6 +242,56 @@
             "NoAdvisory": true
           },
           "Version": "None",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oracle-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-raspi2",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-raspi-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-snapdragon",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-ibm-5.4",
+          "NamespaceName": "ubuntu:18.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:20.04/cve-2019-17185.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:20.04/cve-2019-17185.json
@@ -3,7 +3,18 @@
   "item": {
     "Vulnerability": {
       "Description": "",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "freeradius",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://ubuntu.com/security/CVE-2019-17185",
       "Metadata": {},
       "Name": "CVE-2019-17185",

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:20.04/cve-2021-4204.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:20.04/cve-2021-4204.json
@@ -5,6 +5,16 @@
       "Description": "",
       "FixedIn": [
         {
+          "Available": null,
+          "Name": "linux",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
           "Available": {
             "Date": "2024-01-01",
             "Kind": "first-observed"
@@ -15,6 +25,26 @@
             "NoAdvisory": false
           },
           "Version": "5.11.0-46.51~20.04.1",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-kvm",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-aws",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {
@@ -31,6 +61,16 @@
           "VersionFormat": "dpkg"
         },
         {
+          "Available": null,
+          "Name": "linux-azure",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
           "Available": {
             "Date": "2024-01-01",
             "Kind": "first-observed"
@@ -44,6 +84,26 @@
           "VersionFormat": "dpkg"
         },
         {
+          "Available": null,
+          "Name": "linux-bluefield",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gcp",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
           "Available": {
             "Date": "2024-01-01",
             "Kind": "first-observed"
@@ -54,6 +114,46 @@
             "NoAdvisory": false
           },
           "Version": "5.11.0-1026.29~20.04.1",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gke",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gkeop",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-ibm",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oracle",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {
@@ -106,6 +206,16 @@
             "NoAdvisory": false
           },
           "Version": "5.14.0-1018.19",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-raspi",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {
@@ -194,6 +304,16 @@
           "VersionFormat": "dpkg"
         },
         {
+          "Available": null,
+          "Name": "linux-azure-fde",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
           "Available": {
             "Date": "2024-01-01",
             "Kind": "first-observed"
@@ -204,6 +324,96 @@
             "NoAdvisory": false
           },
           "Version": "5.13.0-1012.14~20.04.1",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-intel-iotg-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-lowlatency-hwe-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-hwe-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-aws-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gcp-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gke-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-azure-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oracle-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-azure-fde-5.15",
+          "NamespaceName": "ubuntu:20.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:20.10/cve-2019-17185.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:20.10/cve-2019-17185.json
@@ -3,7 +3,18 @@
   "item": {
     "Vulnerability": {
       "Description": "",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "freeradius",
+          "NamespaceName": "ubuntu:20.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://ubuntu.com/security/CVE-2019-17185",
       "Metadata": {},
       "Name": "CVE-2019-17185",

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:21.04/cve-2019-17185.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:21.04/cve-2019-17185.json
@@ -3,7 +3,18 @@
   "item": {
     "Vulnerability": {
       "Description": "",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "freeradius",
+          "NamespaceName": "ubuntu:21.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://ubuntu.com/security/CVE-2019-17185",
       "Metadata": {},
       "Name": "CVE-2019-17185",

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:21.10/cve-2019-17185.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:21.10/cve-2019-17185.json
@@ -3,7 +3,18 @@
   "item": {
     "Vulnerability": {
       "Description": "",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "freeradius",
+          "NamespaceName": "ubuntu:21.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://ubuntu.com/security/CVE-2019-17185",
       "Metadata": {},
       "Name": "CVE-2019-17185",

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.04/cve-2019-17185.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.04/cve-2019-17185.json
@@ -3,7 +3,18 @@
   "item": {
     "Vulnerability": {
       "Description": "",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "freeradius",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://ubuntu.com/security/CVE-2019-17185",
       "Metadata": {},
       "Name": "CVE-2019-17185",

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.04/cve-2021-4204.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.04/cve-2021-4204.json
@@ -6,6 +6,66 @@
       "FixedIn": [
         {
           "Available": null,
+          "Name": "linux",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-kvm",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-aws",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-azure",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gcp",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gke",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-gkeop",
           "NamespaceName": "ubuntu:22.04",
           "VendorAdvisory": {
@@ -16,12 +76,82 @@
         },
         {
           "Available": null,
+          "Name": "linux-ibm",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oracle",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-raspi",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-riscv",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-azure-fde",
           "NamespaceName": "ubuntu:22.04",
           "VendorAdvisory": {
             "NoAdvisory": false
           },
           "Version": "None",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-lowlatency",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oem-5.17",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-intel-iotg",
+          "NamespaceName": "ubuntu:22.04",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
           "VersionFormat": "dpkg"
         },
         {

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.10/cve-2019-17185.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.10/cve-2019-17185.json
@@ -3,7 +3,18 @@
   "item": {
     "Vulnerability": {
       "Description": "",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "freeradius",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://ubuntu.com/security/CVE-2019-17185",
       "Metadata": {},
       "Name": "CVE-2019-17185",

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.10/cve-2021-4204.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.10/cve-2021-4204.json
@@ -3,7 +3,118 @@
   "item": {
     "Vulnerability": {
       "Description": "",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Available": null,
+          "Name": "linux",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-kvm",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-aws",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-azure",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-gcp",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-ibm",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oracle",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-raspi",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-riscv",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-lowlatency",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
+          "Name": "linux-oem-5.17",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://ubuntu.com/security/CVE-2021-4204",
       "Metadata": {},
       "Name": "CVE-2021-4204",

--- a/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.10/cve-2022-20566.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/snapshots/ubuntu:22.10/cve-2022-20566.json
@@ -6,6 +6,16 @@
       "FixedIn": [
         {
           "Available": null,
+          "Name": "linux",
+          "NamespaceName": "ubuntu:22.10",
+          "VendorAdvisory": {
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        },
+        {
+          "Available": null,
           "Name": "linux-kvm",
           "NamespaceName": "ubuntu:22.10",
           "VendorAdvisory": {

--- a/tests/unit/providers/ubuntu/test_ubuntu.py
+++ b/tests/unit/providers/ubuntu/test_ubuntu.py
@@ -294,9 +294,9 @@ class TestUbuntuParser:
 
     def test_esm_not_affected_suppresses_needs_triage(self, fake_fixdate_finder):
         """When a needs-triage patch has a corresponding ESM ignored_patch with
-        not-affected status, map_parsed should NOT emit a FixedIn entry for that
-        package+namespace. This prevents false positives where grype would
-        otherwise match all versions due to the empty constraint from needs-triage.
+        not-affected status, map_parsed should emit a version="0" FixedIn entry
+        for that package+namespace instead of the match-all constraint that
+        needs-triage would normally produce.
 
         Uses normalized data from CVE-2023-5752 (literal output of the merge
         pipeline). Key entries in that file:
@@ -316,16 +316,14 @@ class TestUbuntuParser:
                 focal_vuln = v
                 break
 
-        # The focal record should either not exist or have an empty FixedIn list,
-        # because the ESM data tells us the code is not present.
-        if focal_vuln is not None:
-            fixed_pip = [f for f in focal_vuln.FixedIn if f.Name == "python-pip"]
-            assert fixed_pip == [], (
-                f"Expected no FixedIn for python-pip on focal because esm-apps/focal says not-affected, "
-                f"but got: {[f.json() for f in fixed_pip]}"
-            )
+        # The focal record should have a version="0" FixedIn for python-pip,
+        # signaling "not affected" to downstream consumers.
+        assert focal_vuln is not None, "Expected a vulnerability record for ubuntu:20.04 (focal)"
+        fixed_pip = [f for f in focal_vuln.FixedIn if f.Name == "python-pip"]
+        assert len(fixed_pip) == 1, f"Expected exactly one FixedIn for python-pip on focal, got: {[f.json() for f in fixed_pip]}"
+        assert fixed_pip[0].Version == "0", f"Expected version '0' (not-affected), got: {fixed_pip[0].Version}"
 
-        # Verify jammy (not-affected in patches) still gets a record with empty FixedIn
+        # Verify jammy (not-affected in patches) also gets a version="0" FixedIn
         jammy_vuln = None
         for v in vulns:
             if v.NamespaceName == "ubuntu:22.04":
@@ -333,7 +331,8 @@ class TestUbuntuParser:
                 break
         assert jammy_vuln is not None, "Expected a vulnerability record for ubuntu:22.04 (jammy)"
         jammy_pip = [f for f in jammy_vuln.FixedIn if f.Name == "python-pip"]
-        assert jammy_pip == [], "jammy python-pip is not-affected, should have no FixedIn entry"
+        assert len(jammy_pip) == 1, f"Expected exactly one FixedIn for python-pip on jammy, got: {[f.json() for f in jammy_pip]}"
+        assert jammy_pip[0].Version == "0", f"Expected version '0' (not-affected), got: {jammy_pip[0].Version}"
 
     def test_esm_not_affected_version_string_does_not_suppress(self, fake_fixdate_finder):
         """When the ESM not-affected entry has a version string (e.g. a kernel


### PR DESCRIPTION
Previously, the ubuntu provider would drop records where upstream data indicated that a package was not affected by a CVE; however, that leaves downstream consumers unable to distinguish between a search miss (no record of that CVE affecting that package) and a true "not affected" (the vendor examined their code and decided the vulnerability did not apply).

Instead, emit a FixedIn record that essentially says, "this was fixed at version 0" in situations where there upstream data indicates something is not affected.