### PR TITLE
feat(oracle): emit architecture-scoped versions in ELSAs

### DIFF
--- a/schema/vulnerability/os/schema-1.1.1.json
+++ b/schema/vulnerability/os/schema-1.1.1.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "os-vulnerability",
+  "description": "represents vulnerability records for common linux distributions",
+  "properties": {
+    "Vulnerability": {
+      "type": "object",
+      "properties": {
+        "CVSS": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "base_metrics": {
+                  "type": "object",
+                  "properties": {
+                    "base_score": {
+                      "type": "number"
+                    },
+                    "base_severity": {
+                      "type": "string"
+                    },
+                    "exploitability_score": {
+                      "type": "number"
+                    },
+                    "impact_score": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "base_score",
+                    "base_severity",
+                    "exploitability_score",
+                    "impact_score"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "vector_string": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "base_metrics",
+                "status",
+                "vector_string",
+                "version"
+              ]
+            }
+          ]
+        },
+        "Description": {
+          "type": "string"
+        },
+        "FixedIn": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "Name": {
+                  "type": "string"
+                },
+                "NamespaceName": {
+                  "type": "string"
+                },
+                "VendorAdvisory": {
+                  "type": "object",
+                  "properties": {
+                    "AdvisorySummary": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "NoAdvisory": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "NoAdvisory"
+                  ]
+                },
+                "Version": {
+                  "type": "string"
+                },
+                "VersionFormat": {
+                  "type": "string"
+                },
+                "Availability": {
+                  "type": "object",
+                  "properties": {
+                    "Date": {
+                      "type": "string"
+                    },
+                    "Kind": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "VulnerableRange": {
+                  "type": ["string", "null"]
+                },
+                "Module": {
+                  "type": ["string", "null"]
+                },
+                "Arch": {
+                  "type": ["string", "null"],
+                  "description": "the architecture this fix applies to (e.g. \"x86_64\", \"aarch64\"). Set only when a single advisory ships different fixes per architecture; omitted/null when the fix is identical across architectures, in which case it applies to all."
+                }
+              },
+              "required": [
+                "Name",
+                "NamespaceName",
+                "Version",
+                "VersionFormat"
+              ]
+            }
+          ]
+        },
+        "Link": {
+          "type": "string"
+        },
+        "Metadata": {
+          "type": "object",
+          "properties": {
+            "Issued": {
+              "type": "string",
+              "description": "date the vulnerability was published"
+            },
+            "Updated": {
+              "type": "string",
+              "description": "date the vulnerability was last updated"
+            },
+            "Withdrawn": {
+              "type": "string",
+              "description": "date the vulnerability was withdrawn"
+            },
+            "RefId": {
+              "type": "string"
+            },
+            "CVE": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Name": {
+                      "type": "string"
+                    },
+                    "Link": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Name"
+                  ]
+                }
+              ]
+            },
+            "NVD": {
+              "type": "object",
+              "properties": {
+                "CVSSv2": {
+                  "type": "object",
+                  "properties": {
+                    "Score": {
+                      "type": "number"
+                    },
+                    "Vectors": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Score"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "Name": {
+          "type": "string"
+        },
+        "NamespaceName": {
+          "type": "string"
+        },
+        "Severity": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Description",
+        "FixedIn",
+        "Link",
+        "Metadata",
+        "Name",
+        "NamespaceName",
+        "Severity"
+      ]
+    }
+  },
+  "required": [
+    "Vulnerability"
+  ]
+}

--- a/src/vunnel/providers/oracle/__init__.py
+++ b/src/vunnel/providers/oracle/__init__.py
@@ -25,7 +25,11 @@ class Config:
 
 
 class Provider(provider.Provider):
-    __schema__ = schema.OSSchema()
+    # Oracle advisories can ship a different fix per architecture (e.g. an x86_64 and aarch64 build
+    # respun at different revisions), which this provider records via the optional FixedIn.Arch
+    # field added in OS schema 1.1.1. Other OS providers never emit Arch and stay on the default
+    # OS schema version, so only Oracle advertises 1.1.1.
+    __schema__ = schema.OSSchema(version="1.1.1")
     __distribution_version__ = int(__schema__.major_version)
 
     def __init__(self, root: str, config: Config | None = None):

--- a/src/vunnel/providers/oracle/oval_parser.py
+++ b/src/vunnel/providers/oracle/oval_parser.py
@@ -6,6 +6,7 @@ import gzip
 import logging
 import os
 import re
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import defusedxml.ElementTree as ET
@@ -34,6 +35,10 @@ class Config:
     pkg_module_pattern: re.Pattern | None = None
     signed_with_pattern: re.Pattern | None = None
     platform_version_pattern: re.Pattern | None = None
+    # arch_pattern is optional: when set, a criterion comment matching it (e.g. "Oracle Linux
+    # arch is x86_64") tags the package-version tests gated by that branch with the architecture,
+    # so a single advisory that ships different fixes per arch is not flattened together.
+    arch_pattern: re.Pattern | None = None
 
     # xpath queries
     title_xpath_query: str | None = None
@@ -127,7 +132,7 @@ def _parse_severity(def_element, oval_ns, vuln_id: str, config: Config) -> str:
     return severity
 
 
-def _process_definition(def_element, vuln_dict, config: Config):  # noqa: PLR0912, C901
+def _process_definition(def_element, vuln_dict, config: Config):  # noqa: PLR0912
     oval_ns = re.search(config.ns_pattern, def_element.tag).group(1)
 
     def_version = def_element.attrib["version"]
@@ -175,20 +180,7 @@ def _process_definition(def_element, vuln_dict, config: Config):  # noqa: PLR091
             v["Vulnerability"]["Metadata"]["CVE"] = cves
 
         if ns_pkgs_dict and ns_name in ns_pkgs_dict:
