### PR TITLE
feat(providers/chainguard): add override env var to change cg & wofli secdb url

### DIFF
--- a/src/vunnel/providers/chainguard/__init__.py
+++ b/src/vunnel/providers/chainguard/__init__.py
@@ -21,14 +21,17 @@ class Config:
         ),
     )
     request_timeout: int = 125
+    secdb_url: str = "env:VUNNEL_CHAINGUARD_SECDB_URL"
+    
+    def __post_init__(self) -> None:
+        if self.secdb_url.startswith("env:"):
+            self.secdb_url = os.environ.get(self.secdb_url[4:], "https://packages.cgr.dev/chainguard/security.json")
 
 
 class Provider(provider.Provider):
     __schema__ = schema.OSSchema()
     __distribution_version__ = int(__schema__.major_version)
 
-    _secdb_url = "env:VUNNEL_CHAINGUARD_SECDB_URL"
-    _url_default = "https://packages.cgr.dev/chainguard/security.json"
     _namespace = "chainguard"
 
     def __init__(self, root: str, config: Config | None = None):
@@ -39,13 +42,9 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        # if the environment variable is set, override the default URL (this is primarily for testing purposes)
-        if self._secdb_url.startswith("env:"):
-            self._secdb_url = os.environ.get(self._secdb_url[4:], self._url_default)
-
         self.parser = Parser(
             workspace=self.workspace,
-            url=self._secdb_url,
+            url=config.secdb_url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,
             logger=self.logger,

--- a/src/vunnel/providers/chainguard/__init__.py
+++ b/src/vunnel/providers/chainguard/__init__.py
@@ -21,11 +21,8 @@ class Config:
         ),
     )
     request_timeout: int = 125
-    secdb_url: str = "env:VUNNEL_CHAINGUARD_SECDB_URL"
-    
-    def __post_init__(self) -> None:
-        if self.secdb_url.startswith("env:"):
-            self.secdb_url = os.environ.get(self.secdb_url[4:], "https://packages.cgr.dev/chainguard/security.json")
+    # Override with VUNNEL_PROVIDERS_CHAINGUARD_SECDB_URL
+    secdb_url: str = "https://packages.cgr.dev/chainguard/security.json"
 
 
 class Provider(provider.Provider):
@@ -73,4 +70,4 @@ class Provider(provider.Provider):
                             payload=record,
                         )
 
-            return [self._secdb_url], len(writer)
+            return [self.config.secdb_url], len(writer)

--- a/src/vunnel/providers/chainguard/__init__.py
+++ b/src/vunnel/providers/chainguard/__init__.py
@@ -27,7 +27,8 @@ class Provider(provider.Provider):
     __schema__ = schema.OSSchema()
     __distribution_version__ = int(__schema__.major_version)
 
-    _url = "https://packages.cgr.dev/chainguard/security.json"
+    _secdb_url = "env:VUNNEL_CHAINGUARD_SECDB_URL"
+    _url_default = "https://packages.cgr.dev/chainguard/security.json"
     _namespace = "chainguard"
 
     def __init__(self, root: str, config: Config | None = None):
@@ -38,9 +39,13 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
+        # if the environment variable is set, override the default URL (this is primarily for testing purposes)
+        if self._secdb_url.startswith("env:"):
+            self._secdb_url = os.environ.get(self._secdb_url[4:], self._url_default)
+
         self.parser = Parser(
             workspace=self.workspace,
-            url=self._url,
+            url=self._secdb_url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,
             logger=self.logger,
@@ -69,4 +74,4 @@ class Provider(provider.Provider):
                             payload=record,
                         )
 
-            return [self._url], len(writer)
+            return [self._secdb_url], len(writer)

--- a/src/vunnel/providers/wolfi/__init__.py
+++ b/src/vunnel/providers/wolfi/__init__.py
@@ -28,7 +28,8 @@ class Provider(provider.Provider):
     __schema__ = schema.OSSchema()
     __distribution_version__ = int(__schema__.major_version)
 
