### PR TITLE
release pipeline refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -23,16 +18,6 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
-    groups:
-      ruff:
-        patterns:
-          - "ruff"
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-        exclude-patterns:
-          - "ruff"
     ignore:
       # used to generate Mariner models.
       # pin to keep from introducing needless drift in the models.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,9 +1,4 @@
 rules:
-  unpinned-uses:
-    config:
-      policies:
-        # anchore/workflows is an internal repository; using @main is acceptable
-        anchore/*: any
   template-injection:
     ignore:
       # Allow provider name in step names for debugging purposes


### PR DESCRIPTION
quick pass cleaning up vunnel's CI config:

- dependabot.yml: dropped the grouping config (minor-and-patch groups on github-actions + uv, and the ruff group) so dependency updates come through as individual PRs. kept the uv `ignore` for xsdata.
- zizmor.yml: removed the `unpinned-uses` policy config (the template-injection ignores remain).

note: release.yaml was left as-is. it already has the skip-checks workflow_dispatch input, the check-gate `if: !inputs.skip-checks` with both `contents: read` + `checks: read`, and the tag job's `always()` conditional. it doesn't use `make ci-release`/go-make for tagging - tagging is done by a dedicated `tag` job via anchore/workflows' `create-tag-via-deploy-key` composite action, which only accepts an SSH `deploy-key` (there's no token-based variant in anchore/workflows). swapping DEPLOY_KEY for a TAG_TOKEN PAT there would break tagging, so I left it. this is a Python/PyPI repo with no `.make` dir and no golangci config, so those items are N/A.