### PR TITLE
feat(RHEL): handle multiple fix streams

### DIFF
--- a/schema/vulnerability/os/schema-1.1.1.json
+++ b/schema/vulnerability/os/schema-1.1.1.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "os-vulnerability",
+  "description": "represents vulnerability records for common linux distributions",
+  "properties": {
+    "Vulnerability": {
+      "type": "object",
+      "properties": {
+        "CVSS": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "base_metrics": {
+                  "type": "object",
+                  "properties": {
+                    "base_score": {
+                      "type": "number"
+                    },
+                    "base_severity": {
+                      "type": "string"
+                    },
+                    "exploitability_score": {
+                      "type": "number"
+                    },
+                    "impact_score": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "base_score",
+                    "base_severity",
+                    "exploitability_score",
+                    "impact_score"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "vector_string": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "base_metrics",
+                "status",
+                "vector_string",
+                "version"
+              ]
+            }
+          ]
+        },
+        "Description": {
+          "type": "string"
+        },
+        "FixedIn": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "Name": {
+                  "type": "string"
+                },
+                "NamespaceName": {
+                  "type": "string"
+                },
+                "VendorAdvisory": {
+                  "type": "object",
+                  "properties": {
+                    "AdvisorySummary": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "NoAdvisory": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "NoAdvisory"
+                  ]
+                },
+                "Version": {
+                  "type": "string"
+                },
+                "VersionFormat": {
+                  "type": "string"
+                },
+                "Availability": {
+                  "type": "object",
+                  "properties": {
+                    "Date": {
+                      "type": "string"
+                    },
+                    "Kind": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "VulnerableRange": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "Module": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "AdditionalAdvisoryFixes": {
+                  "type": "array",
+                  "description": "additional per-stream fix builds beyond the canonical (highest) Version, each paired with the advisory that shipped it; emitted when multiple advisories fix this package in the same major version",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Version": {
+                        "type": "string"
+                      },
+                      "Advisory": {
+                        "type": "object",
+                        "properties": {
+                          "ID": {
+                            "type": "string"
+                          },
+                          "Link": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "required": [
+                "Name",
+                "NamespaceName",
+                "Version",
+                "VersionFormat"
+              ]
+            }
+          ]
+        },
+        "Link": {
+          "type": "string"
+        },
+        "Metadata": {
+          "type": "object",
+          "properties": {
+            "Issued": {
+              "type": "string",
+              "description": "date the vulnerability was published"
+            },
+            "Updated": {
+              "type": "string",
+              "description": "date the vulnerability was last updated"
+            },
+            "Withdrawn": {
+              "type": "string",
+              "description": "date the vulnerability was withdrawn"
+            },
+            "RefId": {
+              "type": "string"
+            },
+            "CVE": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Name": {
+                      "type": "string"
+                    },
+                    "Link": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Name"
+                  ]
+                }
+              ]
+            },
+            "NVD": {
+              "type": "object",
+              "properties": {
+                "CVSSv2": {
+                  "type": "object",
+                  "properties": {
+                    "Score": {
+                      "type": "number"
+                    },
+                    "Vectors": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Score"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "Name": {
+          "type": "string"
+        },
+        "NamespaceName": {
+          "type": "string"
+        },
+        "Severity": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Description",
+        "FixedIn",
+        "Link",
+        "Metadata",
+        "Name",
+        "NamespaceName",
+        "Severity"
+      ]
+    }
+  },
+  "required": [
+    "Vulnerability"
+  ]
+}

--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -41,7 +41,10 @@ class Config:
 
 
 class Provider(provider.Provider):
-    __schema__ = schema.OSSchema()
+    # RHEL emits the additive AdditionalAdvisoryFixes field (per-stream fix builds), introduced in
+    # OS schema 1.1.1. Pinned here rather than bumping the shared OS_SCHEMA_VERSION default so only
+    # this provider advances and other OS providers don't churn.
+    __schema__ = schema.OSSchema("1.1.1")
     __distribution_version__ = int(__schema__.major_version)
 
     def __init__(self, root: str, config: Config | None = None):

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -43,6 +43,11 @@ FixedIn = namedtuple(
 )
 RHSAFixedIn = namedtuple("RHSAFixedIn", ["package", "version"])
 Advisory = namedtuple("Advisory", ["wont_fix", "rhsa_id", "link", "severity"])
+# AdvisoryFix pairs a single called-out fix build (EVR) with the advisory that shipped it. Option A
+# carries every distinct per-stream fix build for a same-base package as these pairs, so the grype
+# matcher can pick the build matching the installed package's own .elN_M dist-tag minor at match time
+# rather than collapsing to a single total-ordered EVR.
+AdvisoryFix = namedtuple("AdvisoryFix", ["version", "advisory"])
 NamespacePayload = namedtuple("NamespacePayload", ["namespace", "payload"])
 
 
@@ -443,9 +448,9 @@ class Parser:
         platform_packages = {}  # dictionary of platform -> set of package names
         all_ar_objs = []
         # collect every affected release for the same (package, platform, module). When Red Hat ships
-        # more than one fix for the same tuple (e.g. a Z-stream/EUS backport in one minor and an upstream
-        # rebase in a later minor), each fix lands here and is later reduced to a single FixedIn that
-        # carries a VulnerableRange describing the per-stream fix boundaries.
+        # more than one fix for the same tuple (e.g. fixes on several minor streams that share an
+        # upstream base and differ only by .elN_M dist tag), each fix lands here and is later reduced
+        # to a single FixedIn whose additional_advisories carries every distinct per-stream fix build.
         collected_ar_objs: dict[tuple, list] = {}  # (package, platform, module) -> list[AffectedRelease]
 
         try:
@@ -555,10 +560,13 @@ class Parser:
                 except Exception:
                     self.logger.exception(f"error processing {cve_id} affected release object: {ar_obj.__dict__}")
 
-            # reduce each (package, platform, module) bucket to a single FixedIn. When the bucket
-            # holds fixes from more than one upstream version base, compute a VulnerableRange that
-            # describes the per-stream fix boundaries so that, e.g., a host carrying a 9.4 Z-stream
-            # backport is not falsely flagged against a later minor's upstream rebase.
+            # reduce each (package, platform, module) bucket to a single FixedIn. Option A keeps one
+            # record per CVE but carries EVERY distinct called-out fix build paired with its advisory
+            # in additional_advisories, so the grype matcher can select the build matching the
+            # installed package's own .elN_M dist-tag minor at match time. This handles the same-base
+            # multi-stream case (several fixes that share an upstream base and differ only by dist
+            # tag) that a single total-ordered EVR — or a VulnerableRange keyed on the upstream base —
+            # cannot represent.
             for (pkg_name, platform, module), ar_objs in collected_ar_objs.items():
                 if not ar_objs:
                     continue
@@ -566,40 +574,36 @@ class Parser:
                 # sort ascending using true RPM version ordering (not lexical)
                 ar_objs.sort(key=functools.cmp_to_key(lambda a, b: rpm.compare_versions(a.version, b.version)))
 
