### PR TITLE
feat(http): default User-Agent + treat 403+Retry-After as rate-limit (#1037)

### DIFF
--- a/src/vunnel/utils/http_wrapper.py
+++ b/src/vunnel/utils/http_wrapper.py
@@ -5,6 +5,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from email.utils import parsedate_to_datetime
+from importlib import metadata
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -23,6 +24,21 @@ DEFAULT_RATE_LIMIT_WAIT = 30.0
 MAX_RATE_LIMIT_WAIT = 300.0  # 5 minutes
 
 
+def default_user_agent() -> str:
+    """
+    Return the default User-Agent string used when a caller does not supply one.
+
+    Format follows the same convention as the per-provider helpers
+    (chainguard_libraries, secureos, fedora) so vunnel always identifies
+    itself when fetching upstream data sources.
+    """
+    try:
+        version = metadata.version("vunnel")
+    except metadata.PackageNotFoundError:
+        version = "unknown"
+    return f"anchore/vunnel-{version}"
+
+
 def _is_rate_limited(response: requests.Response) -> bool:
     """
     Check if response indicates rate limiting.
@@ -30,10 +46,15 @@ def _is_rate_limited(response: requests.Response) -> bool:
     Rate limiting is detected for:
     - 429 (Too Many Requests) - always
     - 503 (Service Unavailable) - only if Retry-After header is present
+    - 403 (Forbidden) - only if Retry-After header is present
+      (GitHub returns 403 + Retry-After for secondary rate limits;
+      see https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
     """
     if response.status_code == 429:
         return True
-    return response.status_code == 503 and bool(response.headers.get("Retry-After"))
+    if response.status_code in (403, 503):
+        return bool(response.headers.get("Retry-After"))
+    return False
 
 
 def parse_retry_after(header_value: str | None) -> float | None:
@@ -184,7 +205,7 @@ def _extract_hostname(url: str) -> str:
     return hostname if hostname else "unknown"
 
 
-def get(  # noqa: PLR0913, C901
+def get(  # noqa: PLR0913, PLR0915, C901
     url: str,
     logger: logging.Logger,
     retries: int = 5,
@@ -200,11 +221,11 @@ def get(  # noqa: PLR0913, C901
 
     Features:
         - Per-host connection pooling (TCP connection reuse)
-        - Rate limit handling with Retry-After support (429, 503 with header)
+        - Rate limit handling with Retry-After support (429 always; 403 / 503 with header)
         - Exponential backoff on errors
 
     Response handling follows a 3-step fallback:
-        1. Rate limit check (always enforced) - 429 or 503 with Retry-After
+        1. Rate limit check (always enforced) - 429, or 403 / 503 with Retry-After
         2. status_handler (if provided) - caller controls validation
         3. raise_for_status() - default validation with retry on HTTPError
 
@@ -219,7 +240,9 @@ def get(  # noqa: PLR0913, C901
             If the Callable does not raise, the response will be returned, and the caller is responsible for any
             further validation.
             If no Callable is provided, `raise_for_status` is called on the response instead.
-        user_agent: the User-Agent header value. If None or empty, no User-Agent header is set.
+        user_agent: the User-Agent header value. If None (the default), the wrapper sets
+            a vunnel-identifying User-Agent so we always identify ourselves to upstream
+            servers; pass an empty string to skip the header entirely.
         **kwargs: additional args are passed to requests.get unchanged.
     Raises:
         If retries are exhausted, re-raises the exception from the last requests.get attempt.
@@ -230,7 +253,11 @@ def get(  # noqa: PLR0913, C901
 
     """
     headers = kwargs.pop("headers", {})
-    if user_agent:
+    if user_agent is None:
+        # Default: always identify ourselves so providers and upstreams can attribute traffic.
+        # Callers that need to opt out can pass user_agent="".
+        headers.setdefault("User-Agent", default_user_agent())
+    elif user_agent:
         headers["User-Agent"] = user_agent
 
     hostname = _extract_hostname(url)

--- a/tests/unit/utils/test_http_wrapper.py
+++ b/tests/unit/utils/test_http_wrapper.py
@@ -82,13 +82,22 @@ class TestGetRequests:
         mock_sleep.assert_called_with(22.1)
         mock_logger.warning.assert_called()
         mock_logger.error.assert_not_called()
-        mock_session_get.assert_called_with("http://example.com/some-path", timeout=http.DEFAULT_TIMEOUT, headers={})
+        # When user_agent is None (default) the wrapper now identifies itself.
+        mock_session_get.assert_called_with(
+            "http://example.com/some-path",
+            timeout=http.DEFAULT_TIMEOUT,
+            headers={"User-Agent": http.default_user_agent()},
+        )
 
     @patch("requests.Session.get")
     def test_timeout_is_passed_in(self, mock_session_get, mock_logger, success_response):
         mock_session_get.return_value = success_response
         http.get("http://example.com/some-path", mock_logger, timeout=12345)
-        mock_session_get.assert_called_with("http://example.com/some-path", timeout=12345, headers={})
+        mock_session_get.assert_called_with(
+            "http://example.com/some-path",
+            timeout=12345,
+            headers={"User-Agent": http.default_user_agent()},
+        )
 
     @patch("requests.Session.get")
     def test_user_agent_is_passed_in(self, mock_session_get, mock_logger, success_response):
@@ -102,6 +111,22 @@ class TestGetRequests:
         mock_session_get.return_value = success_response
         http.get("http://example.com/some-path", mock_logger, timeout=12345, user_agent="")
         mock_session_get.assert_called_with("http://example.com/some-path", timeout=12345, headers={})
+
+    @patch("requests.Session.get")
+    def test_default_user_agent_identifies_vunnel(self, mock_session_get, mock_logger, success_response):
+        """When user_agent is omitted (None), the wrapper sets a vunnel-identifying default."""
+        mock_session_get.return_value = success_response
+        http.get("http://example.com/some-path", mock_logger, timeout=12345)
+        called_headers = mock_session_get.call_args.kwargs["headers"]
+        assert called_headers["User-Agent"].startswith("anchore/vunnel-")
+
+    @patch("requests.Session.get")
+    def test_caller_supplied_headers_override_default_user_agent(self, mock_session_get, mock_logger, success_response):
+        """A User-Agent supplied via headers={} should win over the default."""
+        mock_session_get.return_value = success_response
+        http.get("http://example.com/some-path", mock_logger, headers={"User-Agent": "custom/1.0"})
+        called_headers = mock_session_get.call_args.kwargs["headers"]
+        assert called_headers["User-Agent"] == "custom/1.0"
 
     @patch("time.sleep")
     @patch("requests.Session.get")
@@ -393,6 +418,44 @@ class TestRateLimiting:
         assert any("will retry" in msg for msg in logged_warnings)
         assert not any("Rate limited" in msg for msg in logged_warnings)
 
+    @patch("time.sleep")
+    @patch("requests.Session.get")
+    def test_403_with_retry_after_is_rate_limited(self, mock_session_get, mock_sleep, mock_logger):
+        """403 with Retry-After is treated as rate limiting (e.g. GitHub secondary limits)."""
+        rate_limited_response = MagicMock()
+        rate_limited_response.status_code = 403
+        rate_limited_response.headers = {"Retry-After": "5"}
+        rate_limited_response.raise_for_status.side_effect = requests.HTTPError("403 Forbidden")
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.headers = {}
+
+        mock_session_get.side_effect = [rate_limited_response, success_response]
+
+        result = http.get("http://example.com/api", mock_logger, retries=2)
+
+        assert result == success_response
+        logged_warnings = [call.args[0] for call in mock_logger.warning.call_args_list]
+        assert any("Rate limited" in msg for msg in logged_warnings)
+
+    @patch("time.sleep")
+    @patch("requests.Session.get")
+    def test_403_without_retry_after_is_not_rate_limited(self, mock_session_get, mock_sleep, mock_logger):
+        """403 without Retry-After remains a permission error (no rate-limit handling)."""
+        error_403 = MagicMock()
+        error_403.status_code = 403
+        error_403.headers = {}  # No Retry-After
+        error_403.raise_for_status.side_effect = requests.HTTPError("403 Forbidden")
+
+        mock_session_get.return_value = error_403
+
+        with pytest.raises(requests.HTTPError):
+            http.get("http://example.com/api", mock_logger, retries=2, backoff_in_seconds=1)
+
+        logged_warnings = [call.args[0] for call in mock_logger.warning.call_args_list]
+        assert not any("Rate limited" in msg for msg in logged_warnings)
+
 
 class TestConnectionPooling:
     @pytest.fixture
@@ -510,6 +573,20 @@ class TestIsRateLimited:
         """Test that 503 without Retry-After is not rate limited."""
         response = MagicMock()
         response.status_code = 503
+        response.headers = {}
+        assert http._is_rate_limited(response) is False
+
+    def test_403_with_header_is_rate_limited(self):
+        """Test that 403 with Retry-After is rate limited (GitHub secondary limits)."""
+        response = MagicMock()
+        response.status_code = 403
+        response.headers = {"Retry-After": "60"}
+        assert http._is_rate_limited(response) is True
+
+    def test_403_without_header_is_not_rate_limited(self):
+        """Test that 403 without Retry-After is not rate limited (plain forbidden)."""
+        response = MagicMock()
+        response.status_code = 403
         response.headers = {}
         assert http._is_rate_limited(response) is False
 


### PR DESCRIPTION
Closes the two remaining unchecked items in #1037:

- [x] **always set a User-Agent header so we identify ourselves**
- [x] **respect Retry-After on 403s** (GitHub returns 403 + Retry-After for [secondary rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api))

The 429 and 503-with-Retry-After items were already shipped.

## Default User-Agent

`http_wrapper.default_user_agent()` returns `anchore/vunnel-<version>`, falling back to `anchore/vunnel-unknown` when package metadata is unavailable (e.g. some editable / CI installs). It matches the convention already used by the per-provider helpers in `chainguard_libraries`, `secureos`, and `fedora` — so a future cleanup PR could deduplicate those onto the central helper if desired.

`http.get()` now sets the default automatically when the caller does not specify one:

| `user_agent` argument | Behaviour |
|---|---|
| `None` (default)      | `User-Agent: anchore/vunnel-<version>` |
| `""`                  | no `User-Agent` header (explicit opt-out, used by tests) |
| any non-empty string  | sent verbatim (unchanged) |

A caller that pre-populates `headers={"User-Agent": "..."}` still wins — `setdefault` only fills the slot when it's empty.

## 403 + Retry-After

`_is_rate_limited()` now treats 403 + Retry-After the same way it already treats 503 + Retry-After. 403 **without** `Retry-After` is still a normal permission error (not rate-limit handling), so existing callers that legitimately receive 403s are unaffected.

## Tests

`tests/unit/utils/test_http_wrapper.py`: **47 passed** (up from 41).

New tests:

- `test_default_user_agent_identifies_vunnel` — covers the new `None` default.
- `test_caller_supplied_headers_override_default_user_agent` — explicit header still wins.
- `test_403_with_retry_after_is_rate_limited` — full path through `get()` with retry handling.
- `test_403_without_retry_after_is_not_rate_limited` — plain 403 still raises HTTPError without rate-limit logging.
- `test_403_with_header_is_rate_limited` / `_without_header_is_not_rate_limited` — direct unit tests on `_is_rate_limited`.

Updated existing tests `test_succeeds_if_retries_succeed` and `test_timeout_is_passed_in` to expect the new default UA in outgoing headers. `test_empty_user_agent_sets_no_header` is unchanged and still passes — the `""` opt-out path is preserved exactly.

Full unit suite: **826 passed**, no regressions.