### PR TITLE
feat(rhel): use version ranges for multi upstream RHSAs

### DIFF
--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import concurrent.futures
 import contextlib
 import copy
+import functools
 import logging
 import os
 import queue
@@ -35,7 +36,11 @@ if TYPE_CHECKING:
 namespace = "rhel"
 
 
-FixedIn = namedtuple("FixedIn", ["package", "platform", "version", "module", "advisory"])
+FixedIn = namedtuple(
+    "FixedIn",
+    ["package", "platform", "version", "module", "advisory", "vulnerable_range", "additional_advisories"],
+    defaults=[None, ()],
+)
 RHSAFixedIn = namedtuple("RHSAFixedIn", ["package", "version"])
 Advisory = namedtuple("Advisory", ["wont_fix", "rhsa_id", "link", "severity"])
 NamespacePayload = namedtuple("NamespacePayload", ["namespace", "payload"])
@@ -436,8 +441,11 @@ class Parser:
         # to deal with affected releases missing package-version strings
         platform_packages = {}  # dictionary of platform -> set of package names
         all_ar_objs = []
-        # to deal with multiple affected releases for the same platform and package
-        final_ar_objs = {}  # dictionary of (package, platform, module) -> AffectedRelease object
+        # collect every affected release for the same (package, platform, module). When Red Hat ships
+        # more than one fix for the same tuple (e.g. a Z-stream/EUS backport in one minor and an upstream
+        # rebase in a later minor), each fix lands here and is later reduced to a single FixedIn that
+        # carries a VulnerableRange describing the per-stream fix boundaries.
+        collected_ar_objs: dict[tuple, list] = {}  # (package, platform, module) -> list[AffectedRelease]
 
         try:
             # first pass to just parse affected releases and construct a list of objects
@@ -536,51 +544,81 @@ class Parser:
                     ar_obj.version = final_v  # store the final_v in the object for future usage
                     ar_obj.module = final_m
 
-                    prev_ar_obj = final_ar_objs.get((ar_obj.name, ar_obj.platform, ar_obj.module), None)
-                    if prev_ar_obj:
-                        if rpm.compare_versions(prev_ar_obj.version, ar_obj.version) < 0:
-                            self.logger.debug(
-                                f"{cve_id}, platform={prev_ar_obj.platform}, package={prev_ar_obj.name}, module={prev_ar_obj.module} : multiple fix versions found, {ar_obj.version} > {prev_ar_obj.version}",  # noqa: E501
-                            )
-                            final_ar_objs[(ar_obj.name, ar_obj.platform, ar_obj.module)] = ar_obj
-                        else:
-                            self.logger.debug(
-                                f"{cve_id}, platform={prev_ar_obj.platform}, package={prev_ar_obj.name}, module={prev_ar_obj.module} : multiple fix versions found, {ar_obj.version} <= {prev_ar_obj.version}",  # noqa: E501
-                            )
-                    else:
-                        final_ar_objs[(ar_obj.name, ar_obj.platform, ar_obj.module)] = ar_obj
+                    key = (ar_obj.name, ar_obj.platform, ar_obj.module)
+                    bucket = collected_ar_objs.setdefault(key, [])
+                    # skip exact-duplicate versions (e.g. the same fix listed under both the
+                    # cpe:/a and cpe:/o product flavors); they carry no new information.
+                    if not any(rpm.compare_versions(existing.version, ar_obj.version) == 0 for existing in bucket):
+                        bucket.append(ar_obj)
 
                 except Exception:
                     self.logger.exception(f"error processing {cve_id} affected release object: {ar_obj.__dict__}")
 