-                # reduce to distinct upstream version bases, keeping the highest fix within each base.
-                # Keeping the highest preserves the historical "fixed in the newest build" behavior for
-                # the common single-stream case; the per-base reduction only changes behavior when there
-                # is genuinely more than one upstream base (the multi-RHSA case Phase 1 targets).
-                fix_by_base: dict[str, AffectedRelease] = {}
-                for ar_obj in ar_objs:  # ascending, so the last write per base wins (highest)
-                    fix_by_base[_get_version_base(ar_obj.version)] = ar_obj
-                distinct_base_fixes = list(fix_by_base.values())  # ascending by base
+                # de-duplicate to distinct fix builds (by full EVR), keeping the first advisory seen
+                # for each build. We keep ALL distinct builds (not just one per upstream base) because
+                # same-base streams differing only by dist tag are exactly the case Option A targets.
+                distinct_fixes: list[AffectedRelease] = []
+                seen_versions: set[str] = set()
+                for ar_obj in ar_objs:  # ascending by version
+                    if ar_obj.version in seen_versions:
+                        continue
+                    seen_versions.add(ar_obj.version)
+                    distinct_fixes.append(ar_obj)
 
                 # the canonical "fixed in" version reported for the major-version namespace is the
-                # newest stream's fix (highest base). VulnerableRange, when present, is what actually
-                # drives matching downstream; this version is the single-constraint fallback.
-                canonical = distinct_base_fixes[-1]
+                # newest build (highest EVR). This preserves the historical coarse "< highest fix"
+                # behavior as the matcher's fallback when no per-stream build matches the host.
+                canonical = distinct_fixes[-1]
+                primary_advisory = _advisory_from_rhsa(canonical.rhsa_id)
 
-                if len(distinct_base_fixes) > 1:
-                    vulnerable_range = _build_vulnerable_range(distinct_base_fixes)
-                    self.logger.debug(
-                        f"{cve_id}, platform={platform}, package={pkg_name}, module={module} : computed VulnerableRange from {len(distinct_base_fixes)} fix streams: {vulnerable_range}",  # noqa: E501
+                # additional_advisories carries every distinct fix build + its advisory (including the
+                # canonical one), newest first. The grype side encodes these as AdditionalAdvisoryFixes
+                # and uses them for per-stream selection.
+                additional_advisories: list[AdvisoryFix] = []
+                for ar_obj in reversed(distinct_fixes):  # descending by version
+                    additional_advisories.append(
+                        AdvisoryFix(version=ar_obj.version, advisory=_advisory_from_rhsa(ar_obj.rhsa_id)),
                     )
-                    # fold every advisory that touched this bucket into the record, newest fix first and
-                    # de-duplicated. The primary advisory corresponds to the canonical (newest) fix.
-                    folded: list[Advisory] = []
-                    seen_rhsa: set[str] = set()
-                    for ar_obj in reversed(ar_objs):  # descending by version
-                        if ar_obj.rhsa_id and ar_obj.rhsa_id not in seen_rhsa:
-                            seen_rhsa.add(ar_obj.rhsa_id)
-                            folded.append(_advisory_from_rhsa(ar_obj.rhsa_id))
-                    primary_advisory = folded[0] if folded else _advisory_from_rhsa(canonical.rhsa_id)
-                    additional_advisories = tuple(folded[1:])
-                else:
-                    # single upstream stream: behave exactly as before — newest build, its advisory.
-                    vulnerable_range = None
-                    primary_advisory = _advisory_from_rhsa(canonical.rhsa_id)
-                    additional_advisories = ()
+
+                if len(distinct_fixes) > 1:
+                    self.logger.debug(
+                        f"{cve_id}, platform={platform}, package={pkg_name}, module={module} : carrying {len(distinct_fixes)} per-stream fix builds as AdditionalAdvisoryFixes",  # noqa: E501
+                    )
 
                 fixed_ins.append(
                     FixedIn(
@@ -608,8 +612,8 @@ class Parser:
                         version=canonical.version,
                         module=module,
                         advisory=primary_advisory,
-                        vulnerable_range=vulnerable_range,
-                        additional_advisories=additional_advisories,
+                        vulnerable_range=None,
+                        additional_advisories=tuple(additional_advisories),
                     ),
                 )
         finally:
@@ -864,14 +868,22 @@ class Parser:
                     v["Vulnerability"]["CVSS"].append(cvssv3_obj.normalize())
 
                 for artifact in artifacts:
+                    # additional_advisories carries (version, advisory) for every distinct called-out
+                    # fix build for this package (Option A). Build the list of (version, advisory)
+                    # pairs once and reuse it for both AdvisorySummary and AdditionalAdvisoryFixes.
+                    advisory_fixes = list(getattr(artifact, "additional_advisories", ()) or ())
+
                     if artifact.advisory.wont_fix:
                         a = {"NoAdvisory": True}
                     else:
                         a = {"NoAdvisory": False, "AdvisorySummary": []}
-                        # primary advisory (corresponds to the canonical fix version) first, then any
-                        # additional advisories folded in from other fix streams for the same package.
-                        for adv in (artifact.advisory, *artifact.additional_advisories):
-                            if adv.rhsa_id and adv.link:
+                        # Fold ALL contributing advisories into AdvisorySummary: the primary advisory
+                        # (canonical/highest fix) first, then every distinct per-stream advisory, so a
+                        # match against any stream's build can surface every relevant advisory.
+                        seen_advisories: set[str] = set()
+                        for adv in (artifact.advisory, *(af.advisory for af in advisory_fixes)):
+                            if adv.rhsa_id and adv.link and adv.rhsa_id not in seen_advisories:
+                                seen_advisories.add(adv.rhsa_id)
                                 a["AdvisorySummary"].append(
                                     {
                                         "ID": adv.rhsa_id,
@@ -891,11 +903,24 @@ class Parser:
                         "VendorAdvisory": a,
                     }
 
-                    # When multiple fix streams exist for the same package, VulnerableRange encodes the
-                    # per-stream fix boundaries directly as a grype version constraint. grype-db uses it
-                    # verbatim in preference to deriving "< Version" from the single fix version.
-                    if artifact.vulnerable_range:
-                        record["VulnerableRange"] = artifact.vulnerable_range
+                    # AdditionalAdvisoryFixes carries every distinct per-stream fix build + its advisory
+                    # (Option A). The grype matcher reads the installed package's own .elN_M dist-tag
+                    # minor, selects the build whose dist tag matches, and compares against it - so a
+                    # host already carrying its own stream's (lower-EVR) fix is not falsely flagged.
+                    # Additive and backwards compatible: omitted when there is nothing to carry, and
+                    # ignored by older grype.
+                    if advisory_fixes:
+                        record["AdditionalAdvisoryFixes"] = [
+                            {
+                                "Version": af.version,
+                                "Advisory": {
+                                    "ID": af.advisory.rhsa_id or "",
+                                    "Link": af.advisory.link or "",
+                                },
+                            }
+                            for af in advisory_fixes
+                            if af.version
+                        ]
 
                     result = self.fixdater.best(
                         vuln_id=cve_id,
@@ -1033,41 +1058,6 @@ def _advisory_from_rhsa(rhsa_id: str | None) -> Advisory:
             severity=None,
         )
     return Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None)
-
-
-def _build_vulnerable_range(sorted_base_fixes: list) -> str | None:
-    """Build an OR'd grype version constraint from fixes that live on distinct upstream bases.
-
-    Red Hat sometimes fixes the same package in the same major version more than once: a backport
-    that keeps the older upstream base on an older minor (e.g. python3.9 3.9.18-3.el9_4.5 for 9.4)
-    and a rebase to a newer upstream on a later minor (3.9.19-8.el9 for 9.5). Hydra flattens both
-    into "Red Hat Enterprise Linux 9", so a naive "fixed in the highest version" record falsely
-    flags a 9.4 host that already carries its backport (because 3.9.18 < 3.9.19 in RPM ordering).
-
-    Given the per-base fixes sorted ascending by upstream base, this produces a constraint like:
-
-        < 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9
-
-    read as: vulnerable if below the lowest stream's fix, OR within a later stream (at or above that
-    stream's base) but below that stream's fix. The `>= base` pivot is what isolates each stream:
-    a 9.4 build at-or-above its fix is < 3.9.19, so it falls into no clause and is considered fixed.
-
-    Returns None when fewer than two distinct upstream bases are present (nothing to disambiguate);
-    callers fall back to the single "< fix" constraint in that case.
-
-    NOTE: this only works when the streams have *distinct upstream bases*. Two fixes that share a
-    base but differ only in their `.elN_M` dist tag (e.g. an el9_2 vs el9_4 backport of 2.34) cannot
-    be separated by RPM version comparison and require per-minor namespacing instead.
-    """
-    if not sorted_base_fixes or len(sorted_base_fixes) < 2:
-        return None
-
-    groups = [f"< {sorted_base_fixes[0].version}"]
-    for fix in sorted_base_fixes[1:]:
-        base = _get_version_base(fix.version)
-        groups.append(f">= {base}, < {fix.version}")
-
-    return " || ".join(groups)
 
 
 class RHELCVSS3:

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3509.json
@@ -55,5 +55,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3511.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3526.json
@@ -55,5 +55,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3533.json
@@ -55,5 +55,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3539.json
@@ -55,5 +55,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3544.json
@@ -55,5 +55,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3509.json
@@ -18,6 +18,15 @@
       "Description": "It was discovered that the HTTP client implementation in the Networking component of OpenJDK could cache and re-use an NTLM authenticated connection in a different security context. A remote attacker could possibly use this flaw to make a Java application perform HTTP requests authenticated with credentials of a different user.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1109",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1109"
+              },
+              "Version": "1:1.8.0.131-0.b11.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3511.json
@@ -18,6 +18,15 @@
       "Description": "An untrusted library search path flaw was found in the JCE component of OpenJDK. A local attacker could possibly use this flaw to cause a Java application using JCE to load an attacker-controlled library and hence escalate their privileges.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1109",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1109"
