### PR TITLE
fix: clean destination prior to extracting archive

### DIFF
--- a/src/vunnel/utils/archive.py
+++ b/src/vunnel/utils/archive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tarfile
 import tempfile
 from pathlib import Path
@@ -9,6 +10,9 @@ import zstandard
 
 
 def extract(path: str, destination_dir: str) -> None:
+    if os.path.exists(destination_dir):
+        shutil.rmtree(destination_dir)
+
     if path.endswith(".tar.zst"):
         return _extract_tar_zst(path, destination_dir)
 

--- a/tests/quality/configure.py
+++ b/tests/quality/configure.py
@@ -454,7 +454,7 @@ def select_providers(cfg: Config, output_json: bool, tag: str | None):
         "src/vunnel/result.py",
         "src/vunnel/provider.py",
         "src/vunnel/tool/fixdate/**",
-        "src/vunnel/utils/http_wrapper.py",
+        "src/vunnel/utils/**",
     ]
 
     for search_glob in gate_globs:


### PR DESCRIPTION
Otherwise artifacts from previous caches that have been removed in upstream data will continue to be considered in the output