### PR TITLE
feat(ubuntu): capture Notes section from Ubuntu security data (#1126)

### DIFF
--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -36,6 +36,10 @@ _patch_state_regex = re.compile(r"\s*(\S+)(\s+.+)?\s*")
 _indent_line_regex = re.compile(r"\s+\S+\s*")
 _package_priority_regex = re.compile(r"\s*Priority_(\S+)\s*:\s+(\S+)\s*")
 _cve_filename_regex = re.compile("CVE-[0-9]+-[0-9]+")
+# Notes section uses the format "<author>> <text>" on the first line of each note,
+# with continuation lines indented further than the author line. The author may be
+# omitted, in which case the line is just "> <text>" or "<text>".
+_note_author_regex = re.compile(r"^(\S+)?>\s?(.*)$")
 
 # Per the Ubuntu README in the security tracker BZR repo:
 # Maps the state name to whether it indicates a package is vulnerable
@@ -187,6 +191,19 @@ class Patch:
 
 
 @dataclass
+class Note:
+    """A single analyst note from the Ubuntu security tracker Notes: section.
+
+    Each note has an optional author (the Canonical analyst's launchpad
+    username) and a text body. Multiple notes may appear under one Notes:
+    block; this dataclass represents one.
+    """
+
+    text: str
+    author: str | None = None
+
+
+@dataclass
 class CVEFile:
     # Keep this naming for now to preserve compatibility with legacy
     name: str
@@ -196,6 +213,7 @@ class CVEFile:
     git_last_processed_rev: str | None = None
     references: list[str] | None = None
     description: str | None = None
+    notes: list[Note] = field(default_factory=list)
 
     @staticmethod
     def from_dict(d: dict[str, Any]):
@@ -206,6 +224,7 @@ class CVEFile:
         git_last_processed_rev = d.get("git_last_processed_rev")
         references = d.get("references", d.get("References"))
         description = d.get("description", d.get("Description"))
+        notes = [Note(**n) for n in d.get("notes", d.get("Notes", []))]
         return CVEFile(
             name=name,
             priority=priority,
@@ -214,6 +233,7 @@ class CVEFile:
             git_last_processed_rev=git_last_processed_rev,
             references=references,
             description=description,
+            notes=notes,
         )
 
 
@@ -338,6 +358,55 @@ def parse_simple_keyvalue(expected_key: str, lines: list[str]) -> str:
     return value
 
 
+def parse_notes(header: str, lines: list[str]) -> list[Note]:
+    """
+    Parse a Notes: section into a list of Note objects.
+
+    The upstream tracker format for each note is::
+
+        Notes:
+         author> first line of the note
+          continuation of that note (indented further than the author line)
+         author2> another note's first line
+
+    The author prefix is optional; lines without an author prefix are treated as
+    a continuation of the most recent note. If there is no preceding author line,
+    they form an authorless note.
+
+    Returns an empty list if the section is empty or absent.
+    """
+    check_header(header, lines)
+
+    notes: list[Note] = []
+    current_author: str | None = None
+    current_text: list[str] = []
+
+    while lines and _indent_line_regex.match(lines[0]):
+        raw = lines.pop(0)
+        # strip only leading whitespace; trailing whitespace gets cleaned per-line
+        stripped = raw.lstrip().rstrip()
+        if not stripped:
+            continue
+
+        m = _note_author_regex.match(stripped)
+        if m:
+            # finalize the note in progress before starting a new one
+            if current_text:
+                notes.append(Note(author=current_author, text=" ".join(current_text).strip()))
+                current_text = []
+            current_author = m.group(1) or None
+            first_line = m.group(2).strip()
+            if first_line:
+                current_text.append(first_line)
+        else:
+            current_text.append(stripped)
+
+    if current_text:
+        notes.append(Note(author=current_author, text=" ".join(current_text).strip()))
+
+    return notes
+
+
 def parse_multiline_keyvalue(header: str, lines: list[str]) -> str:
     """
     Parse a header plus multiple lines (to an empty line) into a single string, stripping newlines
@@ -440,6 +509,8 @@ def parse_cve_file(cve_id: str, content_lines: list[str]) -> CVEFile:
                 parsed.references = parse_list(section, lines)
             elif section == "Description":
                 parsed.description = parse_multiline_keyvalue(section, lines)
+            elif section == "Notes":
+                parsed.notes = parse_notes(section, lines)
             elif section == "Priority":
                 parsed.priority = parse_simple_keyvalue(section, lines)
             else:
@@ -554,6 +625,12 @@ def map_parsed(parsed_cve: CVEFile, fixdater: fixdate.Finder, logger: logging.Lo
             r.Link = ubuntu_cve_url.format(r.Name)
             r.FixedIn = []
             r.NamespaceName = namespace_name
+            # Carry along any analyst notes from the upstream Notes: section
+            # so downstream consumers (e.g. grype) can surface them next to
+            # findings. Only set the attribute when notes are present so
+            # existing record shapes are preserved when the section is empty.
+            if parsed_cve.notes:
+                r.Notes = [{"author": n.author, "text": n.text} for n in parsed_cve.notes]
             vulns[namespace_name] = r
 
         # Emit an explicit "not affected" FixedIn (version "0") so downstream consumers

--- a/tests/unit/providers/ubuntu/test-fixtures/example_ubuntu_cve_with_notes
+++ b/tests/unit/providers/ubuntu/test-fixtures/example_ubuntu_cve_with_notes
@@ -1,0 +1,31 @@
+Candidate: CVE-2024-3094
+PublicDate: 2024-03-29 17:15:00 UTC
+References:
+ https://www.openwall.com/lists/oss-security/2024/03/29/4
+ https://discourse.ubuntu.com/t/xz-liblzma-security-update/43714
+Description:
+ Malicious code was discovered in the upstream tarballs of xz, starting with
+ version 5.6.0.
+Ubuntu-Description:
+Notes:
+ mdeslaur> The affected version of xz-utils was only in noble-proposed, and
+  was removed before migrating to noble itself. No released
+  versions of Ubuntu were affected by this issue.
+ > Priority reason:
+  Results in a backdoor in sshd
+Mitigation:
+Bugs:
+Priority: critical
+Discovered-by:
+Assigned-to:
+CVSS:
+ nvd: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H [10.0 CRITICAL]
+
+Patches_xz-utils:
+upstream_xz-utils: needs-triage
+trusty_xz-utils: not-affected
+xenial_xz-utils: not-affected
+bionic_xz-utils: not-affected
+focal_xz-utils: not-affected (5.2.4-1ubuntu1.1)
+jammy_xz-utils: not-affected (5.2.5-2ubuntu1)
+noble_xz-utils: not-affected (5.4.5-0.3)

--- a/tests/unit/providers/ubuntu/test_ubuntu.py
+++ b/tests/unit/providers/ubuntu/test_ubuntu.py
@@ -9,22 +9,25 @@ import sys
 from dataclasses import asdict
 
 import pytest
+
 from vunnel import result, workspace
 from vunnel.providers import ubuntu
 from vunnel.providers.ubuntu.parser import (
     CVEFile,
+    Note,
     Parser,
     Patch,
+    Severity,
     check_merge,
     check_patch,
     map_parsed,
     parse_cve_file,
     parse_list,
     parse_multiline_keyvalue,
+    parse_notes,
     parse_severity_from_priority,
     parse_simple_keyvalue,
     patch_states,
-    Severity,
     ubuntu_version_names,
 )
 
@@ -33,6 +36,7 @@ class TestUbuntuParser:
     _location_ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__), "test-fixtures"))
     _data_ = os.path.join(_location_, "example_ubuntu_cve")
     _weird_data_ = os.path.join(_location_, "weird_example_cve")
+    _notes_data_ = os.path.join(_location_, "example_ubuntu_cve_with_notes")
     _workspace_ = "/tmp/ubuntu"
 
     # @classmethod
@@ -250,6 +254,112 @@ class TestUbuntuParser:
 
         print(result)
 
+    def test_parse_notes_empty(self):
+        """An empty Notes: section should yield an empty list."""
+        # Body terminates because the next line ("Bugs:") is not indented and
+        # so does not match _indent_line_regex.
+        text = "Notes:\nBugs:\n"
+        lines = text.splitlines()
+        got = parse_notes("Notes", lines)
+        assert got == []
+
+    def test_parse_notes_single_authored(self):
+        """A single authored note with continuation lines should be joined."""
+        text = "Notes:\n mdeslaur> first line of the note\n  second line continues\n  third line\nBugs:\n"
+        lines = text.splitlines()
+        got = parse_notes("Notes", lines)
+        assert got == [Note(author="mdeslaur", text="first line of the note second line continues third line")]
+
+    def test_parse_notes_multiple_authors_and_authorless(self):
+        """Multiple notes should be split on the author> marker, including authorless ones."""
+        text = "Notes:\n mdeslaur> First note\n  spans two lines\n > Priority reason:\n  results in a backdoor\n sbeattie> A short one\nMitigation:\n"
+        lines = text.splitlines()
+        got = parse_notes("Notes", lines)
+        assert got == [
+            Note(author="mdeslaur", text="First note spans two lines"),
+            Note(author=None, text="Priority reason: results in a backdoor"),
+            Note(author="sbeattie", text="A short one"),
+        ]
+
+    def test_parse_cve_with_notes_fixture(self):
+        """Parsing a fixture with a populated Notes: block should produce CVEFile.notes."""
+        with open(self._notes_data_) as f:
+            data = f.readlines()
+
+        result = parse_cve_file("CVE-2024-3094", data)
+
+        assert result.notes == [
+            Note(
+                author="mdeslaur",
+                text=(
+                    "The affected version of xz-utils was only in noble-proposed, and "
+                    "was removed before migrating to noble itself. No released "
+                    "versions of Ubuntu were affected by this issue."
+                ),
+            ),
+            Note(author=None, text="Priority reason: Results in a backdoor in sshd"),
+        ]
+
+    def test_parse_cve_empty_notes_fixture(self):
+        """The original example fixture has Notes: empty — notes should be []."""
+        with open(self._data_) as f:
+            data = f.readlines()
+        result = parse_cve_file("CVE-2017-9996", data)
+        assert result.notes == []
+
+    def test_notes_round_trip_through_dataclass_dict(self):
+        """A CVEFile with notes should survive an asdict/from_dict round trip."""
+        from dataclasses import asdict as _asdict
+
+        original = CVEFile(
+            name="CVE-9999-0001",
+            notes=[
+                Note(author="mdeslaur", text="A note"),
+                Note(author=None, text="An authorless note"),
+            ],
+        )
+
+        restored = CVEFile.from_dict(_asdict(original))
+        assert restored.notes == original.notes
+
+    def test_mapper_emits_notes_when_present(self, fake_fixdate_finder):
+        """When parsed CVE has notes, the JSON output should include them."""
+        with open(self._notes_data_) as f:
+            parsed = parse_cve_file("CVE-2024-3094", f.readlines())
+
+        vulns = map_parsed(parsed, fixdater=fake_fixdate_finder())
+        assert vulns, "expected at least one Vulnerability record"
+        for v in vulns:
+            j = v.json()
+            assert "Notes" in j, f"expected Notes key on namespace {v.NamespaceName}"
+            assert j["Notes"] == [
+                {
+                    "author": "mdeslaur",
+                    "text": (
+                        "The affected version of xz-utils was only in noble-proposed, and "
+                        "was removed before migrating to noble itself. No released "
+                        "versions of Ubuntu were affected by this issue."
+                    ),
+                },
+                {"author": None, "text": "Priority reason: Results in a backdoor in sshd"},
+            ]
+
+    def test_mapper_omits_notes_when_absent(self, fake_fixdate_finder):
+        """When parsed CVE has no notes, the JSON output should not include a Notes key.
+
+        This preserves backward compatibility with the existing record shape and
+        avoids unnecessary churn in downstream consumers when the Notes section
+        is empty (the common case).
+        """
+        with open(self._data_) as f:
+            parsed = parse_cve_file("CVE-2017-9996", f.readlines())
+
+        vulns = map_parsed(parsed, fixdater=fake_fixdate_finder())
+        assert vulns, "expected at least one Vulnerability record"
+        for v in vulns:
+            j = v.json()
+            assert "Notes" not in j, f"did not expect Notes key on namespace {v.NamespaceName}"
+
     def test_simple_multiline_parser(self):
         data = {
             """Description:
@@ -413,8 +523,7 @@ class TestUbuntuParser:
         assert questing_vuln is not None, "Expected a vulnerability record for ubuntu:25.10 (questing)"
         fixed_gcc = [f for f in questing_vuln.FixedIn if f.Name == "gcc-arm-none-eabi"]
         assert len(fixed_gcc) == 1, (
-            f"Expected needs-triage gcc-arm-none-eabi on questing to still produce a FixedIn entry "
-            f"(no ESM counterpart exists), got {len(fixed_gcc)}"
+            f"Expected needs-triage gcc-arm-none-eabi on questing to still produce a FixedIn entry (no ESM counterpart exists), got {len(fixed_gcc)}"
         )
 
     def test_bare_ignored_produces_fixedin(self, fake_fixdate_finder):
@@ -443,13 +552,9 @@ class TestUbuntuParser:
 
         assert jammy_vuln is not None, "Expected a vulnerability record for ubuntu:22.04 (jammy)"
         fixed_coreutils = [f for f in jammy_vuln.FixedIn if f.Name == "coreutils"]
-        assert len(fixed_coreutils) == 1, (
-            f"Expected bare-ignored coreutils on jammy to produce a FixedIn entry, got {len(fixed_coreutils)}"
-        )
+        assert len(fixed_coreutils) == 1, f"Expected bare-ignored coreutils on jammy to produce a FixedIn entry, got {len(fixed_coreutils)}"
         assert fixed_coreutils[0].Version == "None", "Expected Version='None' for won't-fix entry"
-        assert fixed_coreutils[0].VendorAdvisory == {"NoAdvisory": True}, (
-            "Expected NoAdvisory=True for ignored entry"
-        )
+        assert fixed_coreutils[0].VendorAdvisory == {"NoAdvisory": True}, "Expected NoAdvisory=True for ignored entry"
 
         # noble (also bare ignored) should behave the same
         noble_vuln = None
@@ -460,9 +565,7 @@ class TestUbuntuParser:
 
         assert noble_vuln is not None, "Expected a vulnerability record for ubuntu:24.04 (noble)"
         fixed_coreutils = [f for f in noble_vuln.FixedIn if f.Name == "coreutils"]
-        assert len(fixed_coreutils) == 1, (
-            f"Expected bare-ignored coreutils on noble to produce a FixedIn entry, got {len(fixed_coreutils)}"
-        )
+        assert len(fixed_coreutils) == 1, f"Expected bare-ignored coreutils on noble to produce a FixedIn entry, got {len(fixed_coreutils)}"
 
         # focal (ignored with EOL reason) should also produce a FixedIn via check_merge
         focal_vuln = None
@@ -474,12 +577,9 @@ class TestUbuntuParser:
         assert focal_vuln is not None, "Expected a vulnerability record for ubuntu:20.04 (focal)"
         fixed_coreutils = [f for f in focal_vuln.FixedIn if f.Name == "coreutils"]
         assert len(fixed_coreutils) == 1, (
-            f"Expected ignored (end of standard support) coreutils on focal to produce a FixedIn entry, "
-            f"got {len(fixed_coreutils)}"
+            f"Expected ignored (end of standard support) coreutils on focal to produce a FixedIn entry, got {len(fixed_coreutils)}"
         )
-        assert fixed_coreutils[0].VendorAdvisory == {"NoAdvisory": True}, (
-            "Expected NoAdvisory=True for ignored entry with EOL reason"
-        )
+        assert fixed_coreutils[0].VendorAdvisory == {"NoAdvisory": True}, "Expected NoAdvisory=True for ignored entry with EOL reason"
 
     def test_checkers(self):
         check_data = [
@@ -642,7 +742,7 @@ class TestUbuntuParser:
             parse_severity_from_priority(cve)
 
 
-@pytest.fixture()
+@pytest.fixture
 def hydrate_git_repo(tmpdir, helpers):
     def run(cmd, **kwargs):
         subprocess.run(shlex.split(cmd), **kwargs, stderr=sys.stderr, stdout=sys.stdout)


### PR DESCRIPTION
## What

Closes #1126.

The Ubuntu security tracker entries include a `Notes:` section where Canonical analysts add free-form context: why a package isn't affected, why a fix is deferred, the rationale for a priority assignment, mitigation observations, and so on. The vunnel provider parses Ubuntu CVE files but currently discards everything in this section.

This PR captures that content end-to-end:

- `parse_notes()` parses the `Notes:` block into `(author, text)` pairs.
- A new `Note` dataclass carries each note on the in-memory `CVEFile`.
- Notes survive the asdict / orjson dump → load round trip used by `_merge_cve` / `_load_merged_cve`.
- `map_parsed()` attaches them to each affected-namespace `Vulnerability` record so the JSON written by the provider includes them, ready for grype (or any other consumer of the os vulnerability schema) to surface alongside findings.

## Format handled

```
Notes:
 mdeslaur> first line of a note
  continuation of the same note (indented further)
 sbeattie> another note
 > an authorless note
Mitigation:
```

The parser tolerates missing author prefixes, blank intra-section lines, and continuation lines on any indent depth deeper than the author line.

## Output shape

When the upstream entry has notes, the produced JSON gains a `Notes` field on the `Vulnerability` object:

```json
{
  "Vulnerability": {
    "Name": "CVE-2024-3094",
    "NamespaceName": "ubuntu:24.04",
    "Notes": [
      {
        "author": "mdeslaur",
        "text": "The affected version of xz-utils was only in noble-proposed, and was removed before migrating to noble itself. No released versions of Ubuntu were affected by this issue."
      },
      {
        "author": null,
        "text": "Priority reason: Results in a backdoor in sshd"
      }
    ],
    "...": "..."
  }
}
```

The `Notes` key is only emitted when at least one note was parsed. Empty `Notes:` blocks (the common case) leave the existing record shape untouched, which means existing snapshots in this repo still match and downstream consumers don't see a churn of empty arrays. The os vulnerability schema does not pin `additionalProperties`, so this is additive without a schema bump.

The grype-side schema is intentionally not changed in this PR — the issue calls out that grype consumption is a follow-up, and this PR just gets the data flowing into the vunnel intermediate.

## Tests

Added eight unit tests covering:

- empty `Notes:` block (yields `[]`)
- single authored note with continuation lines
- multiple notes with mixed authored / authorless entries
- end-to-end parse of a fixture CVE file with a populated `Notes:` block (`example_ubuntu_cve_with_notes`)
- the existing `example_ubuntu_cve` fixture (empty Notes) still parses to `notes == []`
- `asdict` / `from_dict` round trip preserves notes
- `map_parsed` emits `Notes` on the JSON record when present
- `map_parsed` omits `Notes` from the JSON record when no notes were parsed (snapshot stability)

The existing snapshot test (`test_provider_via_snapshot`) still passes against the unmodified snapshots since none of the fast-export fixtures have populated notes.

```
$ uv run pytest tests/unit/providers/ubuntu/ -q
46 passed in 0.69s
$ uv run pytest tests/unit/ -q
834 passed in 2.86s
```

## Test plan

- [x] `uv run pytest tests/unit/providers/ubuntu/` — 46 / 46 pass
- [x] `uv run pytest tests/unit/` — 834 / 834 pass
- [x] `uv run ruff check src/vunnel/providers/ubuntu/parser.py tests/unit/providers/ubuntu/test_ubuntu.py` — only pre-existing project-wide warnings (S101 pytest assertions, A001 in unrelated tests); no new errors introduced
- [x] `uv run ruff format` applied
- [x] Commit signed off (DCO)