### PR TITLE
Remove nightly quality gate for release gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       # these are checks that should be run on pull-request and merges to main.
       # we do NOT want to kick off a release if these have not been verified on main.
       # Please see the validations.yaml and nightly-quality-gate.yaml workflows for the names that should be used here.
-      checks: '["Static Analysis", "Test Gate", "Nightly-Quality-Gate"]'
+      checks: '["Static Analysis", "Test Gate"]'
 
   tag:
     needs: [check-gate, version-available]


### PR DESCRIPTION
This should not be required to release given we have the PR gate checks