+              },
+              "Version": "1:1.8.0.131-0.b11.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3526.json
@@ -18,6 +18,15 @@
       "Description": "It was found that the JAXP component of OpenJDK failed to correctly enforce parse tree size limits when parsing XML document. An attacker able to make a Java application parse a specially crafted XML document could use this flaw to make it consume an excessive amount of CPU and memory.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1109",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1109"
+              },
+              "Version": "1:1.8.0.131-0.b11.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3533.json
@@ -18,6 +18,15 @@
       "Description": "A newline injection flaw was discovered in the FTP client implementation in the Networking component in OpenJDK. A remote attacker could possibly use this flaw to manipulate FTP connections established by a Java application.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1109",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1109"
+              },
+              "Version": "1:1.8.0.131-0.b11.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3539.json
@@ -18,6 +18,15 @@
       "Description": "It was discovered that the Security component of OpenJDK did not allow users to restrict the set of algorithms allowed for Jar integrity verification. This flaw could allow an attacker to modify content of the Jar file that used weak signing key or hash algorithm.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1109",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1109"
+              },
+              "Version": "1:1.8.0.131-0.b11.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3544.json
@@ -18,6 +18,15 @@
       "Description": "A newline injection flaw was discovered in the SMTP client implementation in the Networking component in OpenJDK. A remote attacker could possibly use this flaw to manipulate SMTP connections established by a Java application.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1109",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1109"
+              },
+              "Version": "1:1.8.0.131-0.b11.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el6_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2019-25059.json
@@ -36,5 +36,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16587.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16588.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20298.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20299.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1921.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1922.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1923.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1924.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1925.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-4863.json
@@ -35,5 +35,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5129.json
@@ -35,5 +35,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5217.json
@@ -35,5 +35,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3509.json
@@ -18,6 +18,15 @@
       "Description": "It was discovered that the HTTP client implementation in the Networking component of OpenJDK could cache and re-use an NTLM authenticated connection in a different security context. A remote attacker could possibly use this flaw to make a Java application perform HTTP requests authenticated with credentials of a different user.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1108",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1108"
+              },
+              "Version": "1:1.8.0.131-2.b11.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3511.json
@@ -18,6 +18,15 @@
       "Description": "An untrusted library search path flaw was found in the JCE component of OpenJDK. A local attacker could possibly use this flaw to cause a Java application using JCE to load an attacker-controlled library and hence escalate their privileges.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1108",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1108"
+              },
+              "Version": "1:1.8.0.131-2.b11.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3526.json
@@ -18,6 +18,15 @@
       "Description": "It was found that the JAXP component of OpenJDK failed to correctly enforce parse tree size limits when parsing XML document. An attacker able to make a Java application parse a specially crafted XML document could use this flaw to make it consume an excessive amount of CPU and memory.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1108",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1108"
+              },
+              "Version": "1:1.8.0.131-2.b11.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3533.json
@@ -18,6 +18,15 @@
       "Description": "A newline injection flaw was discovered in the FTP client implementation in the Networking component in OpenJDK. A remote attacker could possibly use this flaw to manipulate FTP connections established by a Java application.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1108",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1108"
+              },
+              "Version": "1:1.8.0.131-2.b11.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3539.json
@@ -18,6 +18,15 @@
       "Description": "It was discovered that the Security component of OpenJDK did not allow users to restrict the set of algorithms allowed for Jar integrity verification. This flaw could allow an attacker to modify content of the Jar file that used weak signing key or hash algorithm.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1108",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1108"
+              },
+              "Version": "1:1.8.0.131-2.b11.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3544.json
@@ -18,6 +18,15 @@
       "Description": "A newline injection flaw was discovered in the SMTP client implementation in the Networking component in OpenJDK. A remote attacker could possibly use this flaw to manipulate SMTP connections established by a Java application.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1108",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1108"
