### PR TITLE
feat(debian): emit fixed ins for version 0 records

### DIFF
--- a/src/vunnel/providers/debian/parser.py
+++ b/src/vunnel/providers/debian/parser.py
@@ -387,11 +387,16 @@ class Parser:
                             if "fixed_version" in distro_record:
                                 fixed_el["Version"] = distro_record["fixed_version"]
                                 if distro_record["fixed_version"] == "0":
-                                    # version == 0 should mean that the
-                                    # package was determined to not be
-                                    # vulnerable in the distro namespace
-                                    # (from reviewing
-                                    # https://security-tracker.debian.org/tracker/)
+                                    # version == 0 means the package was determined
+                                    # to not be vulnerable in this distro namespace.
+                                    # Emit an explicit "not affected" FixedIn so
+                                    # downstream consumers can distinguish this from
+                                    # "no data available".
+                                    fixed_el["VendorAdvisory"] = {
+                                        "NoAdvisory": False,
+                                        "AdvisorySummary": [],
+                                    }
+                                    vuln_record["Vulnerability"]["FixedIn"].append(fixed_el)
                                     skip_fixedin = True
                             else:
                                 fixed_el["Version"] = "None"

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2007-2383.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:10/cve-2007-2383.json
@@ -4,7 +4,18 @@
     "Vulnerability": {
       "CVSS": [],
       "Description": "The Prototype (prototypejs) framework before 1.5.1 RC3 exchanges data using JavaScript Object Notation (JSON) without an associated protection scheme, which allows remote attackers to obtain the data via a web page that retrieves the data through a URL in the SRC attribute of a SCRIPT element and captures the data using other JavaScript code, aka \"JavaScript Hijacking.\"",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Name": "prototypejs",
+          "NamespaceName": "debian:10",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://security-tracker.debian.org/tracker/CVE-2007-2383",
       "Metadata": {},
       "Name": "CVE-2007-2383",

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2007-2383.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:8/cve-2007-2383.json
@@ -4,7 +4,18 @@
     "Vulnerability": {
       "CVSS": [],
       "Description": "The Prototype (prototypejs) framework before 1.5.1 RC3 exchanges data using JavaScript Object Notation (JSON) without an associated protection scheme, which allows remote attackers to obtain the data via a web page that retrieves the data through a URL in the SRC attribute of a SCRIPT element and captures the data using other JavaScript code, aka \"JavaScript Hijacking.\"",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Name": "prototypejs",
+          "NamespaceName": "debian:8",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://security-tracker.debian.org/tracker/CVE-2007-2383",
       "Metadata": {},
       "Name": "CVE-2007-2383",

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2007-2383.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:9/cve-2007-2383.json
@@ -4,7 +4,18 @@
     "Vulnerability": {
       "CVSS": [],
       "Description": "The Prototype (prototypejs) framework before 1.5.1 RC3 exchanges data using JavaScript Object Notation (JSON) without an associated protection scheme, which allows remote attackers to obtain the data via a web page that retrieves the data through a URL in the SRC attribute of a SCRIPT element and captures the data using other JavaScript code, aka \"JavaScript Hijacking.\"",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Name": "prototypejs",
+          "NamespaceName": "debian:9",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://security-tracker.debian.org/tracker/CVE-2007-2383",
       "Metadata": {},
       "Name": "CVE-2007-2383",

--- a/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2007-2383.json
+++ b/tests/unit/providers/debian/test-fixtures/snapshots/debian:unstable/cve-2007-2383.json
@@ -4,7 +4,18 @@
     "Vulnerability": {
       "CVSS": [],
       "Description": "The Prototype (prototypejs) framework before 1.5.1 RC3 exchanges data using JavaScript Object Notation (JSON) without an associated protection scheme, which allows remote attackers to obtain the data via a web page that retrieves the data through a URL in the SRC attribute of a SCRIPT element and captures the data using other JavaScript code, aka \"JavaScript Hijacking.\"",
-      "FixedIn": [],
+      "FixedIn": [
+        {
+          "Name": "prototypejs",
+          "NamespaceName": "debian:unstable",
+          "VendorAdvisory": {
+            "AdvisorySummary": [],
+            "NoAdvisory": false
+          },
+          "Version": "0",
+          "VersionFormat": "dpkg"
+        }
+      ],
       "Link": "https://security-tracker.debian.org/tracker/CVE-2007-2383",
       "Metadata": {},
       "Name": "CVE-2007-2383",


### PR DESCRIPTION
Previously, the Debian provider would drop records where upstream data indicated a package was fixed at "version 0", since these records could never result in a vulnerability match in grype. However, this left downstream providers unable to distinguish between a "search miss" (upstream data has no mention of this CVE/package/distro version tuple) and an explicit indication of "not affected" (Debian maintainers believe this CVE/package/distro version tuple is not affected).

Instead, forward the idea of "fixed at version 0" into the results, so that downstream consumers can distinguish between a search miss and a package that maintainers believe is not affected.