-    _url = "https://packages.wolfi.dev/os/security.json"
+    _secdb_url = "env:VUNNEL_WOLFI_SECDB_URL"
+    _url_default = "https://packages.wolfi.dev/os/security.json"
     _namespace = "wolfi"
 
     def __init__(self, root: str, config: Config | None = None):
@@ -39,9 +40,13 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
+        # if the environment variable is set, override the default URL (this is primarily for testing purposes)
+        if self._secdb_url.startswith("env:"):
+            self._secdb_url = os.environ.get(self._secdb_url[4:], self._url_default)
+
         self.parser = Parser(
             workspace=self.workspace,
-            url=self._url,
+            url=self._secdb_url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,
             logger=self.logger,
@@ -70,4 +75,4 @@ class Provider(provider.Provider):
                             payload=record,
                         )
 
-            return [self._url], len(writer)
+            return [self._secdb_url], len(writer)

--- a/src/vunnel/providers/wolfi/__init__.py
+++ b/src/vunnel/providers/wolfi/__init__.py
@@ -22,11 +22,8 @@ class Config:
         ),
     )
     request_timeout: int = 125
-    secdb_url: str = "env:VUNNEL_WOLFI_SECDB_URL"
-
-    def __post_init__(self) -> None:
-        if self.secdb_url.startswith("env:"):
-            self.secdb_url = os.environ.get(self.secdb_url[4:], "https://packages.wolfi.dev/os/security.json")
+    # Override with VUNNEL_PROVIDERS_WOLFI_SECDB_URL
+    secdb_url: str = "https://packages.wolfi.dev/os/security.json"
 
 
 class Provider(provider.Provider):
@@ -74,4 +71,4 @@ class Provider(provider.Provider):
                             payload=record,
                         )
 
-            return [self._secdb_url], len(writer)
+            return [self.config.secdb_url], len(writer)

--- a/src/vunnel/providers/wolfi/__init__.py
+++ b/src/vunnel/providers/wolfi/__init__.py
@@ -22,14 +22,17 @@ class Config:
         ),
     )
     request_timeout: int = 125
+    secdb_url: str = "env:VUNNEL_WOLFI_SECDB_URL"
+
+    def __post_init__(self) -> None:
+        if self.secdb_url.startswith("env:"):
+            self.secdb_url = os.environ.get(self.secdb_url[4:], "https://packages.wolfi.dev/os/security.json")
 
 
 class Provider(provider.Provider):
     __schema__ = schema.OSSchema()
     __distribution_version__ = int(__schema__.major_version)
 
-    _secdb_url = "env:VUNNEL_WOLFI_SECDB_URL"
-    _url_default = "https://packages.wolfi.dev/os/security.json"
     _namespace = "wolfi"
 
     def __init__(self, root: str, config: Config | None = None):
@@ -40,13 +43,9 @@ class Provider(provider.Provider):
 
         self.logger.debug(f"config: {config}")
 