+              },
+              "Version": "1:1.8.0.131-2.b11.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2017:1204",
+                "Link": "https://access.redhat.com/errata/RHSA-2017:1204"
+              },
+              "Version": "1:1.7.0.141-2.6.10.1.el7_3"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -65,5 +83,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2019-25059.json
@@ -36,5 +36,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16587.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16588.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20298.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20299.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1921.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1922.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1923.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1924.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1925.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
@@ -29,6 +29,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5191",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5191"
+              },
+              "Version": "0:102.15.1-1.el7_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -49,6 +58,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5197",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5197"
+              },
+              "Version": "0:102.15.1-1.el7_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -76,5 +94,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
@@ -29,6 +29,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5191",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5191"
+              },
+              "Version": "0:102.15.1-1.el7_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -49,6 +58,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5197",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5197"
+              },
+              "Version": "0:102.15.1-1.el7_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -76,5 +94,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
@@ -29,6 +29,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5475",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5475"
+              },
+              "Version": "0:115.3.1-1.el7_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -49,6 +58,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5477",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5477"
+              },
+              "Version": "0:115.3.1-1.el7_9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -76,5 +94,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-4863.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer flaw was found in the way libwebp, a library used to process \"WebP\" image format data, processes certain specially formatted WebP images. An attacker could use this flaw to crash or execute remotely arbitrary code in an application such as a web browser compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5189",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5189"
+              },
+              "Version": "0:1.0.0-7.el8_6.1"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5198",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5198"
+              },
+              "Version": "0:102.15.1-1.el8_6"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5202",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5202"
+              },
+              "Version": "0:102.15.1-1.el8_6"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5129.json
@@ -18,6 +18,15 @@
       "Description": "This CVE ID has been rejected by its CVE Numbering Authority. Duplicate of CVE-2023-4863.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5189",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5189"
+              },
+              "Version": "0:1.0.0-7.el8_6.1"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5198",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5198"
+              },
+              "Version": "0:102.15.1-1.el8_6"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5202",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5202"
+              },
+              "Version": "0:102.15.1-1.el8_6"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5217.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer overflow flaw was found in the way libvpx, a library used to process VP8 and VP9 video codecs data, processes certain specially formatted video data via a crafted HTML page. This flaw allows an attacker to crash or remotely execute arbitrary code in an application, such as a web browser that is compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5430",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5430"
+              },
+              "Version": "0:115.3.1-1.el8_6"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5436",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5436"
+              },
+              "Version": "0:115.3.1-1.el8_6"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5538",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5538"
+              },
+              "Version": "0:1.7.0-10.el8_6"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2019-25059.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16587.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16588.json
@@ -36,5 +36,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20298.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20299.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1921.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1922.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1923.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1924.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1925.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-2309.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-2309.json
@@ -58,5 +58,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-4863.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer flaw was found in the way libwebp, a library used to process \"WebP\" image format data, processes certain specially formatted WebP images. An attacker could use this flaw to crash or execute remotely arbitrary code in an application such as a web browser compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5184",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5184"
+              },
+              "Version": "0:102.15.1-1.el8_8"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5201",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5201"
+              },
+              "Version": "0:102.15.1-1.el8_8"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5309",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5309"
+              },
+              "Version": "0:1.0.0-8.el8_8.1"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5129.json
@@ -18,6 +18,15 @@
       "Description": "This CVE ID has been rejected by its CVE Numbering Authority. Duplicate of CVE-2023-4863.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5184",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5184"
+              },
+              "Version": "0:102.15.1-1.el8_8"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5201",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5201"
+              },
+              "Version": "0:102.15.1-1.el8_8"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5309",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5309"
+              },
+              "Version": "0:1.0.0-8.el8_8.1"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5217.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer overflow flaw was found in the way libvpx, a library used to process VP8 and VP9 video codecs data, processes certain specially formatted video data via a crafted HTML page. This flaw allows an attacker to crash or remotely execute arbitrary code in an application, such as a web browser that is compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5428",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5428"
+              },
+              "Version": "0:115.3.1-1.el8_8"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5433",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5433"
+              },
+              "Version": "0:115.3.1-1.el8_8"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5537",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5537"
+              },
+              "Version": "0:1.7.0-10.el8_8"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-4863.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer flaw was found in the way libwebp, a library used to process \"WebP\" image format data, processes certain specially formatted WebP images. An attacker could use this flaw to crash or execute remotely arbitrary code in an application such as a web browser compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5204",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5204"
+              },
+              "Version": "0:1.2.0-6.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5205",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5205"
+              },
+              "Version": "0:102.15.1-1.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5223",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5223"
+              },
+              "Version": "0:102.15.1-1.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5129.json
@@ -18,6 +18,15 @@
       "Description": "This CVE ID has been rejected by its CVE Numbering Authority. Duplicate of CVE-2023-4863.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5204",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5204"
+              },
+              "Version": "0:1.2.0-6.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5205",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5205"
+              },
+              "Version": "0:102.15.1-1.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5223",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5223"
+              },
+              "Version": "0:102.15.1-1.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5217.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer overflow flaw was found in the way libvpx, a library used to process VP8 and VP9 video codecs data, processes certain specially formatted video data via a crafted HTML page. This flaw allows an attacker to crash or remotely execute arbitrary code in an application, such as a web browser that is compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5427",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5427"
+              },
+              "Version": "0:115.3.1-1.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5439",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5439"
+              },
+              "Version": "0:115.3.1-1.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5540",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5540"
+              },
+              "Version": "0:1.9.0-7.el9_0"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2019-25059.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1921.json
@@ -18,6 +18,15 @@
       "Description": "A flaw was found in GStreamer. An integer overflow can lead to a heap-based buffer overflow in the avi demuxer when processing a specially crafted AVI file. This vulnerability can result in application crash, memory corruption, and code execution.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:2260",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:2260"
+              },
+              "Version": "0:1.18.4-6.el9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -45,5 +54,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1922.json
@@ -18,6 +18,15 @@
       "Description": "A flaw was found in GStreamer. An integer overflow can lead to a heap-based buffer overflow in the mkv demuxer when processing a specially crafted Matroska/WebM file using zlib decompression. This vulnerability can result in application crash, memory corruption, and code execution.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:2260",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:2260"
+              },
+              "Version": "0:1.18.4-6.el9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -45,5 +54,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1923.json
@@ -18,6 +18,15 @@
       "Description": "A flaw was found in GStreamer. An integer overflow can lead to a heap-based buffer overflow in the mkv demuxer when processing a specially crafted Matroska/WebM file using bzip decompression. This vulnerability can result in application crash, memory corruption, and code execution.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:2260",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:2260"
