### PR TITLE
Tighten workflow security, update release shape, add CodeQL

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -1,3 +1,5 @@
+cooldown: 7d
+
 tools:
   # we want to use a pinned version of binny to manage the toolchain (so binny manages itself!)
   - name: binny

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,22 +3,11 @@ updates:
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 10
-    directory: "/.github/actions/bootstrap"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "github-actions"
-    open-pull-requests-limit: 10
-    directory: "/.github/workflows"
-    schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     groups:
@@ -30,9 +19,10 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
     groups:
       ruff:
         patterns:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,62 @@
+# CodeQL scans for security vulnerabilities and coding errors across all
+# languages in this repo. Results appear in the "Security" tab under
+# "Code scanning alerts" and are enforced by branch protection rules.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  # Weekly scheduled scan catches newly disclosed vulnerabilities in
+  # existing code, not just changes introduced by PRs.
+  schedule:
+    - cron: '38 11 * * 3'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to the "Security" tab.
+      security-events: write
+      # Required to fetch internal or private CodeQL packs.
+      packages: read
+      # Only required for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # GitHub Actions workflow linting — no build needed.
+          - language: actions
+            build-mode: none
+
+          # Python uses "none" build mode since it is an interpreted language
+          # and does not require compilation for CodeQL analysis.
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          # The category tag lets GitHub associate SARIF results with the
+          # correct language when branch protection checks for required
+          # code scanning results.
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/nightly-quality-gate.yaml
+++ b/.github/workflows/nightly-quality-gate.yaml
@@ -7,8 +7,7 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: nightly-quality-gate
@@ -17,6 +16,8 @@ concurrency:
 jobs:
   select-providers:
     runs-on: runs-on=${{ github.run_id }}/cpu=2/ram=4+8/family=t4g+t3a+t3+m6g+m6a/spot=price-capacity-optimized/retry=when-interrupted/extras=s3-cache
+    permissions:
+      contents: read
     outputs:
       providers: ${{ steps.determine-providers.outputs.providers }}
       multicore-providers: ${{ steps.split-providers.outputs.multicore-providers }}

--- a/.github/workflows/pr-quality-gate.yaml
+++ b/.github/workflows/pr-quality-gate.yaml
@@ -9,8 +9,7 @@ on:
       # custom types...
       - labeled
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: pr-quality-gate-${{ github.event.pull_request.number }}
@@ -19,6 +18,8 @@ concurrency:
 jobs:
   select-providers:
     runs-on: runs-on=${{ github.run_id }}/cpu=2/ram=4+8/family=t4g+t3a+t3+m6g+m6a/spot=price-capacity-optimized/retry=when-interrupted/extras=s3-cache
+    permissions:
+      contents: read
     outputs:
       providers: ${{ steps.determine-providers.outputs.providers }}
       multicore-providers: ${{ steps.split-providers.outputs.multicore-providers }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,8 @@ jobs:
     with:
       # these are checks that should be run on pull-request and merges to main.
       # we do NOT want to kick off a release if these have not been verified on main.
-      # Please see the validations.yaml workflow for the names that should be used here.
-      checks: '["Discover-Test-Envs", "Static Analysis", "Test Gate"]'
+      # Please see the validations.yaml and nightly-quality-gate.yaml workflows for the names that should be used here.
+      checks: '["Static Analysis", "Test Gate", "Nightly-Quality-Gate"]'
 
   tag:
     needs: [check-gate, version-available]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,92 +1,38 @@
 name: "Release"
+
+permissions: {}
+
+# there should never be two releases in progress at the same time
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
-      bypassQualityGate:
-        description: bypass the quality gate check
-        required: false
-        default: false
-
-permissions:
-  contents: read
 
 jobs:
-  quality-gate:
-    environment: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
-        with:
-          persist-credentials: false
 
-      - name: Check if tag already exists
-        # note: this will fail if the tag already exists
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-        run: |
-          # Validate version format
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Version must match pattern v*.*.* (e.g., v1.2.3)"
-            exit 1
-          fi
-          git tag "$VERSION"
+  version-available:
+    uses: anchore/workflows/.github/workflows/check-version-available.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      version: ${{ github.event.inputs.version }}
 
-      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
-      - name: Ensure tagged commit is on main
-        run: |
-          echo "Tag: ${GITHUB_REF##*/}"
-          git fetch origin main
-          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
-
-      - name: Check static analysis results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.1.1
-        id: static-analysis
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Static Analysis"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check test results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.1.1
-        id: test
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Test Gate"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check nightly quality gate results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: nightly-quality-gate
-        if: ${{ github.event.inputs.bypassQualityGate != 'true' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/nightly-quality-gate.yaml)
-          checkName: "Nightly-Quality-Gate"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          # If there is no result in 10 seconds, assume it hasn't run yet
-          timeoutSeconds: 10
-          intervalSeconds: 3
-
-      - name: Release quality gate
-        if: steps.static-analysis.conclusion != 'success' || steps.test.conclusion != 'success' || (steps.nightly-quality-gate.conclusion != 'success' && steps.nightly-quality-gate.conclusion != 'skipped')
-        env:
-          STATIC_ANALYSIS_STATUS: ${{ steps.static-analysis.conclusion }}
-          TEST_STATUS: ${{ steps.test.conclusion }}
-          QUALITY_GATE_STATUS: ${{ steps.nightly-quality-gate.conclusion }}
-        run: |
-          echo "Static Analysis Status: $STATIC_ANALYSIS_STATUS"
-          echo "Test Status: $TEST_STATUS"
-          echo "Nightly Quality Gate Status: $QUALITY_GATE_STATUS"
-          false
+  check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
+    uses: anchore/workflows/.github/workflows/check-gate.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      # these are checks that should be run on pull-request and merges to main.
+      # we do NOT want to kick off a release if these have not been verified on main.
+      # Please see the validations.yaml workflow for the names that should be used here.
+      checks: '["Discover-Test-Envs", "Static Analysis", "Test Gate"]'
 
   tag:
-    needs:
-      - quality-gate
+    needs: [check-gate, version-available]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -8,8 +8,7 @@ on:
   # needed when running from forks
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
@@ -43,6 +42,8 @@ jobs:
 
   Discover-Test-Envs:
     runs-on: runs-on=${{ github.run_id }}/cpu=2/ram=4+8/family=t4g+t3a+t3+m6g+m6a/spot=price-capacity-optimized/retry=when-interrupted/extras=s3-cache
+    permissions:
+      contents: read
     outputs:
       envs: ${{ steps.get-envs.outputs.envs }}
     steps:


### PR DESCRIPTION
Brings workflows in line with org-wide security requirements: empty top-level permissions with per-job grants, canonical release workflow shape using reusable check-gate, consolidated dependabot config, binny global cooldown, and a new CodeQL workflow for Python.

Changes:
- release.yaml: replace bespoke quality-gate job with reusable check-version-available + check-gate workflows; add concurrency block; remove bypassQualityGate input; set top-level permissions: {}
- nightly-quality-gate.yaml, pr-quality-gate.yaml, validate-github-actions.yaml, validations.yaml: change top-level permissions: contents: read to permissions: {}; push contents: read down to job level where needed
- dependabot.yml: consolidate github-actions entries into one with both / and /.github/actions/* directories; switch all intervals to weekly; add open-pull-requests-limit to uv ecosystem
- .binny.yaml: add top-level cooldown: 7d
- codeql.yaml: new CodeQL workflow scanning actions and python languages

Notes:
- Publish-PreProd packages: write left as-is; the job is already scoped to main only (if: github.ref == 'refs/heads/main') and permissions are job-scoped