-            fixed_in_list = []
-            for x in ns_pkgs_dict[ns_name]:
-                fixed_el = {
-                    "Name": x[0],
-                    "Version": x[1],
-                    "Module": x[2],
-                    "VersionFormat": "rpm",  # hard code version format for now
-                    "NamespaceName": ns_name,
-                }
-                # add Available object if fix version exists and issued date is available
-                if x[1] != "None" and issued:
-                    fixed_el["Available"] = {"Date": date.normalize_date(issued), "Kind": "advisory"}
-                fixed_in_list.append(fixed_el)
-            v["Vulnerability"]["FixedIn"] = fixed_in_list
+            v["Vulnerability"]["FixedIn"] = _build_fixed_in(ns_pkgs_dict[ns_name], ns_name, issued)
         else:
             logger.warning(f"No affected packages found for {name}, this is unusual")
 
@@ -216,66 +208,108 @@ def _process_definition(def_element, vuln_dict, config: Config):  # noqa: PLR091
 
 def _process_criteria(element_a, oval_ns, config: Config):
     """
-    Parse and return a dict containing namespace mapped to a set of (package, version) tuples
-    :param element_a: outermost criteria element within a definition element
-    :param oval_ns: namespace URL of the oval
-    :return:
+    Parse and return a dict mapping namespace -> set of (package, version, module, arch) tuples.
+
+    The outermost criteria of a definition is either a single platform group (operator AND) or an
+    OR of per-platform groups (a definition that covers multiple OS releases). Each group is walked
+    recursively so a package-version test inherits the module and architecture of the branch that
+    gates it (see _collect_affected). arch is None unless config.arch_pattern is set and the branch
+    carried an arch criterion.
     """
     criteria_element = element_a.find(config.criteria_xpath_query.format(oval_ns))
-    groups = []
-    ns_pkgs_dict = {}
+    ns_pkgs_dict: dict = {}
+    if criteria_element is None:
+        return ns_pkgs_dict
 
-    if criteria_element.attrib["operator"].lower() == "or":
-        for child in list(criteria_element):
-            groups.append(_get_all_criterion(child, oval_ns, config))
-    else:
-        groups.append(_get_all_criterion(criteria_element, oval_ns, config))
+    groups = list(criteria_element.findall(f"{oval_ns}criteria")) if criteria_element.attrib["operator"].lower() == "or" else [criteria_element]
 
     for group in groups:
-        if not group:
-            # logger.debug('Parsed group for one or more criterion is empty, skipping')
-            continue  # bail out of processing the group if its empty
-
-        # Find the first platform version string in the returned list
-        ns_name, ns_module = next((x for x in group if not isinstance(x, tuple)), None)
-
-        if ns_name:  # proceed only if a platform is found
-            # Filter out duplicate (package, version) tuples
-            ns_pkgs_dict[ns_name] = {tuple(list(x) + [ns_module]) for x in group if isinstance(x, tuple)}  # noqa: RUF005
-        else:
-            # logger.debug('Namespace for the criteria not found, ignoring criteria')
-            continue  # ignore this group of conditions if namespace is not found
+        ns_name, affected = _collect_affected(group, oval_ns, config)
+        if ns_name and affected:
+            ns_pkgs_dict.setdefault(ns_name, set()).update(affected)
 
     return ns_pkgs_dict
 
 
-def _get_all_criterion(element_b, oval_ns, config: Config):
+def _collect_affected(criteria_element, oval_ns, config: Config, arch=None, module=None):
     """
-    Search for all the criterion elements under the given criteria element and
-    parse contents into a list. Returned list may contain tuples and or simple strings.
-    Package name and version found in the comment of a criterion element is represented by a tuple.
-    Platform version found in the comment of a criterion element is represented by a simple string.
-    :param element_b: criteria element
-    :param oval_ns: namespace URL of the oval
-    :return:
+    Recursively walk a criteria subtree and return (ns_name, [(package, version, module, arch), ...]).
+
+    module and arch are inherited from the nearest enclosing criterion that sets them, so a
+    "PKG is earlier than V" test picks up the module and architecture of the branch gating it. This
+    keeps a per-arch fix (e.g. an advisory whose x86_64 and aarch64 builds were respun at different
+    revisions) attributed to the right architecture instead of being flattened together.
     """
-    collectibles = []
-    final_ns_name = None
-    final_module_name = None
     ns_name = None