+              },
+              "Version": "0:1.18.4-6.el9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -45,5 +54,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1924.json
@@ -18,6 +18,15 @@
       "Description": "A flaw was found in GStreamer. An integer overflow can lead to a heap-based buffer overflow in the mkv demuxer when processing a specially crafted Matroska/WebM file using lzo decompression. This vulnerability can result in application crash, memory corruption, and code execution.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:2260",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:2260"
+              },
+              "Version": "0:1.18.4-6.el9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -45,5 +54,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1925.json
@@ -18,6 +18,15 @@
       "Description": "A flaw was found in GStreamer. An integer overflow can lead to a heap-based buffer overflow in the mkv demuxer when processing a specially crafted Matroska/WebM file using HEADERSTRIP decompression. This vulnerability can result in application crash, memory corruption, and code execution.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:2260",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:2260"
+              },
+              "Version": "0:1.18.4-6.el9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -45,5 +54,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-2309.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-2309.json
@@ -18,6 +18,15 @@
       "Description": "A NULL Pointer dereference vulnerability found in lxml, caused by the iterwalk function (also used by the canonicalize function). This flaw can lead to a crash when the incorrect parser input occurs together with usages.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2022:8226",
+                "Link": "https://access.redhat.com/errata/RHSA-2022:8226"
+              },
+              "Version": "0:4.6.5-3.el9"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -45,5 +54,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-4863.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer flaw was found in the way libwebp, a library used to process \"WebP\" image format data, processes certain specially formatted WebP images. An attacker could use this flaw to crash or execute remotely arbitrary code in an application such as a web browser compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5200",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5200"
+              },
+              "Version": "0:102.15.1-1.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5214",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5214"
+              },
+              "Version": "0:1.2.0-7.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5224",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5224"
+              },
+              "Version": "0:102.15.1-1.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5129.json
@@ -18,6 +18,15 @@
       "Description": "This CVE ID has been rejected by its CVE Numbering Authority. Duplicate of CVE-2023-4863.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5200",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5200"