-            # construct the final fixed in objects
-            fixed_ins = [
-                FixedIn(
-                    platform=ar_obj.platform,
-                    package=ar_obj.name,
-                    version=ar_obj.version,
-                    module=ar_obj.module,
-                    advisory=(
-                        Advisory(
-                            wont_fix=False,
-                            rhsa_id=ar_obj.rhsa_id,
-                            link=f"https://access.redhat.com/errata/{ar_obj.rhsa_id}",
-                            severity=None,
-                        )
-                        if ar_obj.rhsa_id
-                        else Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None)
+            # reduce each (package, platform, module) bucket to a single FixedIn. When the bucket
+            # holds fixes from more than one upstream version base, compute a VulnerableRange that
+            # describes the per-stream fix boundaries so that, e.g., a host carrying a 9.4 Z-stream
+            # backport is not falsely flagged against a later minor's upstream rebase.
+            for (pkg_name, platform, module), ar_objs in collected_ar_objs.items():
+                if not ar_objs:
+                    continue
+
+                # sort ascending using true RPM version ordering (not lexical)
+                ar_objs.sort(key=functools.cmp_to_key(lambda a, b: rpm.compare_versions(a.version, b.version)))
+
+                # reduce to distinct upstream version bases, keeping the highest fix within each base.
+                # Keeping the highest preserves the historical "fixed in the newest build" behavior for
+                # the common single-stream case; the per-base reduction only changes behavior when there
+                # is genuinely more than one upstream base (the multi-RHSA case Phase 1 targets).
+                fix_by_base: dict[str, AffectedRelease] = {}
+                for ar_obj in ar_objs:  # ascending, so the last write per base wins (highest)
+                    fix_by_base[_get_version_base(ar_obj.version)] = ar_obj
+                distinct_base_fixes = list(fix_by_base.values())  # ascending by base
+
+                # the canonical "fixed in" version reported for the major-version namespace is the
+                # newest stream's fix (highest base). VulnerableRange, when present, is what actually
+                # drives matching downstream; this version is the single-constraint fallback.
+                canonical = distinct_base_fixes[-1]
+
+                if len(distinct_base_fixes) > 1:
+                    vulnerable_range = _build_vulnerable_range(distinct_base_fixes)
+                    self.logger.debug(
+                        f"{cve_id}, platform={platform}, package={pkg_name}, module={module} : computed VulnerableRange from {len(distinct_base_fixes)} fix streams: {vulnerable_range}",  # noqa: E501
+                    )
+                    # fold every advisory that touched this bucket into the record, newest fix first and
+                    # de-duplicated. The primary advisory corresponds to the canonical (newest) fix.
+                    folded: list[Advisory] = []
+                    seen_rhsa: set[str] = set()
+                    for ar_obj in reversed(ar_objs):  # descending by version
+                        if ar_obj.rhsa_id and ar_obj.rhsa_id not in seen_rhsa:
+                            seen_rhsa.add(ar_obj.rhsa_id)
+                            folded.append(_advisory_from_rhsa(ar_obj.rhsa_id))
+                    primary_advisory = folded[0] if folded else _advisory_from_rhsa(canonical.rhsa_id)
+                    additional_advisories = tuple(folded[1:])
+                else:
+                    # single upstream stream: behave exactly as before — newest build, its advisory.
+                    vulnerable_range = None
+                    primary_advisory = _advisory_from_rhsa(canonical.rhsa_id)
+                    additional_advisories = ()
+
+                fixed_ins.append(
+                    FixedIn(
+                        platform=platform,
+                        package=pkg_name,
+                        version=canonical.version,
+                        module=module,
+                        advisory=primary_advisory,
+                        vulnerable_range=vulnerable_range,
+                        additional_advisories=additional_advisories,
                     ),
                 )
-                for ar_obj in final_ar_objs.values()
-            ]
         finally:
             # free up intermediate data structures
             try:
                 platform_packages.clear()
-                final_ar_objs.clear()
+                collected_ar_objs.clear()
                 del all_ar_objs[:]
                 del platform_packages
-                del final_ar_objs
+                del collected_ar_objs
                 del all_ar_objs
             except Exception:
                 self.logger.info("exception freeing up intermediate data structures", exc_info=True)
@@ -829,13 +867,16 @@ class Parser:
                         a = {"NoAdvisory": True}
                     else:
                         a = {"NoAdvisory": False, "AdvisorySummary": []}
-                        if artifact.advisory.rhsa_id and artifact.advisory.link:
-                            a["AdvisorySummary"].append(
-                                {
-                                    "ID": artifact.advisory.rhsa_id,
-                                    "Link": artifact.advisory.link,
-                                },
-                            )
+                        # primary advisory (corresponds to the canonical fix version) first, then any
+                        # additional advisories folded in from other fix streams for the same package.
+                        for adv in (artifact.advisory, *artifact.additional_advisories):
+                            if adv.rhsa_id and adv.link:
+                                a["AdvisorySummary"].append(
+                                    {
+                                        "ID": adv.rhsa_id,
+                                        "Link": adv.link,
+                                    },
+                                )
 
                     fix_version = artifact.version
                     package_name = artifact.package
@@ -848,6 +889,12 @@ class Parser:
                         "NamespaceName": ns,
                         "VendorAdvisory": a,
                     }