-    module_name = None
-    for criterion in element_b.iterfind(config.criterion_xpath_query.format(oval_ns)):
-        if re.search(config.pkg_version_pattern, criterion.attrib["comment"]):
-            pkg, version = re.search(config.pkg_version_pattern, criterion.attrib["comment"]).groups()
-            collectibles.append((pkg, version))
-        elif re.search(config.is_installed_pattern, criterion.attrib["comment"]):
-            ns_name = config.ns_format.format(re.search(config.is_installed_pattern, criterion.attrib["comment"]).group(1))
-        elif re.search(config.pkg_module_pattern, criterion.attrib["comment"]):
-            module_name = re.search(config.pkg_module_pattern, criterion.attrib["comment"]).group(1)
-        if ns_name:
-            final_ns_name = ns_name
-        if module_name:
-            final_module_name = module_name
-    if final_ns_name:
-        collectibles.append([final_ns_name, final_module_name])
-    return collectibles
+    local_arch = arch
+    local_module = module
+    versions = []
+
+    for criterion in criteria_element.findall(f"{oval_ns}criterion"):
+        comment = criterion.attrib["comment"]
+        m = re.search(config.pkg_version_pattern, comment)
+        if m:
+            versions.append((m.group(1), m.group(2)))
+            continue
+        m = re.search(config.is_installed_pattern, comment)
+        if m:
+            ns_name = config.ns_format.format(m.group(1))
+            continue
+        if config.pkg_module_pattern:
+            m = re.search(config.pkg_module_pattern, comment)
+            if m:
+                local_module = m.group(1)
+                continue
+        if config.arch_pattern:
+            m = re.search(config.arch_pattern, comment)
+            if m:
+                local_arch = m.group(1)
+                continue
+
+    affected = [(pkg, version, local_module, local_arch) for pkg, version in versions]
+
+    for child in criteria_element.findall(f"{oval_ns}criteria"):
+        child_ns, child_affected = _collect_affected(child, oval_ns, config, local_arch, local_module)
+        if child_ns:
+            ns_name = child_ns
+        affected.extend(child_affected)
+
+    return ns_name, affected
+
+
+def _build_fixed_in(pkg_tuples, ns_name, issued):
+    """
+    Build the FixedIn list from (package, version, module, arch) tuples, emitting an architecture
+    only when it actually differentiates a fix.
+
+    For a given (package, module): if every architecture is fixed at the same version, a single
+    arch-less FixedIn is emitted (it applies to all arches, saving database space and matching the
+    historical shape). If the fixed version differs across architectures, one FixedIn per (arch,
+    version) is emitted with Arch set, so a fix for one arch never over-matches another.
+    """
+    grouped: dict = defaultdict(set)  # (name, module) -> {(version, arch), ...}
+    for pkg, version, module, arch in pkg_tuples:
+        grouped[(pkg, module)].add((version, arch))
+
+    fixed_in_list = []
+    for (pkg, module), version_arches in grouped.items():
+        distinct_versions = {version for version, _ in version_arches}
+        entries = [(next(iter(distinct_versions)), None)] if len(distinct_versions) <= 1 else sorted(version_arches)
+        for version, arch in entries:
+            fixed_el = {
+                "Name": pkg,
+                "Version": version,
+                "Module": module,
+                "VersionFormat": "rpm",  # hard code version format for now
+                "NamespaceName": ns_name,
+            }
+            if arch:
+                fixed_el["Arch"] = arch
+            # add Available object if fix version exists and issued date is available
+            if version != "None" and issued:
+                fixed_el["Available"] = {"Date": date.normalize_date(issued), "Kind": "advisory"}
+            fixed_in_list.append(fixed_el)
+
+    # stable ordering for reproducible output
+    fixed_in_list.sort(key=lambda f: (f["Name"], f.get("Arch") or "", f["Version"]))
+    return fixed_in_list

--- a/src/vunnel/providers/oracle/oval_parser.py
+++ b/src/vunnel/providers/oracle/oval_parser.py
@@ -282,10 +282,16 @@ def _build_fixed_in(pkg_tuples, ns_name, issued):
     Build the FixedIn list from (package, version, module, arch) tuples, emitting an architecture
     only when it actually differentiates a fix.
 