+              },
+              "Version": "0:102.15.1-1.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5214",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5214"
+              },
+              "Version": "0:1.2.0-7.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5224",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5224"
+              },
+              "Version": "0:102.15.1-1.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5217.json
@@ -18,6 +18,15 @@
       "Description": "A heap-based buffer overflow flaw was found in the way libvpx, a library used to process VP8 and VP9 video codecs data, processes certain specially formatted video data via a crafted HTML page. This flaw allows an attacker to crash or remotely execute arbitrary code in an application, such as a web browser that is compiled with this library.",
       "FixedIn": [
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5434",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5434"
+              },
+              "Version": "0:115.3.1-1.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -38,6 +47,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5435",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5435"
+              },
+              "Version": "0:115.3.1-1.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -58,6 +76,15 @@
           "VersionFormat": "rpm"
         },
         {
+          "AdditionalAdvisoryFixes": [
+            {
+              "Advisory": {
+                "ID": "RHSA-2023:5539",
+                "Link": "https://access.redhat.com/errata/RHSA-2023:5539"
+              },
+              "Version": "0:1.9.0-7.el9_2"
+            }
+          ],
           "Available": {
             "date": "2024-01-01",
             "kind": "first-observed"
@@ -85,5 +112,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.1.json"
 }

--- a/tests/unit/providers/rhel/test_multi_rhsa.py
+++ b/tests/unit/providers/rhel/test_multi_rhsa.py
@@ -1,22 +1,25 @@
-"""Tests for the "multiple RHSAs for one package" matching mechanism (Phase 1).
+"""Tests for the Option A "multiple advisory fixes for one package" emission shape.
 
-Red Hat sometimes ships more than one fix for the same package within a single RHEL
-major version: a Z-stream/EUS backport that keeps the older upstream base on an older
-minor, plus an upstream rebase on a later minor. The Hydra API flattens both into
-"Red Hat Enterprise Linux N", so a naive "fixed in the highest version" record falsely
-flags a host that already carries the older stream's backport.
+Red Hat sometimes ships more than one fix for the same package within a single RHEL major
+version. Two flavors matter:
 
-The canonical real-world example is CVE-2024-8088 / python3.9 on RHEL 9:
-  - RHSA-2024:6163 fixes the 9.4 Z-stream at python3.9-0:3.9.18-3.el9_4.5
-  - RHSA-2024:9371 fixes the 9.5 GA build at python3.9-0:3.9.19-8.el9
+  - distinct upstream bases: a backport on an older minor (python3.9 3.9.18-3.el9_4.5 for 9.4)
+    plus a rebase to a newer upstream on a later minor (3.9.19-8.el9 for 9.5).
+  - SAME upstream base: fixes on several minor streams that differ only by their .elN_M dist
+    tag (e.g. glibc 2.34-60.el9_2.7 for the 9.2 Z-stream and 2.34-100.el9 for the 9.3 GA).
 
-Phase 1 emits a VulnerableRange constraint that partitions the two streams by their
-upstream version base so that existing grype/grype-db match correctly with no upgrade:
+The Hydra API flattens all of these into "Red Hat Enterprise Linux N", so a naive "fixed in the
+highest version" record falsely flags a host that already carries its own stream's (lower-EVR)
+fix - and the same-base case cannot be separated by RPM version comparison at all (the leading
+release is a single total order).
 
-    < 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9
+Option A keeps one record per CVE and emits, additively, every distinct called-out fix build
+paired with its advisory in AdditionalAdvisoryFixes, plus folds ALL contributing advisories into
+VendorAdvisory.AdvisorySummary. The grype matcher then reads the installed package's own dist-tag
+minor and selects the matching per-stream build at match time.
 
-The integration test below drives the real CSAF parser against subsetted-but-real CSAF
-advisories (RHSA-2024:6163, RHSA-2024:9371) and a subsetted-but-real Hydra CVE record.
+The integration test below drives the real CSAF parser against subsetted-but-real CSAF advisories
+(RHSA-2024:6163, RHSA-2024:9371) and a subsetted-but-real Hydra CVE record.
 See https://access.redhat.com/security/cve/cve-2024-8088#cve-affected-packages
 """
 
@@ -31,7 +34,7 @@ import pytest
 from vunnel import workspace
 from vunnel.providers.rhel.csaf_parser import CSAFParser
 from vunnel.providers.rhel.csaf_client import CSAFClient
-from vunnel.providers.rhel.parser import AffectedRelease, Parser, _build_vulnerable_range, _get_version_base
+from vunnel.providers.rhel.parser import AffectedRelease, Parser, _get_version_base
 from vunnel.providers.rhel.rhsa_provider import CSAFRHSAProvider
 
 
@@ -62,27 +65,117 @@ class TestGetVersionBase:
         assert _get_version_base(version) == expected
 
 
-class TestBuildVulnerableRange:
-    def test_distinct_bases_python39(self):
-        # the canonical CVE-2024-8088 shape (already deduped + sorted ascending by base)
-        fixes = [_ar("0:3.9.18-3.el9_4.5"), _ar("0:3.9.19-8.el9")]
-        assert _build_vulnerable_range(fixes) == "< 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9"
+class TestSameBaseAdditionalAdvisoryFixes:
+    """Directly exercises _parse_affected_release for the same-base multi-stream case, which is the
+    scenario Option A's matcher-side selection exists for. Two glibc fixes share the upstream base
+    2.34 and differ only by dist tag (.el9_2.7 vs .el9); both must be carried as distinct
+    AdditionalAdvisoryFixes paired with their advisories."""
 
-    def test_three_distinct_bases(self):
-        fixes = [
-            _ar("4:20200609-2.20201027.1.el8_3"),
-            _ar("4:20210216-1.20210608.1.el8_4"),
-            _ar("4:20240910-1.el8_5"),
-        ]
-        assert _build_vulnerable_range(fixes) == (
-            "< 4:20200609-2.20201027.1.el8_3 || >= 4:20210216, < 4:20210216-1.20210608.1.el8_4 || >= 4:20240910, < 4:20240910-1.el8_5"
+    def _driver_with_static_rhsa(self, tmpdir):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        driver = Parser(workspace=ws, skip_namespaces=[])
+        # Resolve each affected-release's fix version straight from its parsed package string and
+        # advisory, so the test exercises the bucket reduction without any CSAF/OVAL plumbing.
+        versions = {
+            "RHSA-2023:5453": "0:2.34-60.el9_2.7",
+            "RHBA-2024:2413": "0:2.34-100.el9",
+        }
+        driver._fetch_rhsa_fix_version = lambda cve_id, ar_obj, override_package_name=None: (  # type: ignore[method-assign]
+            versions.get(ar_obj.rhsa_id),
+            None,
         )
+        return driver
 
-    def test_single_fix_returns_none(self):
-        assert _build_vulnerable_range([_ar("0:3.9.19-8.el9")]) is None
+    def _affected_release_payload(self):
+        # two streams, same upstream base 2.34, differing only by .elN_M dist tag
+        return {
+            "affected_release": [
+                {
+                    "product_name": "Red Hat Enterprise Linux 9",
+                    "package": "glibc-0:2.34-60.el9_2.7",
+                    "advisory": "RHSA-2023:5453",
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9",
+                },
+                {
+                    "product_name": "Red Hat Enterprise Linux 9",
+                    "package": "glibc-0:2.34-100.el9",
+                    "advisory": "RHBA-2024:2413",
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9",
+                },
+            ],
+        }
 
-    def test_empty_returns_none(self):
-        assert _build_vulnerable_range([]) is None
+    def test_carries_every_distinct_stream_fix(self, tmpdir):
+        driver = self._driver_with_static_rhsa(tmpdir)
+        fixed_ins = driver._parse_affected_release("CVE-2023-4813", self._affected_release_payload())
+
+        glibc = [f for f in fixed_ins if f.package == "glibc" and f.platform == "9"]
+        assert len(glibc) == 1
+        record = glibc[0]
+
+        # canonical (single-constraint fallback) is the highest build
+        assert record.version == "0:2.34-100.el9"
+        # Option A does not emit a VulnerableRange (the matcher does per-stream selection)
+        assert record.vulnerable_range is None
+
+        # every distinct fix build is carried with its advisory, newest first
+        carried = [(af.version, af.advisory.rhsa_id) for af in record.additional_advisories]
+        assert carried == [
+            ("0:2.34-100.el9", "RHBA-2024:2413"),
+            ("0:2.34-60.el9_2.7", "RHSA-2023:5453"),
+        ]
+
+    def test_emitted_json_shape(self, tmpdir, auto_fake_fixdate_finder):
+        driver = self._driver_with_static_rhsa(tmpdir)
+        results = driver._parse_cve("CVE-2023-4813", {**self._affected_release_payload(), "threat_severity": "moderate"})
+
+        rhel9 = [r for r in results if r.namespace == "rhel:9"]
+        assert len(rhel9) == 1
+        fixed_in = [f for f in rhel9[0].payload["Vulnerability"]["FixedIn"] if f["Name"] == "glibc"]
+        assert len(fixed_in) == 1
+        record = fixed_in[0]
+
+        assert record["Version"] == "0:2.34-100.el9"
+        assert "VulnerableRange" not in record
+
+        # AdvisorySummary folds ALL contributing advisories (both streams), de-duplicated
+        ids = [s["ID"] for s in record["VendorAdvisory"]["AdvisorySummary"]]
+        assert ids == ["RHBA-2024:2413", "RHSA-2023:5453"]
+
+        # AdditionalAdvisoryFixes carries each distinct fix build + its advisory, matching the
+        # {Version, Advisory:{ID,Link}} shape the grype side consumes
+        assert record["AdditionalAdvisoryFixes"] == [
+            {
+                "Version": "0:2.34-100.el9",
+                "Advisory": {"ID": "RHBA-2024:2413", "Link": "https://access.redhat.com/errata/RHBA-2024:2413"},
+            },
+            {
+                "Version": "0:2.34-60.el9_2.7",
+                "Advisory": {"ID": "RHSA-2023:5453", "Link": "https://access.redhat.com/errata/RHSA-2023:5453"},
+            },
+        ]
+
+    def test_single_stream_still_carries_its_single_fix(self, tmpdir):
+        """A package with only one called-out fix is backwards compatible: one AdditionalAdvisoryFixes
+        entry, no VulnerableRange, canonical version unchanged."""
+        driver = self._driver_with_static_rhsa(tmpdir)
+        payload = {
+            "affected_release": [
+                {
+                    "product_name": "Red Hat Enterprise Linux 9",
+                    "package": "glibc-0:2.34-60.el9_2.7",
+                    "advisory": "RHSA-2023:5453",
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9",
+                },
+            ],
+        }
+        fixed_ins = driver._parse_affected_release("CVE-2023-4813", payload)
+        glibc = [f for f in fixed_ins if f.package == "glibc"][0]
+        assert glibc.version == "0:2.34-60.el9_2.7"
+        assert glibc.vulnerable_range is None
+        assert [(af.version, af.advisory.rhsa_id) for af in glibc.additional_advisories] == [
+            ("0:2.34-60.el9_2.7", "RHSA-2023:5453"),
+        ]
 
 
 def _wire_csaf_rhsa_provider(ws: workspace.Workspace, fixture_dir: Path) -> Mock:
@@ -111,7 +204,7 @@ def _wire_csaf_rhsa_provider(ws: workspace.Workspace, fixture_dir: Path) -> Mock
 
 
 class TestCVE2024_8088:
-    """End-to-end through _parse_cve with subsetted real CSAF + Hydra data."""
+    """End-to-end through _parse_cve with subsetted real CSAF + Hydra data (distinct-base case)."""
 
     @pytest.fixture()
     def hydra_cve(self, fixture_dir):
@@ -127,17 +220,27 @@ class TestCVE2024_8088:
         assert len(py) == 1, f"expected exactly one python3.9 FixedIn, got {fixed_in}"
         return py[0]
 
-    def test_emits_partitioned_vulnerable_range(self, hydra_cve, fixture_dir, tmpdir, auto_fake_fixdate_finder):
+    def test_emits_additional_advisory_fixes(self, hydra_cve, fixture_dir, tmpdir, auto_fake_fixdate_finder):
         ws = workspace.Workspace(tmpdir, "test", create=True)
         driver = Parser(workspace=ws, skip_namespaces=[])
         driver.rhsa_provider = _wire_csaf_rhsa_provider(ws, fixture_dir)
 
-        results = driver._parse_cve("CVE-2024-8088", hydra_cve)
-        record = self._python39_fixed_in(results)
+        record = self._python39_fixed_in(driver._parse_cve("CVE-2024-8088", hydra_cve))
 
-        # the two streams are partitioned by upstream version base; a 9.4 host at or above
-        # 3.9.18-3.el9_4.5 is < 3.9.19 and therefore matches no clause (not vulnerable).
-        assert record["VulnerableRange"] == "< 0:3.9.18-3.el9_4.5 || >= 0:3.9.19, < 0:3.9.19-8.el9"
+        # both distinct stream builds are carried, newest first, each paired with its advisory; the
+        # grype matcher selects between them by the installed package's dist-tag minor at match time.
+        assert record["AdditionalAdvisoryFixes"] == [
+            {
+                "Version": "0:3.9.19-8.el9",
+                "Advisory": {"ID": "RHSA-2024:9371", "Link": "https://access.redhat.com/errata/RHSA-2024:9371"},
+            },
+            {
+                "Version": "0:3.9.18-3.el9_4.5",
+                "Advisory": {"ID": "RHSA-2024:6163", "Link": "https://access.redhat.com/errata/RHSA-2024:6163"},
+            },
+        ]
+        # Option A drives stream selection in the matcher, not via a VulnerableRange constraint
+        assert "VulnerableRange" not in record
 
     def test_canonical_version_is_newest_stream(self, hydra_cve, fixture_dir, tmpdir, auto_fake_fixdate_finder):
         ws = workspace.Workspace(tmpdir, "test", create=True)

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -7,8 +7,18 @@ import pytest
 
 from vunnel import result, workspace
 from vunnel.providers.rhel import Config, Provider
-from vunnel.providers.rhel.parser import Advisory, AffectedRelease, FixedIn, Parser
+from vunnel.providers.rhel.parser import Advisory, AdvisoryFix, AffectedRelease, FixedIn, Parser
 from vunnel.providers.rhel.rhsa_provider import RHSAProvider
+
+
+def _af(version: str, advisory: Advisory) -> AdvisoryFix:
+    """Build the AdvisoryFix (version + advisory) that Option A now carries for each distinct
+    called-out fix build. Single-stream fixes carry exactly one entry mirroring the canonical fix."""
+    return AdvisoryFix(version=version, advisory=advisory)
+
+
+def _no_advisory() -> Advisory:
+    return Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None)
 
 
 class FakeRHSAProvider(RHSAProvider):
@@ -457,14 +467,14 @@ class TestParser:
 
         # see https://access.redhat.com/security/cve/cve-2021-33631
         expected = [
-            FixedIn(package='kernel-rt', platform='8', version='0:4.18.0-513.24.1.rt7.326.el8_9', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1614', link='https://access.redhat.com/errata/RHSA-2024:1614', severity=None)),
-            FixedIn(package='kernel', platform='8', version='0:4.18.0-513.24.1.el8_9', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1607', link='https://access.redhat.com/errata/RHSA-2024:1607', severity=None)),
-            FixedIn(package='kernel', platform='8.6+eus', version='0:4.18.0-372.98.1.el8_6', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1653', link='https://access.redhat.com/errata/RHSA-2024:1653', severity=None)),
-            FixedIn(package='kernel', platform='8.8+eus', version='0:4.18.0-477.55.1.el8_8', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:2621', link='https://access.redhat.com/errata/RHSA-2024:2621', severity=None)),
-            FixedIn(package='kernel', platform='9', version='0:5.14.0-284.11.1.el9_2', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2023:2458', link='https://access.redhat.com/errata/RHSA-2023:2458', severity=None)),
-            FixedIn(package='kernel-rt', platform='9', version='0:5.14.0-284.11.1.rt14.296.el9_2', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2023:2148', link='https://access.redhat.com/errata/RHSA-2023:2148', severity=None)),
-            FixedIn(package='kernel', platform='9.0+eus', version='0:5.14.0-70.97.1.el9_0', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1836', link='https://access.redhat.com/errata/RHSA-2024:1836', severity=None)),
-            FixedIn(package='kernel-rt', platform='9.0+eus', version='0:5.14.0-70.97.1.rt21.169.el9_0', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1840', link='https://access.redhat.com/errata/RHSA-2024:1840', severity=None)),
+            FixedIn(package='kernel-rt', platform='8', version='0:4.18.0-513.24.1.rt7.326.el8_9', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1614', link='https://access.redhat.com/errata/RHSA-2024:1614', severity=None), additional_advisories=(_af('0:4.18.0-513.24.1.rt7.326.el8_9', Advisory(wont_fix=False, rhsa_id='RHSA-2024:1614', link='https://access.redhat.com/errata/RHSA-2024:1614', severity=None)),)),
+            FixedIn(package='kernel', platform='8', version='0:4.18.0-513.24.1.el8_9', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1607', link='https://access.redhat.com/errata/RHSA-2024:1607', severity=None), additional_advisories=(_af('0:4.18.0-513.24.1.el8_9', Advisory(wont_fix=False, rhsa_id='RHSA-2024:1607', link='https://access.redhat.com/errata/RHSA-2024:1607', severity=None)),)),
+            FixedIn(package='kernel', platform='8.6+eus', version='0:4.18.0-372.98.1.el8_6', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1653', link='https://access.redhat.com/errata/RHSA-2024:1653', severity=None), additional_advisories=(_af('0:4.18.0-372.98.1.el8_6', Advisory(wont_fix=False, rhsa_id='RHSA-2024:1653', link='https://access.redhat.com/errata/RHSA-2024:1653', severity=None)),)),
+            FixedIn(package='kernel', platform='8.8+eus', version='0:4.18.0-477.55.1.el8_8', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:2621', link='https://access.redhat.com/errata/RHSA-2024:2621', severity=None), additional_advisories=(_af('0:4.18.0-477.55.1.el8_8', Advisory(wont_fix=False, rhsa_id='RHSA-2024:2621', link='https://access.redhat.com/errata/RHSA-2024:2621', severity=None)),)),
+            FixedIn(package='kernel', platform='9', version='0:5.14.0-284.11.1.el9_2', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2023:2458', link='https://access.redhat.com/errata/RHSA-2023:2458', severity=None), additional_advisories=(_af('0:5.14.0-284.11.1.el9_2', Advisory(wont_fix=False, rhsa_id='RHSA-2023:2458', link='https://access.redhat.com/errata/RHSA-2023:2458', severity=None)),)),
+            FixedIn(package='kernel-rt', platform='9', version='0:5.14.0-284.11.1.rt14.296.el9_2', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2023:2148', link='https://access.redhat.com/errata/RHSA-2023:2148', severity=None), additional_advisories=(_af('0:5.14.0-284.11.1.rt14.296.el9_2', Advisory(wont_fix=False, rhsa_id='RHSA-2023:2148', link='https://access.redhat.com/errata/RHSA-2023:2148', severity=None)),)),
+            FixedIn(package='kernel', platform='9.0+eus', version='0:5.14.0-70.97.1.el9_0', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1836', link='https://access.redhat.com/errata/RHSA-2024:1836', severity=None), additional_advisories=(_af('0:5.14.0-70.97.1.el9_0', Advisory(wont_fix=False, rhsa_id='RHSA-2024:1836', link='https://access.redhat.com/errata/RHSA-2024:1836', severity=None)),)),
+            FixedIn(package='kernel-rt', platform='9.0+eus', version='0:5.14.0-70.97.1.rt21.169.el9_0', module=None, advisory=Advisory(wont_fix=False, rhsa_id='RHSA-2024:1840', link='https://access.redhat.com/errata/RHSA-2024:1840', severity=None), additional_advisories=(_af('0:5.14.0-70.97.1.rt21.169.el9_0', Advisory(wont_fix=False, rhsa_id='RHSA-2024:1840', link='https://access.redhat.com/errata/RHSA-2024:1840', severity=None)),)),
         ]
 
         assert expected == results
@@ -513,6 +523,17 @@ class TestParser:
                             severity=None,
                             link="https://access.redhat.com/errata/RHSA-2019:2308",
                         ),
+                        additional_advisories=(
+                            _af(
+                                "0:7.2-3.el7",
+                                Advisory(
+                                    wont_fix=False,
+                                    rhsa_id="RHSA-2019:2308",
+                                    severity=None,
+                                    link="https://access.redhat.com/errata/RHSA-2019:2308",
+                                ),
+                            ),
+                        ),
                     ),
                     FixedIn(
                         module=None,
@@ -524,6 +545,17 @@ class TestParser:
                             rhsa_id="RHSA-2019:3345",
                             severity=None,
                             link="https://access.redhat.com/errata/RHSA-2019:3345",
+                        ),
+                        additional_advisories=(
+                            _af(
+                                "0:7.2-3.el8",
+                                Advisory(
+                                    wont_fix=False,
+                                    rhsa_id="RHSA-2019:3345",
+                                    severity=None,
+                                    link="https://access.redhat.com/errata/RHSA-2019:3345",
+                                ),
+                            ),
                         ),
                     ),
                 ],
@@ -557,6 +589,17 @@ class TestParser:
                             severity=None,
                             link="https://access.redhat.com/errata/RHSA-2019:2308",
                         ),
+                        additional_advisories=(
+                            _af(
+                                "0:7.2-3.el7",
+                                Advisory(
+                                    wont_fix=False,
+                                    rhsa_id="RHSA-2019:2308",
+                                    severity=None,
+                                    link="https://access.redhat.com/errata/RHSA-2019:2308",
+                                ),
+                            ),
+                        ),
                     )
                 ],
             ),
@@ -589,6 +632,17 @@ class TestParser:
                             severity=None,
                             link="https://access.redhat.com/errata/RHSA-2019:1234",
                         ),
+                        additional_advisories=(
+                            _af(
+                                "7.2-3.el7",
+                                Advisory(
+                                    wont_fix=False,
+                                    rhsa_id="RHSA-2019:1234",
+                                    severity=None,
+                                    link="https://access.redhat.com/errata/RHSA-2019:1234",
+                                ),
+                            ),
+                        ),
                     )
                 ],
             ),
@@ -609,6 +663,7 @@ class TestParser:
                         platform="7",
                         version="7.2-3.el7",
                         advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        additional_advisories=(_af("7.2-3.el7", _no_advisory()),),
                     )
                 ],
             ),
@@ -634,14 +689,19 @@ class TestParser:
                         platform="7",
                         version="7.2-3.el7.1",
                         advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        # both distinct builds carried, newest first
+                        additional_advisories=(
+                            _af("7.2-3.el7.1", _no_advisory()),
+                            _af("7.2-3.el7", _no_advisory()),
+                        ),
                     )
                 ],
             ),
             (
                 # same package and platform, different versions across distinct upstream bases
-                # (10.19.0 / 11.19.1 / 12.16.1). These are genuinely different streams, so a
-                # VulnerableRange is emitted partitioning each stream below its own fix. The
-                # reported Version remains the newest stream's fix (single-constraint fallback).
+                # (10.19.0 / 11.19.1 / 12.16.1). Option A carries each distinct fix build in
+                # additional_advisories (newest first) for matcher-side selection; the reported
+                # Version remains the newest stream's fix (the coarse single-constraint fallback).
                 {
                     "affected_release": [
                         {
@@ -666,10 +726,10 @@ class TestParser:
                         platform="8",
                         version="1:12.16.1-2.module+el8.1.0+6117+b25a342c",
                         advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
-                        vulnerable_range=(
-                            "< 1:10.19.0-2.module+el8.1.0+6118+5aaa808b "
-                            "|| >= 1:11.19.1, < 1:11.19.1-2.module+el8.1.0+6118+5aaa808b "
-                            "|| >= 1:12.16.1, < 1:12.16.1-2.module+el8.1.0+6117+b25a342c"
+                        additional_advisories=(
+                            _af("1:12.16.1-2.module+el8.1.0+6117+b25a342c", _no_advisory()),
+                            _af("1:11.19.1-2.module+el8.1.0+6118+5aaa808b", _no_advisory()),
+                            _af("1:10.19.0-2.module+el8.1.0+6118+5aaa808b", _no_advisory()),
                         ),
                     )
                 ],
@@ -696,6 +756,10 @@ class TestParser:
                         platform="6",
                         version="2:0.12.1.2-2.209.el6_2.1",
                         advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        additional_advisories=(
+                            _af("2:0.12.1.2-2.209.el6_2.1", _no_advisory()),
+                            _af("2:0.12.1.2-2.160.el6_1.9", _no_advisory()),
+                        ),
                     )
                 ],
             ),


### PR DESCRIPTION
Previously, when there were multiple RHSAs that fixed the same RPM for the same RHEL major version, Vunnel would either collapse them into a complex boolean expression if possible (for example if upstream moved and EVR was enough to distinguish the versions) or else would collapse to the higher version to prevent false negatives.

Instead, emit an additional item in the JSON for each additional relevant advisory. Crucially, the highest EVR is still in the "version" field so that legacy consumers of the data won't know the change, but these additional advisories will enable new consumers to decide which RHSA is most applicable to their stream.

Note that this makes the 'elN_M' suffixes on RPM versions somewhat load bearing, since that is how stream information is reported through, but that convention seems very strong and well-established.