+
+                    # When multiple fix streams exist for the same package, VulnerableRange encodes the
+                    # per-stream fix boundaries directly as a grype version constraint. grype-db uses it
+                    # verbatim in preference to deriving "< Version" from the single fix version.
+                    if artifact.vulnerable_range:
+                        record["VulnerableRange"] = artifact.vulnerable_range
 
                     result = self.fixdater.best(
                         vuln_id=cve_id,
@@ -955,6 +1002,71 @@ class Parser:
             if self.rhsa_dict:
                 self.rhsa_dict.clear()
                 del self.rhsa_dict
+
+
+def _get_version_base(version: str) -> str:
+    """Return the epoch:version portion of an RPM version string, dropping the release.
+
+    The release (which carries the `.elN_M` dist tag) is what differentiates Z-stream/EUS
+    builds within a single upstream version, so the base is the right unit for deciding
+    whether two fixes belong to genuinely different upstream streams.
+
+    Examples:
+        "0:3.9.19-8.el9"        -> "0:3.9.19"
+        "3.9.18-3.el9_4.5"      -> "3.9.18"
+        "1:2.27-34.base.el7"    -> "1:2.27"
+    """
+    epoch, ver, _ = rpm.split_fullversion(version)
+    if ver is None:
+        return version
+    return f"{epoch}:{ver}" if epoch is not None else ver
+
+
+def _advisory_from_rhsa(rhsa_id: str | None) -> Advisory:
+    """Build an Advisory namedtuple from an RHSA ID, or an empty one when there is no advisory."""
+    if rhsa_id:
+        return Advisory(
+            wont_fix=False,
+            rhsa_id=rhsa_id,
+            link=f"https://access.redhat.com/errata/{rhsa_id}",
+            severity=None,
+        )
+    return Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None)
+
+
+def _build_vulnerable_range(sorted_base_fixes: list) -> str | None:
+    """Build an OR'd grype version constraint from fixes that live on distinct upstream bases.
+
+    Red Hat sometimes fixes the same package in the same major version more than once: a backport
+    that keeps the older upstream base on an older minor (e.g. python3.9 3.9.18-3.el9_4.5 for 9.4)
+    and a rebase to a newer upstream on a later minor (3.9.19-8.el9 for 9.5). Hydra flattens both
+    into "Red Hat Enterprise Linux 9", so a naive "fixed in the highest version" record falsely
+    flags a 9.4 host that already carries its backport (because 3.9.18 < 3.9.19 in RPM ordering).
+
+    Given the per-base fixes sorted ascending by upstream base, this produces a constraint like:
+
+        < 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9
+
+    read as: vulnerable if below the lowest stream's fix, OR within a later stream (at or above that
+    stream's base) but below that stream's fix. The `>= base` pivot is what isolates each stream:
+    a 9.4 build at-or-above its fix is < 3.9.19, so it falls into no clause and is considered fixed.
+
+    Returns None when fewer than two distinct upstream bases are present (nothing to disambiguate);
+    callers fall back to the single "< fix" constraint in that case.
+
+    NOTE: this only works when the streams have *distinct upstream bases*. Two fixes that share a
+    base but differ only in their `.elN_M` dist tag (e.g. an el9_2 vs el9_4 backport of 2.34) cannot
+    be separated by RPM version comparison and require per-minor namespacing instead.
+    """
+    if not sorted_base_fixes or len(sorted_base_fixes) < 2:
+        return None
+
+    groups = [f"< {sorted_base_fixes[0].version}"]
+    for fix in sorted_base_fixes[1:]:
+        base = _get_version_base(fix.version)
+        groups.append(f">= {base}, < {fix.version}")
+
+    return " || ".join(groups)
 
 
 class RHELCVSS3:

