### PR TITLE
Fix release permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
   check-gate:
     permissions:
       checks: read # required for getting the status of specific check names
+      contents: read # needed for using the wait-for-check action upstream
     uses: anchore/workflows/.github/workflows/check-gate.yaml@15122524ced7906bfa9685eeae12e22647773ea6 # v0.6.0
     with:
       # these are checks that should be run on pull-request and merges to main.


### PR DESCRIPTION
Now that we're using wait-for-check, this requires read permissions