### PR TITLE
Add large tag for ubuntu provider

### DIFF
--- a/src/vunnel/providers/ubuntu/__init__.py
+++ b/src/vunnel/providers/ubuntu/__init__.py
@@ -76,7 +76,12 @@ class Provider(provider.Provider):
 
     @classmethod
     def tags(cls) -> list[str]:
-        return ["vulnerability", "os"]
+        return [
+            "vulnerability",
+            "os",
+            # this generates a large dataset and historically can take a while to process (long wall clock time)
+            "large",
+        ]
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
         with timer(self.name(), self.logger):


### PR DESCRIPTION
Restoring the "large" (but not multicore) tag for grype-db to select a relatively large runner to account for out-of-diskspace errors from the latest release.