--- a/tests/unit/providers/rhel/test-fixtures/csaf/advisories/2024/rhsa-2024_6163.json
+++ b/tests/unit/providers/rhel/test-fixtures/csaf/advisories/2024/rhsa-2024_6163.json
@@ -1,0 +1,344 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Moderate"
+    },
+    "category": "csaf_security_advisory",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright \u00a9 Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "An update for python3.9 is now available for Red Hat Enterprise Linux 9.\n\nRed Hat Product Security has rated this update as having a security impact of Moderate. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* cpython: python: email module doesn't properly quotes newlines in email headers, allowing header injection (CVE-2024-6923)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2024:6163",
+        "url": "https://access.redhat.com/errata/RHSA-2024:6163"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#moderate",
+        "url": "https://access.redhat.com/security/updates/classification/#moderate"
+      },
+      {
+        "category": "external",
+        "summary": "2302255",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://security.access.redhat.com/data/csaf/v2/advisories/2024/rhsa-2024_6163.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: python3.9 security update",
+    "tracking": {
+      "current_release_date": "2026-03-26T18:50:03+00:00",
+      "generator": {
+        "date": "2026-03-26T18:50:03+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "4.7.4"
+        }
+      },
+      "id": "RHSA-2024:6163",
+      "initial_release_date": "2024-09-03T17:57:24+00:00",
+      "revision_history": [
+        {
+          "date": "2024-09-03T17:57:24+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-09-03T17:57:24+00:00",
+          "number": "2",
+          "summary": "Last updated version"
+        },
+        {
+          "date": "2026-03-26T18:50:03+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Red Hat",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                  "product_id": "AppStream-9.4.0.Z.MAIN.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:enterprise_linux:9::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                  "product_id": "BaseOS-9.4.0.Z.MAIN.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9::baseos"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux CRB (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux CRB (v. 9)",
+                  "product_id": "CRB-9.4.0.Z.MAIN.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:enterprise_linux:9::crb"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "category": "architecture",
+            "name": "src",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "python3.9-0:3.9.18-3.el9_4.5.src",
+                "product": {
+                  "name": "python3.9-0:3.9.18-3.el9_4.5.src",
+                  "product_id": "python3.9-0:3.9.18-3.el9_4.5.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3.9@3.9.18-3.el9_4.5?arch=src"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3.9-0:3.9.18-3.el9_4.5.src as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src"
+        },
+        "product_reference": "python3.9-0:3.9.18-3.el9_4.5.src",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3.9-0:3.9.18-3.el9_4.5.src as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src"
+        },
+        "product_reference": "python3.9-0:3.9.18-3.el9_4.5.src",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3.9-0:3.9.18-3.el9_4.5.src as a component of Red Hat Enterprise Linux CRB (v. 9)",
+          "product_id": "CRB-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src"
+        },
+        "product_reference": "python3.9-0:3.9.18-3.el9_4.5.src",
+        "relates_to_product_reference": "CRB-9.4.0.Z.MAIN.EUS"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-8088",
+      "cwe": {
+        "id": "CWE-835",
+        "name": "Loop with Unreachable Exit Condition ('Infinite Loop')"
+      },
+      "discovery_date": "2024-08-22T19:20:09.516938+00:00",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2307370"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in Python's zipfile module. When iterating over the entries of a zip archive, the process can enter into an infinite loop state and become unresponsive. This flaw allows an attacker to craft a malicious ZIP archive, leading to a denial of service from the application consuming the zipfile module. Only applications that handle user-controlled zip archives are affected by this vulnerability.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "python: cpython: Iterating over a malicious ZIP file may lead to Denial of Service",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "other",
+          "text": "Versions of python36:3.6/python36 as shipped with Red Hat Enterprise Linux 8 are marked as 'Not affected' as they just provide \"symlinks\" to the main python3 component, which provides the actual interpreter of the Python programming language.",
+          "title": "Statement"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "AppStream-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+          "BaseOS-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+          "CRB-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2024-8088"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2307370",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2307370"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2024-8088",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2024-8088"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2024-8088",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8088"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/commit/795f2597a4be988e2bb19b69ff9958e981cb894e",
+          "url": "https://github.com/python/cpython/commit/795f2597a4be988e2bb19b69ff9958e981cb894e"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/commit/8c7348939d8a3ecd79d630075f6be1b0c5b41f64",
+          "url": "https://github.com/python/cpython/commit/8c7348939d8a3ecd79d630075f6be1b0c5b41f64"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/commit/dcc5182f27c1500006a1ef78e10613bb45788dea",
+          "url": "https://github.com/python/cpython/commit/dcc5182f27c1500006a1ef78e10613bb45788dea"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/issues/122905",
+          "url": "https://github.com/python/cpython/issues/122905"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/pull/122906",
+          "url": "https://github.com/python/cpython/pull/122906"
+        },
+        {
+          "category": "external",
+          "summary": "https://mail.python.org/archives/list/security-announce@python.org/thread/GNFCKVI4TCATKQLALJ5SN4L4CSPSMILU/",
+          "url": "https://mail.python.org/archives/list/security-announce@python.org/thread/GNFCKVI4TCATKQLALJ5SN4L4CSPSMILU/"
+        }
+      ],
+      "release_date": "2024-08-22T19:15:09.720000+00:00",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "date": "2024-09-03T17:57:24+00:00",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+            "BaseOS-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+            "CRB-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src"
+          ],
+          "restart_required": {
+            "category": "none"
+          },
+          "url": "https://access.redhat.com/errata/RHSA-2024:6163"
+        },
+        {
+          "category": "workaround",
+          "details": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+          "product_ids": [
+            "AppStream-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+            "BaseOS-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+            "CRB-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "AppStream-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+            "BaseOS-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src",
+            "CRB-9.4.0.Z.MAIN.EUS:python3.9-0:3.9.18-3.el9_4.5.src"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate"
+        }
+      ],
+      "title": "python: cpython: Iterating over a malicious ZIP file may lead to Denial of Service"
+    }
+  ]
+}