-    For a given (package, module): if every architecture is fixed at the same version, a single
-    arch-less FixedIn is emitted (it applies to all arches, saving database space and matching the
-    historical shape). If the fixed version differs across architectures, one FixedIn per (arch,
-    version) is emitted with Arch set, so a fix for one arch never over-matches another.
+    For a given (package, module) we look at which architectures each fixed version covers:
+
+    - If every version covers the same set of architectures, architecture is not a differentiator,
+      so we emit one arch-less FixedIn per distinct version (matching the historical shape and saving
+      database space). This covers the common "one version on all arches" gate as well as "two module
+      rebuilds, each present on every arch" - where splitting by arch would only create redundant
+      duplicate rows.
+    - If different versions cover different architecture sets (e.g. an advisory whose x86_64 and
+      aarch64 builds were respun at different revisions), architecture does differentiate, so we emit
+      one FixedIn per (version, arch) with Arch set, so a fix for one arch never over-matches another.
     """
     grouped: dict = defaultdict(set)  # (name, module) -> {(version, arch), ...}
     for pkg, version, module, arch in pkg_tuples:
@@ -293,8 +299,14 @@ def _build_fixed_in(pkg_tuples, ns_name, issued):
 
     fixed_in_list = []
     for (pkg, module), version_arches in grouped.items():
-        distinct_versions = {version for version, _ in version_arches}
-        entries = [(next(iter(distinct_versions)), None)] if len(distinct_versions) <= 1 else sorted(version_arches)
+        arches_by_version: dict = defaultdict(set)
+        for version, arch in version_arches:
+            arches_by_version[version].add(arch)
+
+        # architecture only matters when different versions cover different arch sets
+        arch_discriminates = len({frozenset(arches) for arches in arches_by_version.values()}) > 1
+        entries = sorted(version_arches) if arch_discriminates else [(version, None) for version in sorted(arches_by_version)]
+
         for version, arch in entries:
             fixed_el = {
                 "Name": pkg,

--- a/src/vunnel/providers/oracle/parser.py
+++ b/src/vunnel/providers/oracle/parser.py
@@ -25,6 +25,7 @@ ol_config.is_installed_pattern = re.compile(r"Oracle Linux (\d+).*is installed")
 ol_config.pkg_version_pattern = re.compile(r"(.*) is earlier than (.*)")
 ol_config.pkg_module_pattern = re.compile(r"Module (.*) is enabled")
 ol_config.signed_with_pattern = re.compile(r"(.*) is signed with the (.*) key")
+ol_config.arch_pattern = re.compile(r"Oracle Linux arch is (\S+)")
 ol_config.platform_version_pattern = re.compile(r"Oracle Linux (\d+)")
 
 # xpath queries

--- a/tests/unit/providers/oracle/test-fixtures/mock_per_arch_data
+++ b/tests/unit/providers/oracle/test-fixtures/mock_per_arch_data
@@ -1,74 +1,562 @@
 <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
+<!-- Real ELSA definitions copied verbatim from com.oracle.elsa-all.xml (prod OVAL).
+     ELSA-2022-4803 rsyslog: x86_64/aarch64 respun at different revisions -> arch-specific.
+     ELSA-2025-10073 firefox: one fix shared by every arch -> arch-less.
+     ELSA-2024-2961 osbuild: two rebuilds, each on both arches -> arch-less (not per-arch).
+     Only the affected <definition> blocks are kept; the parser reads criterion comments
+     and metadata only, so the referenced tests/objects/states are not needed. -->
 <definitions>
 <definition id="oval:com.oracle.elsa:def:20224803" version="501" class="patch">
 <metadata>
-<title>ELSA-2022-4803:  rsyslog security update (IMPORTANT)</title>
-<affected family="unix"><platform>Oracle Linux 7</platform></affected>
+<title>
+ELSA-2022-4803:  rsyslog security update (IMPORTANT)
+</title>
+<affected family="unix">
+<platform>Oracle Linux 7</platform>
+
+</affected>
 <reference source="elsa" ref_id="ELSA-2022-4803" ref_url="https://linux.oracle.com/errata/ELSA-2022-4803.html"/>
 <reference source="CVE" ref_id="CVE-2022-24903" ref_url="https://linux.oracle.com/cve/CVE-2022-24903.html"/>
-<description>rsyslog</description>
-<advisory><severity>IMPORTANT</severity><issued date="2022-05-31"/><cve href="https://linux.oracle.com/cve/CVE-2022-24903.html">CVE-2022-24903</cve></advisory>
+
+<description>
+[8.24.0-57.0.4.el7_9.3]
+- Newer gcc complains about implicit declaration of prctl. Added header file to quiesce the compiler
+
+[8.24.0-57.3]
+- Address CVE-2022-24903, Heap-based overflow in TCP syslog server
+  resolves: rhbz#2081395
+</description>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   advisory details   ~~~~~~~~~~~~~~~~~~~ 
+-->
+<advisory>
+<severity>IMPORTANT</severity>
+<rights>Copyright 2022 Oracle, Inc.</rights>
+<issued date="2022-05-31"/>
+<cve cvss3="8.1/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H" href="https://linux.oracle.com/cve/CVE-2022-24903.html" public="20220506">CVE-2022-24903</cve>
+
+<affected_cpe_list>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.21.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.17.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.20.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.14.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.5.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.2.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:24.1.0.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:linux:7::optional_latest</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:24.1.1.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.4.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.9.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:23.1.0.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.4.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.5.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.15.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.16.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.7.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.6.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.22.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.7.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.8.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.1.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.10.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:23.1.1.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.9.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.6.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.3.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.18.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.10.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.19.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:linux:7:9:patch</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.2.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.1.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:linux:7::latest</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:24.1.3.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:21.2.23.0.0::ol7</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:24.1.4.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.3.0.0::ovs3</cpe>
+<cpe>cpe:/a:oracle:exadata_dbserver:22.1.8.0.0::ol7</cpe>
+</affected_cpe_list>
+</advisory>
 </metadata>
 <criteria operator="AND">
-<criterion test_ref="t1" comment="Oracle Linux 7 is installed"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803001" comment="Oracle Linux 7 is installed"/>
 <criteria operator="OR">
 <criteria operator="AND">
-<criterion test_ref="t2" comment="Oracle Linux arch is aarch64"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803002" comment="Oracle Linux arch is aarch64"/>
 <criteria operator="OR">
 <criteria operator="AND">
-<criterion test_ref="t3" comment="rsyslog is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
-<criterion test_ref="t4" comment="rsyslog is signed with the Oracle Linux 7 key"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803003" comment="rsyslog is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803004" comment="rsyslog is signed with the Oracle Linux 7 key"/>
 </criteria>
 <criteria operator="AND">
-<criterion test_ref="t5" comment="rsyslog-doc is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
-<criterion test_ref="t6" comment="rsyslog-doc is signed with the Oracle Linux 7 key"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803005" comment="rsyslog-crypto is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803006" comment="rsyslog-crypto is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803007" comment="rsyslog-doc is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803008" comment="rsyslog-doc is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803009" comment="rsyslog-elasticsearch is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803010" comment="rsyslog-elasticsearch is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803011" comment="rsyslog-gnutls is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803012" comment="rsyslog-gnutls is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803013" comment="rsyslog-gssapi is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803014" comment="rsyslog-gssapi is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803015" comment="rsyslog-kafka is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803016" comment="rsyslog-kafka is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803017" comment="rsyslog-libdbi is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803018" comment="rsyslog-libdbi is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803019" comment="rsyslog-mmaudit is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803020" comment="rsyslog-mmaudit is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803021" comment="rsyslog-mmjsonparse is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803022" comment="rsyslog-mmjsonparse is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803023" comment="rsyslog-mmkubernetes is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803024" comment="rsyslog-mmkubernetes is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803025" comment="rsyslog-mmnormalize is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803026" comment="rsyslog-mmnormalize is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803027" comment="rsyslog-mmsnmptrapd is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803028" comment="rsyslog-mmsnmptrapd is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803029" comment="rsyslog-mysql is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803030" comment="rsyslog-mysql is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803031" comment="rsyslog-pgsql is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803032" comment="rsyslog-pgsql is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803033" comment="rsyslog-relp is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803034" comment="rsyslog-relp is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803035" comment="rsyslog-snmp is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803036" comment="rsyslog-snmp is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803037" comment="rsyslog-udpspoof is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803038" comment="rsyslog-udpspoof is signed with the Oracle Linux 7 key"/>
 </criteria>
 </criteria>
 </criteria>
 <criteria operator="AND">
-<criterion test_ref="t7" comment="Oracle Linux arch is x86_64"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803039" comment="Oracle Linux arch is x86_64"/>
 <criteria operator="OR">
 <criteria operator="AND">
-<criterion test_ref="t8" comment="rsyslog is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
-<criterion test_ref="t9" comment="rsyslog is signed with the Oracle Linux 7 key"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803040" comment="rsyslog is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803041" comment="rsyslog is signed with the Oracle Linux 7 key"/>
 </criteria>
 <criteria operator="AND">
-<criterion test_ref="t10" comment="rsyslog-doc is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
-<criterion test_ref="t11" comment="rsyslog-doc is signed with the Oracle Linux 7 key"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803042" comment="rsyslog-crypto is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803043" comment="rsyslog-crypto is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803044" comment="rsyslog-doc is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803045" comment="rsyslog-doc is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803046" comment="rsyslog-elasticsearch is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803047" comment="rsyslog-elasticsearch is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803048" comment="rsyslog-gnutls is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803049" comment="rsyslog-gnutls is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803050" comment="rsyslog-gssapi is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803051" comment="rsyslog-gssapi is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803052" comment="rsyslog-kafka is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803053" comment="rsyslog-kafka is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803054" comment="rsyslog-libdbi is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803055" comment="rsyslog-libdbi is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803056" comment="rsyslog-mmaudit is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803057" comment="rsyslog-mmaudit is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803058" comment="rsyslog-mmjsonparse is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803059" comment="rsyslog-mmjsonparse is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803060" comment="rsyslog-mmkubernetes is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803061" comment="rsyslog-mmkubernetes is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803062" comment="rsyslog-mmnormalize is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803063" comment="rsyslog-mmnormalize is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803064" comment="rsyslog-mmsnmptrapd is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803065" comment="rsyslog-mmsnmptrapd is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803066" comment="rsyslog-mysql is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803067" comment="rsyslog-mysql is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803068" comment="rsyslog-pgsql is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803069" comment="rsyslog-pgsql is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803070" comment="rsyslog-relp is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803071" comment="rsyslog-relp is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803072" comment="rsyslog-snmp is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803073" comment="rsyslog-snmp is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803074" comment="rsyslog-udpspoof is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20224803075" comment="rsyslog-udpspoof is signed with the Oracle Linux 7 key"/>
 </criteria>
 </criteria>
 </criteria>
 </criteria>
 </criteria>
+
 </definition>
-<definition id="oval:com.oracle.elsa:def:20990001" version="501" class="patch">
+<definition id="oval:com.oracle.elsa:def:202510073" version="501" class="patch">
 <metadata>
-<title>ELSA-2099-0001:  firefox security update (IMPORTANT)</title>
-<affected family="unix"><platform>Oracle Linux 9</platform></affected>
-<reference source="elsa" ref_id="ELSA-2099-0001" ref_url="https://linux.oracle.com/errata/ELSA-2099-0001.html"/>
-<reference source="CVE" ref_id="CVE-2099-0001" ref_url="https://linux.oracle.com/cve/CVE-2099-0001.html"/>
-<description>firefox</description>
-<advisory><severity>IMPORTANT</severity><issued date="2099-01-01"/><cve href="https://linux.oracle.com/cve/CVE-2099-0001.html">CVE-2099-0001</cve></advisory>
+<title>
+ELSA-2025-10073:  firefox security update (IMPORTANT)
+</title>
+<affected family="unix">
+<platform>Oracle Linux 10</platform>
+
+</affected>
+<reference source="elsa" ref_id="ELSA-2025-10073" ref_url="https://linux.oracle.com/errata/ELSA-2025-10073.html"/>
+<reference source="CVE" ref_id="CVE-2025-6429" ref_url="https://linux.oracle.com/cve/CVE-2025-6429.html"/>
+<reference source="CVE" ref_id="CVE-2025-6424" ref_url="https://linux.oracle.com/cve/CVE-2025-6424.html"/>
+<reference source="CVE" ref_id="CVE-2025-6430" ref_url="https://linux.oracle.com/cve/CVE-2025-6430.html"/>
+<reference source="CVE" ref_id="CVE-2025-6425" ref_url="https://linux.oracle.com/cve/CVE-2025-6425.html"/>
+
+<description>
+[128.12.0-1.0.1]
+- Fix firefox-oracle-default-prefs.js for new nss [Orabug: 37079789]
+
+[128.12.0]
+- Add debranding patches (Mustafa Gezen)
+- Add OpenELA default preferences (Louis Abel)
+
+[128.12.0-1]
+- Update to 128.12.0 build1
+</description>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   advisory details   ~~~~~~~~~~~~~~~~~~~ 
+-->
+<advisory>
+<severity>IMPORTANT</severity>
+<rights>Copyright 2025 Oracle, Inc.</rights>
+<issued date="2025-07-01"/>
+<cve cvss3="6.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N" href="https://linux.oracle.com/cve/CVE-2025-6429.html" public="20250624">CVE-2025-6429</cve>
+<cve cvss3="7.5/CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H" href="https://linux.oracle.com/cve/CVE-2025-6424.html" public="20250624">CVE-2025-6424</cve>
+<cve cvss3="6.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N" href="https://linux.oracle.com/cve/CVE-2025-6430.html" public="20250624">CVE-2025-6430</cve>
+<cve cvss3="6.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N" href="https://linux.oracle.com/cve/CVE-2025-6425.html" public="20250624">CVE-2025-6425</cve>
+
+<affected_cpe_list>
+<cpe>cpe:/a:oracle:linux:10::appstream</cpe>
+</affected_cpe_list>
+</advisory>
 </metadata>
 <criteria operator="AND">
-<criterion test_ref="f1" comment="Oracle Linux 9 is installed"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:202510073001" comment="Oracle Linux 10 is installed"/>
 <criteria operator="OR">
 <criteria operator="AND">
-<criterion test_ref="f2" comment="Oracle Linux arch is aarch64"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:202510073002" comment="Oracle Linux arch is aarch64"/>
 <criteria operator="AND">
-<criterion test_ref="f3" comment="firefox is earlier than 0:128.0-1.el9"/>
-<criterion test_ref="f4" comment="firefox is signed with the Oracle Linux 9 key"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:202510073003" comment="firefox is earlier than 0:128.12.0-1.0.1.el10_0"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:202510073004" comment="firefox is signed with the Oracle Linux 10 key"/>
 </criteria>
 </criteria>
 <criteria operator="AND">
-<criterion test_ref="f5" comment="Oracle Linux arch is x86_64"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:202510073005" comment="Oracle Linux arch is x86_64"/>
 <criteria operator="AND">
-<criterion test_ref="f6" comment="firefox is earlier than 0:128.0-1.el9"/>
-<criterion test_ref="f7" comment="firefox is signed with the Oracle Linux 9 key"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:202510073003" comment="firefox is earlier than 0:128.12.0-1.0.1.el10_0"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:202510073004" comment="firefox is signed with the Oracle Linux 10 key"/>
 </criteria>
 </criteria>
 </criteria>
 </criteria>
+
+</definition>
+<definition id="oval:com.oracle.elsa:def:20242961" version="501" class="patch">
+<metadata>
+<title>
+ELSA-2024-2961:  Image builder components bug fix, enhancement and security update (MODERATE)
+</title>
+<affected family="unix">
+<platform>Oracle Linux 8</platform>
+
+</affected>
+<reference source="elsa" ref_id="ELSA-2024-2961" ref_url="https://linux.oracle.com/errata/ELSA-2024-2961.html"/>
+<reference source="CVE" ref_id="CVE-2024-2307" ref_url="https://linux.oracle.com/cve/CVE-2024-2307.html"/>
+
+<description>
+osbuild
+[110-1]
+- New upstream release
+
+[109-1]
+- New upstream release
+
+[106-1]
+- New upstream release
+
+[105-1]
+- New upstream release
+
+[104-2]
+- Fix unit tests in RHEL CI by backporting upstream fixes
+
+[104-1]
+- New upstream release
+
+[101-1]
+- New upstream release
+
+[100-2]
+- Change unit-test timeout from 3h to 4h
+
+[100-1]
+- New upstream release
+
+[96-1]
+- New upstream release
+
+[95-1]
+- New upstream release
+
+[94-1]
+- New upstream release
+
+osbuild-composer
+[101-1]
+- New upstream release
+
+[100-1]
+- New upstream release
+
+[99-1]
+- New upstream release
+
+[98-1]
+- New upstream release
+
+[96-1]
+- New upstream release
+
+[95-1]
+- New upstream release
+
+[94-1]
+- New upstream release
+
+[93-1]
+- New upstream release
+
+[92-1]
+- New upstream release
+
+[91-1]
+- New upstream release
+
+[90-1]
+- New upstream release
+
+[89-1]
+- New upstream release
+</description>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   advisory details   ~~~~~~~~~~~~~~~~~~~ 
+-->
+<advisory>
+<severity>MODERATE</severity>
+<rights>Copyright 2024 Oracle, Inc.</rights>
+<issued date="2024-05-24"/>
+<cve cvss3="6.1/CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:L" href="https://linux.oracle.com/cve/CVE-2024-2307.html" public="20240319">CVE-2024-2307</cve>
+
+<affected_cpe_list>
+<cpe>cpe:/a:oracle:linux:8:10:appstream_base</cpe>
+<cpe>cpe:/a:oracle:linux:8::appstream</cpe>
+</affected_cpe_list>
+</advisory>
+</metadata>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961001" comment="Oracle Linux 8 is installed"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961002" comment="Oracle Linux arch is aarch64"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961003" comment="osbuild is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961004" comment="osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961005" comment="osbuild is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961006" comment="osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961007" comment="osbuild-composer is earlier than 0:101-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961008" comment="osbuild-composer is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961009" comment="osbuild-composer-core is earlier than 0:101-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961010" comment="osbuild-composer-core is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961011" comment="osbuild-composer-worker is earlier than 0:101-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961012" comment="osbuild-composer-worker is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961013" comment="osbuild-depsolve-dnf is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961014" comment="osbuild-depsolve-dnf is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961015" comment="osbuild-depsolve-dnf is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961016" comment="osbuild-depsolve-dnf is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961017" comment="osbuild-luks2 is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961018" comment="osbuild-luks2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961019" comment="osbuild-luks2 is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961020" comment="osbuild-luks2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961021" comment="osbuild-lvm2 is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961022" comment="osbuild-lvm2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961023" comment="osbuild-lvm2 is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961024" comment="osbuild-lvm2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961025" comment="osbuild-ostree is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961026" comment="osbuild-ostree is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961027" comment="osbuild-ostree is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961028" comment="osbuild-ostree is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961029" comment="osbuild-selinux is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961030" comment="osbuild-selinux is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961031" comment="osbuild-selinux is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961032" comment="osbuild-selinux is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961033" comment="python3-osbuild is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961034" comment="python3-osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961035" comment="python3-osbuild is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961036" comment="python3-osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+</criteria>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961037" comment="Oracle Linux arch is x86_64"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961003" comment="osbuild is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961004" comment="osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961005" comment="osbuild is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961006" comment="osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961007" comment="osbuild-composer is earlier than 0:101-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961008" comment="osbuild-composer is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961009" comment="osbuild-composer-core is earlier than 0:101-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961010" comment="osbuild-composer-core is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961011" comment="osbuild-composer-worker is earlier than 0:101-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961012" comment="osbuild-composer-worker is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961013" comment="osbuild-depsolve-dnf is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961014" comment="osbuild-depsolve-dnf is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961015" comment="osbuild-depsolve-dnf is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961016" comment="osbuild-depsolve-dnf is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961017" comment="osbuild-luks2 is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961018" comment="osbuild-luks2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961019" comment="osbuild-luks2 is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961020" comment="osbuild-luks2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961021" comment="osbuild-lvm2 is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961022" comment="osbuild-lvm2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961023" comment="osbuild-lvm2 is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961024" comment="osbuild-lvm2 is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961025" comment="osbuild-ostree is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961026" comment="osbuild-ostree is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961027" comment="osbuild-ostree is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961028" comment="osbuild-ostree is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961029" comment="osbuild-selinux is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961030" comment="osbuild-selinux is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961031" comment="osbuild-selinux is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961032" comment="osbuild-selinux is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961033" comment="python3-osbuild is earlier than 0:110-1.0.1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961034" comment="python3-osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961035" comment="python3-osbuild is earlier than 0:110-1.el8"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20242961036" comment="python3-osbuild is signed with the Oracle Linux 8 key"/>
+</criteria>
+</criteria>
+</criteria>
+</criteria>
+</criteria>
+
 </definition>
 </definitions>
 </oval_definitions>

--- a/tests/unit/providers/oracle/test-fixtures/mock_per_arch_data
+++ b/tests/unit/providers/oracle/test-fixtures/mock_per_arch_data
@@ -1,0 +1,74 @@
+<oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
+<definitions>
+<definition id="oval:com.oracle.elsa:def:20224803" version="501" class="patch">
+<metadata>
+<title>ELSA-2022-4803:  rsyslog security update (IMPORTANT)</title>
+<affected family="unix"><platform>Oracle Linux 7</platform></affected>
+<reference source="elsa" ref_id="ELSA-2022-4803" ref_url="https://linux.oracle.com/errata/ELSA-2022-4803.html"/>
+<reference source="CVE" ref_id="CVE-2022-24903" ref_url="https://linux.oracle.com/cve/CVE-2022-24903.html"/>
+<description>rsyslog</description>
+<advisory><severity>IMPORTANT</severity><issued date="2022-05-31"/><cve href="https://linux.oracle.com/cve/CVE-2022-24903.html">CVE-2022-24903</cve></advisory>
+</metadata>
+<criteria operator="AND">
+<criterion test_ref="t1" comment="Oracle Linux 7 is installed"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="t2" comment="Oracle Linux arch is aarch64"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="t3" comment="rsyslog is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="t4" comment="rsyslog is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="t5" comment="rsyslog-doc is earlier than 0:8.24.0-57.0.4.el7_9.3"/>
+<criterion test_ref="t6" comment="rsyslog-doc is signed with the Oracle Linux 7 key"/>
+</criteria>
+</criteria>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="t7" comment="Oracle Linux arch is x86_64"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="t8" comment="rsyslog is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="t9" comment="rsyslog is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="t10" comment="rsyslog-doc is earlier than 0:8.24.0-57.0.1.el7_9.3"/>
+<criterion test_ref="t11" comment="rsyslog-doc is signed with the Oracle Linux 7 key"/>
+</criteria>
+</criteria>
+</criteria>
+</criteria>
+</criteria>
+</definition>
+<definition id="oval:com.oracle.elsa:def:20990001" version="501" class="patch">
+<metadata>
+<title>ELSA-2099-0001:  firefox security update (IMPORTANT)</title>
+<affected family="unix"><platform>Oracle Linux 9</platform></affected>
+<reference source="elsa" ref_id="ELSA-2099-0001" ref_url="https://linux.oracle.com/errata/ELSA-2099-0001.html"/>
+<reference source="CVE" ref_id="CVE-2099-0001" ref_url="https://linux.oracle.com/cve/CVE-2099-0001.html"/>
+<description>firefox</description>
+<advisory><severity>IMPORTANT</severity><issued date="2099-01-01"/><cve href="https://linux.oracle.com/cve/CVE-2099-0001.html">CVE-2099-0001</cve></advisory>
+</metadata>
+<criteria operator="AND">
+<criterion test_ref="f1" comment="Oracle Linux 9 is installed"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="f2" comment="Oracle Linux arch is aarch64"/>
+<criteria operator="AND">
+<criterion test_ref="f3" comment="firefox is earlier than 0:128.0-1.el9"/>
+<criterion test_ref="f4" comment="firefox is signed with the Oracle Linux 9 key"/>
+</criteria>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="f5" comment="Oracle Linux arch is x86_64"/>
+<criteria operator="AND">
+<criterion test_ref="f6" comment="firefox is earlier than 0:128.0-1.el9"/>
+<criterion test_ref="f7" comment="firefox is signed with the Oracle Linux 9 key"/>
+</criteria>
+</criteria>
+</criteria>
+</criteria>
+</definition>
+</definitions>
+</oval_definitions>

--- a/tests/unit/providers/oracle/test-fixtures/snapshots/ol:5/elsa-2007-0057.json
+++ b/tests/unit/providers/oracle/test-fixtures/snapshots/ol:5/elsa-2007-0057.json
@@ -114,5 +114,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/oracle/test-fixtures/snapshots/ol:6/elsa-2018-4250.json
+++ b/tests/unit/providers/oracle/test-fixtures/snapshots/ol:6/elsa-2018-4250.json
@@ -100,5 +100,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/oracle/test_oracle.py
+++ b/tests/unit/providers/oracle/test_oracle.py
@@ -301,6 +301,38 @@ def test_parse(tmpdir, helpers, input_file, expected):
     assert vuln_dict == expected
 
 
+def _fixed_in_keys(fixed_in_list):
+    # (Name, Version, Arch-or-None) for stable comparison
+    return {(f["Name"], f["Version"], f.get("Arch")) for f in fixed_in_list}
+
+
+# mock_per_arch_data holds two ELSA definitions: ELSA-2022-4803, whose x86_64 and aarch64 rsyslog
+# builds were respun at different revisions, and ELSA-2099-0001, whose arches share a single fix.
+def test_parse_per_arch_fixed_in(tmpdir, helpers):
+    subject = parser.Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
+
+    mock_data_path = helpers.local_dir("test-fixtures/mock_per_arch_data")
+
+    vuln_dict = subject._parse_oval_data(mock_data_path, subject.config)
+
+    # divergent per-arch fix: each package keeps both arches explicit so the higher aarch64
+    # revision (.0.4) can't suppress/over-match a patched x86_64 package (.0.1) — the FP class
+    # in ELSA-2022-4803.
+    _, divergent = vuln_dict[("ELSA-2022-4803", "ol:7")]
+    assert _fixed_in_keys(divergent["Vulnerability"]["FixedIn"]) == {
+        ("rsyslog", "0:8.24.0-57.0.4.el7_9.3", "aarch64"),
+        ("rsyslog", "0:8.24.0-57.0.1.el7_9.3", "x86_64"),
+        ("rsyslog-doc", "0:8.24.0-57.0.4.el7_9.3", "aarch64"),
+        ("rsyslog-doc", "0:8.24.0-57.0.1.el7_9.3", "x86_64"),
+    }
+
+    # identical fix across arches: collapse to a single arch-less FixedIn (no Arch key) to save space.
+    _, shared = vuln_dict[("ELSA-2099-0001", "ol:9")]
+    shared_fixed = shared["Vulnerability"]["FixedIn"]
+    assert _fixed_in_keys(shared_fixed) == {("firefox", "0:128.0-1.el9", None)}
+    assert all("Arch" not in f for f in shared_fixed), "arch-less fix must not emit an Arch field"
+
+
 class TestKspliceFilterer:
     @pytest.mark.parametrize(
         ("input_vulnerability", "expected_output"),

--- a/tests/unit/providers/oracle/test_oracle.py
+++ b/tests/unit/providers/oracle/test_oracle.py
@@ -301,13 +301,19 @@ def test_parse(tmpdir, helpers, input_file, expected):
     assert vuln_dict == expected
 
 
-def _fixed_in_keys(fixed_in_list):
-    # (Name, Version, Arch-or-None) for stable comparison
-    return {(f["Name"], f["Version"], f.get("Arch")) for f in fixed_in_list}
+def _arch_versions(fixed_in_list, name):
+    # (Version, Arch-or-None) pairs for one package; arch is absent when it doesn't differentiate
+    return {(f["Version"], f.get("Arch")) for f in fixed_in_list if f["Name"] == name}
 
 
-# mock_per_arch_data holds two ELSA definitions: ELSA-2022-4803, whose x86_64 and aarch64 rsyslog
-# builds were respun at different revisions, and ELSA-2099-0001, whose arches share a single fix.
+# mock_per_arch_data holds three real ELSA definitions (verbatim from the prod OVAL) that exercise
+# every branch of _build_fixed_in:
+#   - ELSA-2022-4803 (rsyslog, OL7): x86_64 and aarch64 were respun at DIFFERENT revisions, so arch
+#     differentiates and each (version, arch) is emitted with Arch set.
+#   - ELSA-2025-10073 (firefox, OL10): one fix shared by every arch (a pure gate) -> one arch-less FixedIn.
+#   - ELSA-2024-2961 (osbuild, OL8): two rebuilds, each shipped for BOTH arches -> arch does NOT
+#     differentiate, so it collapses to one arch-less FixedIn per version (must NOT explode to one
+#     per (version, arch), which would create redundant/duplicate rows downstream, e.g. in v5).
 def test_parse_per_arch_fixed_in(tmpdir, helpers):
     subject = parser.Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
 
@@ -315,22 +321,27 @@ def test_parse_per_arch_fixed_in(tmpdir, helpers):
 
     vuln_dict = subject._parse_oval_data(mock_data_path, subject.config)
 
-    # divergent per-arch fix: each package keeps both arches explicit so the higher aarch64
-    # revision (.0.4) can't suppress/over-match a patched x86_64 package (.0.1) — the FP class
-    # in ELSA-2022-4803.
+    # arch-specific fix: each package keeps both arches explicit so the higher aarch64 revision
+    # (.0.4) can't suppress/over-match a patched x86_64 package (.0.1) — the FP class in ELSA-2022-4803.
     _, divergent = vuln_dict[("ELSA-2022-4803", "ol:7")]
-    assert _fixed_in_keys(divergent["Vulnerability"]["FixedIn"]) == {
-        ("rsyslog", "0:8.24.0-57.0.4.el7_9.3", "aarch64"),
-        ("rsyslog", "0:8.24.0-57.0.1.el7_9.3", "x86_64"),
-        ("rsyslog-doc", "0:8.24.0-57.0.4.el7_9.3", "aarch64"),
-        ("rsyslog-doc", "0:8.24.0-57.0.1.el7_9.3", "x86_64"),
+    assert _arch_versions(divergent["Vulnerability"]["FixedIn"], "rsyslog") == {
+        ("0:8.24.0-57.0.4.el7_9.3", "aarch64"),
+        ("0:8.24.0-57.0.1.el7_9.3", "x86_64"),
     }
 
-    # identical fix across arches: collapse to a single arch-less FixedIn (no Arch key) to save space.
-    _, shared = vuln_dict[("ELSA-2099-0001", "ol:9")]
-    shared_fixed = shared["Vulnerability"]["FixedIn"]
-    assert _fixed_in_keys(shared_fixed) == {("firefox", "0:128.0-1.el9", None)}
-    assert all("Arch" not in f for f in shared_fixed), "arch-less fix must not emit an Arch field"
+    # one fix shared by every arch: a single arch-less FixedIn (no Arch key).
+    _, gate = vuln_dict[("ELSA-2025-10073", "ol:10")]
+    assert _arch_versions(gate["Vulnerability"]["FixedIn"], "firefox") == {
+        ("0:128.12.0-1.0.1.el10_0", None),
+    }
+
+    # two rebuilds, each present on BOTH arches: arch is not a differentiator, so emit one arch-less
+    # FixedIn per version, NOT one per (version, arch) (which would duplicate rows once arch is dropped).
+    _, rebuild = vuln_dict[("ELSA-2024-2961", "ol:8")]
+    assert _arch_versions(rebuild["Vulnerability"]["FixedIn"], "osbuild") == {
+        ("0:110-1.el8", None),
+        ("0:110-1.0.1.el8", None),
+    }
 
 
 class TestKspliceFilterer:


### PR DESCRIPTION
Some ELSAs list different fixed versions for the same package name, same version of oracle linux, but different CPU architectures. For example ELSA-2022-4803 has rsyslog fixed at '8.24.0-57.0.4.el7_9.3' on aarch64 and '8.24.0-57.0.1.el7_9.3' on x86_64.

See also https://github.com/anchore/syft/pull/4987 and https://github.com/anchore/grype/pull/3504

See https://github.com/anchore/grype/issues/866