### PR TITLE
fix(quality-gate): Correct hummingbird namespace

### DIFF
--- a/tests/quality/config.yaml
+++ b/tests/quality/config.yaml
@@ -243,7 +243,7 @@ tests:
       # - quay.io/hummingbird/nodejs:latest@sha256:3c798f5a9da72e241f4cbeecc8bd1d653db69d92131ea8d676067b95ae18a5c2
       # - quay.io/hummingbird/postgresql:latest@sha256:6eefb14bced346a8583011f84dd71de8249af74c060369be6ad73891b2a768f0
     expected_namespaces:
-      - hummingbird:distro:hummingbird:1
+      - hummingbird:distro:hummingbird:rolling
     validations:
       - <<: *default-validations
         max_year: 2026 # hummingbird is new


### PR DESCRIPTION
Hummingbird was always supposed to be a rolling distro, but a previous bug marked it as version 1. Update the namespace to have the correct "rolling" marker on the end.