--- a/tests/unit/providers/rhel/test-fixtures/csaf/advisories/2024/rhsa-2024_9371.json
+++ b/tests/unit/providers/rhel/test-fixtures/csaf/advisories/2024/rhsa-2024_9371.json
@@ -1,0 +1,354 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Moderate"
+    },
+    "category": "csaf_security_advisory",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright \u00a9 Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "An update for python3.9 is now available for Red Hat Enterprise Linux 9.\n\nRed Hat Product Security has rated this update as having a security impact of Moderate. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: cpython: Iterating over a malicious ZIP file may lead to Denial of Service (CVE-2024-8088)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 9.5 Release Notes linked from the References section.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2024:9371",
+        "url": "https://access.redhat.com/errata/RHSA-2024:9371"
+      },
+      {
+        "category": "external",
+        "summary": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.5_release_notes/index",
+        "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.5_release_notes/index"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#moderate",
+        "url": "https://access.redhat.com/security/updates/classification/#moderate"
+      },
+      {
+        "category": "external",
+        "summary": "2307370",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2307370"
+      },
+      {
+        "category": "external",
+        "summary": "RHEL-40750",
+        "url": "https://issues.redhat.com/browse/RHEL-40750"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://security.access.redhat.com/data/csaf/v2/advisories/2024/rhsa-2024_9371.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: python3.9 security update",
+    "tracking": {
+      "current_release_date": "2026-03-18T02:40:17+00:00",
+      "generator": {
+        "date": "2026-03-18T02:40:17+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "4.7.3"
+        }
+      },
+      "id": "RHSA-2024:9371",
+      "initial_release_date": "2024-11-12T09:38:54+00:00",
+      "revision_history": [
+        {
+          "date": "2024-11-12T09:38:54+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-11-12T09:38:54+00:00",
+          "number": "2",
+          "summary": "Last updated version"
+        },
+        {
+          "date": "2026-03-18T02:40:17+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Red Hat",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                  "product_id": "AppStream-9.5.0.GA",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:enterprise_linux:9::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                  "product_id": "BaseOS-9.5.0.GA",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9::baseos"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat CodeReady Linux Builder (v. 9)",
+                "product": {
+                  "name": "Red Hat CodeReady Linux Builder (v. 9)",
+                  "product_id": "CRB-9.5.0.GA",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:enterprise_linux:9::crb"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "category": "architecture",
+            "name": "src",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "python3.9-0:3.9.19-8.el9.src",
+                "product": {
+                  "name": "python3.9-0:3.9.19-8.el9.src",
+                  "product_id": "python3.9-0:3.9.19-8.el9.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3.9@3.9.19-8.el9?arch=src"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3.9-0:3.9.19-8.el9.src as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.5.0.GA:python3.9-0:3.9.19-8.el9.src"
+        },
+        "product_reference": "python3.9-0:3.9.19-8.el9.src",
+        "relates_to_product_reference": "AppStream-9.5.0.GA"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3.9-0:3.9.19-8.el9.src as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.5.0.GA:python3.9-0:3.9.19-8.el9.src"
+        },
+        "product_reference": "python3.9-0:3.9.19-8.el9.src",
+        "relates_to_product_reference": "BaseOS-9.5.0.GA"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3.9-0:3.9.19-8.el9.src as a component of Red Hat CodeReady Linux Builder (v. 9)",
+          "product_id": "CRB-9.5.0.GA:python3.9-0:3.9.19-8.el9.src"
+        },
+        "product_reference": "python3.9-0:3.9.19-8.el9.src",
+        "relates_to_product_reference": "CRB-9.5.0.GA"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-8088",
+      "cwe": {
+        "id": "CWE-835",
+        "name": "Loop with Unreachable Exit Condition ('Infinite Loop')"
+      },
+      "discovery_date": "2024-08-22T19:20:09.516938+00:00",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2307370"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in Python's zipfile module. When iterating over the entries of a zip archive, the process can enter into an infinite loop state and become unresponsive. This flaw allows an attacker to craft a malicious ZIP archive, leading to a denial of service from the application consuming the zipfile module. Only applications that handle user-controlled zip archives are affected by this vulnerability.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "python: cpython: Iterating over a malicious ZIP file may lead to Denial of Service",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "other",
+          "text": "Versions of python36:3.6/python36 as shipped with Red Hat Enterprise Linux 8 are marked as 'Not affected' as they just provide \"symlinks\" to the main python3 component, which provides the actual interpreter of the Python programming language.",
+          "title": "Statement"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "AppStream-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+          "BaseOS-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+          "CRB-9.5.0.GA:python3.9-0:3.9.19-8.el9.src"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2024-8088"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2307370",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2307370"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2024-8088",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2024-8088"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2024-8088",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-8088"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/commit/795f2597a4be988e2bb19b69ff9958e981cb894e",
+          "url": "https://github.com/python/cpython/commit/795f2597a4be988e2bb19b69ff9958e981cb894e"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/commit/8c7348939d8a3ecd79d630075f6be1b0c5b41f64",
+          "url": "https://github.com/python/cpython/commit/8c7348939d8a3ecd79d630075f6be1b0c5b41f64"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/commit/dcc5182f27c1500006a1ef78e10613bb45788dea",
+          "url": "https://github.com/python/cpython/commit/dcc5182f27c1500006a1ef78e10613bb45788dea"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/issues/122905",
+          "url": "https://github.com/python/cpython/issues/122905"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/python/cpython/pull/122906",
+          "url": "https://github.com/python/cpython/pull/122906"
+        },
+        {
+          "category": "external",
+          "summary": "https://mail.python.org/archives/list/security-announce@python.org/thread/GNFCKVI4TCATKQLALJ5SN4L4CSPSMILU/",
+          "url": "https://mail.python.org/archives/list/security-announce@python.org/thread/GNFCKVI4TCATKQLALJ5SN4L4CSPSMILU/"
+        }
+      ],
+      "release_date": "2024-08-22T19:15:09.720000+00:00",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "date": "2024-11-12T09:38:54+00:00",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+            "BaseOS-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+            "CRB-9.5.0.GA:python3.9-0:3.9.19-8.el9.src"
+          ],
+          "restart_required": {
+            "category": "none"
+          },
+          "url": "https://access.redhat.com/errata/RHSA-2024:9371"
+        },
+        {
+          "category": "workaround",
+          "details": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+          "product_ids": [
+            "AppStream-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+            "BaseOS-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+            "CRB-9.5.0.GA:python3.9-0:3.9.19-8.el9.src"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "AppStream-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+            "BaseOS-9.5.0.GA:python3.9-0:3.9.19-8.el9.src",
+            "CRB-9.5.0.GA:python3.9-0:3.9.19-8.el9.src"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate"
+        }
+      ],
+      "title": "python: cpython: Iterating over a malicious ZIP file may lead to Denial of Service"
+    }
+  ]
+}