-        # if the environment variable is set, override the default URL (this is primarily for testing purposes)
-        if self._secdb_url.startswith("env:"):
-            self._secdb_url = os.environ.get(self._secdb_url[4:], self._url_default)
-
         self.parser = Parser(
             workspace=self.workspace,
-            url=self._secdb_url,
+            url=config.secdb_url,
             namespace=self._namespace,
             download_timeout=self.config.request_timeout,
             logger=self.logger,

--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -36,7 +36,7 @@ yardstick:
       #  - a repo reference and optional "@branch" (e.g. "github.com/my-user-fork/grype@dev-fix-foo")
       # Note:
       #  - this version should ALWAYS match that of the other "grype" tool above
-      version: main+import-db=https://grype.anchore.io/databases/v6/vulnerability-db_v6.0.2_2025-07-10T01:31:11Z_1752120925.tar.zst
+      version: main+import-db=https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.4_2026-05-13T00:47:21Z_1778657102.tar.zst
       takes: SBOM
       label: reference
 
@@ -321,7 +321,6 @@ tests:
     # This will still test incremental updates relative to the nightly cache that is populated.
     additional_trigger_globs:
       - src/vunnel/utils/oval_parser.py
-    use_cache: true
     images:
       - registry.access.redhat.com/ubi8@sha256:68fecea0d255ee253acbf0c860eaebb7017ef5ef007c25bee9eeffd29ce85b29
       - docker.io/centos:6@sha256:3688aa867eb84332460e172b9250c9c198fdfd8d987605fd53f246f498c60bcf

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -282,6 +282,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
       user_agent: null
+    secdb_url: https://packages.cgr.dev/chainguard/security.json
   chainguard_libraries:
     openvex_url: https://libraries.cgr.dev/openvex/v1/all.json
     request_timeout: 125
@@ -659,6 +660,7 @@ providers:
       skip_download: false
       skip_newer_archive_check: false
       user_agent: null
+    secdb_url: https://packages.wolfi.dev/os/security.json
 root: ./data
 """
     expected_output = expected_output.replace("$VUNNEL_VERSION", vunnel_version)


### PR DESCRIPTION
### What

Implement environment variables to override secdb url in chainguard and wolfi vunnel providers

### Why

Enables testing with alternative secdb feeds

### Notes

Copied the pattern implemented by github and nvd providers for consistency

Tested the following in my branch:
```
❯ uv sync --all-extras --dev
❯ uv pip install -e .

❯ uv run vunnel run wolfi
[INFO ] running wolfi provider in ./data
[INFO ] pulling fix date database from ghcr.io/anchore/grype-db-observed-fix-date/wolfi:latest-zstd
[INFO ] successfully fetched fix date database for wolfi
[INFO ] downloading wolfi secdb https://packages.wolfi.dev/os/security.json
[INFO ] wrote 7523 entries
[INFO ] updating wolfi took 231.01 seconds
[INFO ] recording workspace state

❯ uv run vunnel run chainguard
[INFO ] running chainguard provider in ./data
[INFO ] pulling fix date database from ghcr.io/anchore/grype-db-observed-fix-date/chainguard:latest-zstd
[INFO ] successfully fetched fix date database for chainguard
[INFO ] downloading chainguard secdb https://packages.cgr.dev/chainguard/security.json
[INFO ] wrote 11900 entries
[INFO ] updating chainguard took 480.86 seconds
[INFO ] recording workspace state

❯ env VUNNEL_PROVIDERS_WOLFI_SECDB_URL="https://storage.googleapis.com/zcrosley-dev-secfeed/os/security.json" uv run vunnel run wolfi
[INFO ] running wolfi provider in ./data
[INFO ] fix date database is up to date (digest: sha256:748a2f2ac88ba6fa9a4026a97c533dfdfa13c988c01302cd1747fc30367eaff4)
[INFO ] downloading wolfi secdb https://storage.googleapis.com/zcrosley-dev-secfeed/os/security.json
[INFO ] wrote 6132 entries
[INFO ] updating wolfi took 20.09 seconds
[INFO ] recording workspace state

❯ env VUNNEL_PROVIDERS_CHAINGUARD_SECDB_URL="https://storage.googleapis.com/zcrosley-dev-secfeed/chainguard/security.json" uv run vunnel run chainguard
[INFO ] running chainguard provider in ./data
[INFO ] fix date database is up to date (digest: sha256:3bc921729712234866bee0896c6c7a12b222d3bef321f6216f7ae3fab1d7600f)
[INFO ] downloading chainguard secdb https://storage.googleapis.com/zcrosley-dev-secfeed/chainguard/security.json
[INFO ] wrote 10620 entries
[INFO ] updating chainguard took 55.79 seconds
[INFO ] recording workspace state
```