--- a/tests/unit/providers/rhel/test-fixtures/csaf/hydra/cve-2024-8088.json
+++ b/tests/unit/providers/rhel/test-fixtures/csaf/hydra/cve-2024-8088.json
@@ -1,0 +1,45 @@
+{
+  "name": "CVE-2024-8088",
+  "threat_severity": "Moderate",
+  "public_date": "2024-08-22T19:15:09Z",
+  "cvss3": {
+    "cvss3_base_score": "5.3",
+    "cvss3_scoring_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:H",
+    "status": "verified"
+  },
+  "details": [
+    "There is a HIGH severity vulnerability affecting the CPython \"zipfile\"\nmodule affecting \"zipfile.Path\". Note that the more common API \"zipfile.ZipFile\" class is unaffected.\nWhen iterating over names of entries in a zip archive (for example, methods\nof \"zipfile.Path\" like \"namelist()\", \"iterdir()\", etc)\nthe process can be put into an infinite loop with a maliciously crafted\nzip archive. This defect applies when reading only metadata or extracting\nthe contents of the zip archive. Programs that are not handling\nuser-controlled zip archives are not affected.",
+    "A flaw was found in Python's zipfile module. When iterating over the entries of a zip archive, the process can enter into an infinite loop state and become unresponsive. This flaw allows an attacker to craft a malicious ZIP archive, leading to a denial of service from the application consuming the zipfile module. Only applications that handle user-controlled zip archives are affected by this vulnerability."
+  ],
+  "affected_release": [
+    {
+      "product_name": "Red Hat Enterprise Linux 9",
+      "release_date": "2024-09-03T00:00:00Z",
+      "advisory": "RHSA-2024:6163",
+      "cpe": "cpe:/a:redhat:enterprise_linux:9",
+      "package": "python3.9-0:3.9.18-3.el9_4.5"
+    },
+    {
+      "product_name": "Red Hat Enterprise Linux 9",
+      "release_date": "2024-11-12T00:00:00Z",
+      "advisory": "RHSA-2024:9371",
+      "cpe": "cpe:/a:redhat:enterprise_linux:9",
+      "package": "python3.9-0:3.9.19-8.el9"
+    },
+    {
+      "product_name": "Red Hat Enterprise Linux 9",
+      "release_date": "2024-09-03T00:00:00Z",
+      "advisory": "RHSA-2024:6163",
+      "cpe": "cpe:/o:redhat:enterprise_linux:9",
+      "package": "python3.9-0:3.9.18-3.el9_4.5"
+    },
+    {
+      "product_name": "Red Hat Enterprise Linux 9",
+      "release_date": "2024-11-12T00:00:00Z",
+      "advisory": "RHSA-2024:9371",
+      "cpe": "cpe:/o:redhat:enterprise_linux:9",
+      "package": "python3.9-0:3.9.19-8.el9"
+    }
+  ],
+  "package_state": []
+}

--- a/tests/unit/providers/rhel/test_multi_rhsa.py
+++ b/tests/unit/providers/rhel/test_multi_rhsa.py
@@ -1,0 +1,163 @@
+"""Tests for the "multiple RHSAs for one package" matching mechanism (Phase 1).
+
+Red Hat sometimes ships more than one fix for the same package within a single RHEL
+major version: a Z-stream/EUS backport that keeps the older upstream base on an older
+minor, plus an upstream rebase on a later minor. The Hydra API flattens both into
+"Red Hat Enterprise Linux N", so a naive "fixed in the highest version" record falsely
+flags a host that already carries the older stream's backport.
+
+The canonical real-world example is CVE-2024-8088 / python3.9 on RHEL 9:
+  - RHSA-2024:6163 fixes the 9.4 Z-stream at python3.9-0:3.9.18-3.el9_4.5
+  - RHSA-2024:9371 fixes the 9.5 GA build at python3.9-0:3.9.19-8.el9
+
+Phase 1 emits a VulnerableRange constraint that partitions the two streams by their
+upstream version base so that existing grype/grype-db match correctly with no upgrade:
+
+    < 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9
+
+The integration test below drives the real CSAF parser against subsetted-but-real CSAF
+advisories (RHSA-2024:6163, RHSA-2024:9371) and a subsetted-but-real Hydra CVE record.
+See https://access.redhat.com/security/cve/cve-2024-8088#cve-affected-packages
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import orjson
+import pytest
+
+from vunnel import workspace
+from vunnel.providers.rhel.csaf_parser import CSAFParser
+from vunnel.providers.rhel.csaf_client import CSAFClient
+from vunnel.providers.rhel.parser import AffectedRelease, Parser, _build_vulnerable_range, _get_version_base
+from vunnel.providers.rhel.rhsa_provider import CSAFRHSAProvider
+
+
+@pytest.fixture()
+def fixture_dir():
+    return Path(__file__).parent / "test-fixtures"
+
+
+def _ar(version: str, rhsa: str | None = None, platform: str = "9", module: str | None = None) -> AffectedRelease:
+    ar = AffectedRelease(name="pkg", version=version, platform=platform, module=module)
+    ar.rhsa_id = rhsa
+    return ar
+
+
+class TestGetVersionBase:
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            ("0:3.9.19-8.el9", "0:3.9.19"),
+            ("3.9.18-3.el9_4.5", "3.9.18"),
+            ("1:2.27-34.base.el7", "1:2.27"),
+            ("4:20210216-1.20210608.1.el8_4", "4:20210216"),
+            # no release component: returned unchanged
+            ("3.9.19", "3.9.19"),
+        ],
+    )
+    def test_get_version_base(self, version, expected):
+        assert _get_version_base(version) == expected
+
+
+class TestBuildVulnerableRange:
+    def test_distinct_bases_python39(self):
+        # the canonical CVE-2024-8088 shape (already deduped + sorted ascending by base)
+        fixes = [_ar("0:3.9.18-3.el9_4.5"), _ar("0:3.9.19-8.el9")]
+        assert _build_vulnerable_range(fixes) == "< 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9"
+
+    def test_three_distinct_bases(self):
+        fixes = [
+            _ar("4:20200609-2.20201027.1.el8_3"),
+            _ar("4:20210216-1.20210608.1.el8_4"),
+            _ar("4:20240910-1.el8_5"),
+        ]
+        assert _build_vulnerable_range(fixes) == (
+            "< 4:20200609-2.20201027.1.el8_3 || >= 4:20210216, < 4:20210216-1.20210608.1.el8_4 || >= 4:20240910, < 4:20240910-1.el8_5"
+        )
+
+    def test_single_fix_returns_none(self):
+        assert _build_vulnerable_range([_ar("0:3.9.19-8.el9")]) is None
+
+    def test_empty_returns_none(self):
+        assert _build_vulnerable_range([]) is None
+
+
+def _wire_csaf_rhsa_provider(ws: workspace.Workspace, fixture_dir: Path) -> Mock:
+    """Build a Mock CSAFRHSAProvider backed by the real CSAFParser, resolving fixes from
+    the subsetted real CSAF advisories for RHSA-2024:6163 and RHSA-2024:9371."""
+    from vunnel.utils.csaf_types import from_path
+
+    adv_dir = fixture_dir / "csaf" / "advisories" / "2024"
+    docs = {
+        "RHSA-2024:6163": from_path(adv_dir / "rhsa-2024_6163.json"),
+        "RHSA-2024:9371": from_path(adv_dir / "rhsa-2024_9371.json"),
+    }
+
+    mock_client = Mock(spec=CSAFClient)
+    mock_client.csaf_doc_for_rhsa.side_effect = lambda rhsa: docs.get(rhsa)
+
+    csaf_parser = CSAFParser(workspace=ws, client=mock_client, logger=Mock(), download_timeout=125)
+
+    mock_rhsa_provider = Mock(spec=CSAFRHSAProvider)
+    mock_rhsa_provider.get_fixed_version_and_module.side_effect = lambda cve_id, ar, override_pkg: csaf_parser.get_fix_info(
+        cve_id,
+        ar.as_dict(),
+        override_pkg or ar.name,
+    )
+    return mock_rhsa_provider
+
+
+class TestCVE2024_8088:
+    """End-to-end through _parse_cve with subsetted real CSAF + Hydra data."""
+
+    @pytest.fixture()
+    def hydra_cve(self, fixture_dir):
+        path = fixture_dir / "csaf" / "hydra" / "cve-2024-8088.json"
+        with open(path, "rb") as f:
+            return orjson.loads(f.read())
+
+    def _python39_fixed_in(self, results):
+        rhel9 = [r for r in results if r.namespace == "rhel:9"]
+        assert len(rhel9) == 1, f"expected exactly one rhel:9 payload, got namespaces {[r.namespace for r in results]}"
+        fixed_in = rhel9[0].payload["Vulnerability"]["FixedIn"]
+        py = [f for f in fixed_in if f["Name"] == "python3.9"]
+        assert len(py) == 1, f"expected exactly one python3.9 FixedIn, got {fixed_in}"
+        return py[0]
+
+    def test_emits_partitioned_vulnerable_range(self, hydra_cve, fixture_dir, tmpdir, auto_fake_fixdate_finder):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        driver = Parser(workspace=ws, skip_namespaces=[])
+        driver.rhsa_provider = _wire_csaf_rhsa_provider(ws, fixture_dir)
+
+        results = driver._parse_cve("CVE-2024-8088", hydra_cve)
+        record = self._python39_fixed_in(results)
+
+        # the two streams are partitioned by upstream version base; a 9.4 host at or above
+        # 3.9.18-3.el9_4.5 is < 3.9.19 and therefore matches no clause (not vulnerable).
+        assert record["VulnerableRange"] == "< 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9"
+
+    def test_canonical_version_is_newest_stream(self, hydra_cve, fixture_dir, tmpdir, auto_fake_fixdate_finder):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        driver = Parser(workspace=ws, skip_namespaces=[])
+        driver.rhsa_provider = _wire_csaf_rhsa_provider(ws, fixture_dir)
+
+        record = self._python39_fixed_in(driver._parse_cve("CVE-2024-8088", hydra_cve))
+
+        # the single-constraint fallback / user-facing "fixed in" is the newest stream's fix
+        assert record["Version"] == "0:3.9.19-8.el9"
+        assert record["VersionFormat"] == "rpm"
+
+    def test_folds_both_advisories_newest_first(self, hydra_cve, fixture_dir, tmpdir, auto_fake_fixdate_finder):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        driver = Parser(workspace=ws, skip_namespaces=[])
+        driver.rhsa_provider = _wire_csaf_rhsa_provider(ws, fixture_dir)
+
+        record = self._python39_fixed_in(driver._parse_cve("CVE-2024-8088", hydra_cve))
+
+        summaries = record["VendorAdvisory"]["AdvisorySummary"]
+        ids = [s["ID"] for s in summaries]
+        # both RHSAs that touched this package are surfaced, newest fix first
+        assert ids == ["RHSA-2024:9371", "RHSA-2024:6163"]

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -613,7 +613,10 @@ class TestParser:
                 ],
             ),
             (
-                # same package and platform, different versions - major, minor
+                # same package and platform, different versions across distinct upstream bases
+                # (10.19.0 / 11.19.1 / 12.16.1). These are genuinely different streams, so a
+                # VulnerableRange is emitted partitioning each stream below its own fix. The
+                # reported Version remains the newest stream's fix (single-constraint fallback).
                 {
                     "affected_release": [
                         {
@@ -638,6 +641,11 @@ class TestParser:
                         platform="8",
                         version="1:12.16.1-2.module+el8.1.0+6117+b25a342c",
                         advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        vulnerable_range=(
+                            "< 1:10.19.0-2.module+el8.1.0+6118+5aaa808b "
+                            "|| >= 1:11.19.1, < 1:11.19.1-2.module+el8.1.0+6118+5aaa808b "
+                            "|| >= 1:12.16.1, < 1:12.16.1-2.module+el8.1.0+6117+b25a342c"
+                        ),
                     )
                 ],
             ),


### PR DESCRIPTION
When Red Hat ships more than one fix for the same package in a single RHEL major version at distinct upstream version bases — a minor-stream backport that keeps the older base (release tag .elN_M) plus a later rebase to a newer base (release tag .elN) — Hydra reports both under the same "Red Hat Enterprise Linux N" product. Previously the parser collapsed them to the single highest fix, falsely flagging hosts that already carry the older stream's backport (e.g. python3.9-3.9.18-3.el9_4.5 flagged against the 3.9.19-8.el9 fix for CVE-2024-8088, because 3.9.18 < 3.9.19 in RPM ordering).

_parse_affected_release now collects all fixes per (package, platform, module), reduces them to distinct upstream bases, and when more than one base exists emits a VulnerableRange that partitions each stream below its own fix:

    < 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9

grype-db uses VulnerableRange verbatim and grype already evaluates the compound constraint, so existing clients match correctly with no upgrade. The reported Version stays the newest stream's fix (single-constraint fallback) and all contributing RHSAs are folded into the advisory summary.

The change is additive: single-stream and same-base groups behave exactly as before. Same-base streams (only the .elN_M dist tag differs, e.g. .el9_2 vs .el9_4 of glibc 2.34) can't be separated by RPM version comparison and remain for a later change.

See https://access.redhat.com/security/cve/cve-2024-8088#cve-affected-packages `python3.9` for RHEL 9 for an example.


```
$ grype db search --vuln  CVE-2024-8088 --distro rhel:9
VULNERABILITY  PACKAGE     ECOSYSTEM  NAMESPACE               VERSION CONSTRAINT
CVE-2024-8088  python3.11  rpm        redhat:distro:redhat:9  < 0:3.11.9-7.el9
CVE-2024-8088  python3.12  rpm        redhat:distro:redhat:9  < 0:3.12.5-2.el9
CVE-2024-8088  python3.9   rpm        redhat:distro:redhat:9  < 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9
```