### PR TITLE
feat(rhel): RHEL minor aware advisory grouping

### DIFF
--- a/schema/vulnerability/os/schema-1.1.2.json
+++ b/schema/vulnerability/os/schema-1.1.2.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "os-vulnerability",
+  "description": "represents vulnerability records for common linux distributions",
+  "properties": {
+    "Vulnerability": {
+      "type": "object",
+      "properties": {
+        "CVSS": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "base_metrics": {
+                  "type": "object",
+                  "properties": {
+                    "base_score": {
+                      "type": "number"
+                    },
+                    "base_severity": {
+                      "type": "string"
+                    },
+                    "exploitability_score": {
+                      "type": "number"
+                    },
+                    "impact_score": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "base_score",
+                    "base_severity",
+                    "exploitability_score",
+                    "impact_score"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "vector_string": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "base_metrics",
+                "status",
+                "vector_string",
+                "version"
+              ]
+            }
+          ]
+        },
+        "Description": {
+          "type": "string"
+        },
+        "FixedIn": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "Name": {
+                  "type": "string"
+                },
+                "NamespaceName": {
+                  "type": "string"
+                },
+                "VendorAdvisory": {
+                  "type": "object",
+                  "properties": {
+                    "AdvisorySummary": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "NoAdvisory": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "NoAdvisory"
+                  ]
+                },
+                "Version": {
+                  "type": "string"
+                },
+                "VersionFormat": {
+                  "type": "string"
+                },
+                "Availability": {
+                  "type": "object",
+                  "properties": {
+                    "Date": {
+                      "type": "string"
+                    },
+                    "Kind": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "VulnerableRange": {
+                  "type": ["string", "null"]
+                },
+                "Module": {
+                  "type": ["string", "null"]
+                },
+                "Arch": {
+                  "type": ["string", "null"],
+                  "description": "the architecture this fix applies to (e.g. \"x86_64\", \"aarch64\"). Set only when a single advisory ships different fixes per architecture; omitted/null when the fix is identical across architectures, in which case it applies to all."
+                },
+                "Advisories": {
+                  "type": "array",
+                  "description": "the complete per-stream fix table for same-base multi-minor RHSAs: every distinct fix build for this (cve, package, major) group, each with the target RHEL minor and the extended-support channels that deliver it, parsed from the CSAF product_ids. emitted only when 2+ distinct fix streams exist; the top-level Version remains the highest-EVR build for back-compat",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Advisory": {
+                        "type": "string",
+                        "description": "the RHSA/RHBA id that shipped this fix build (may be empty when no advisory is associated)"
+                      },
+                      "Version": {
+                        "type": "string",
+                        "description": "the full fixed EVR including epoch and dist tag, e.g. 0:2.44.3-2.el9_2"
+                      },
+                      "Minor": {
+                        "type": ["integer", "null"],
+                        "description": "the target RHEL minor recovered from the product_id, or null when it could not be determined"
+                      },
+                      "Channels": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": [],
+                        "description": "support channels this fix shipped to; 'ga' = generally available; extended tiers eus/e4s/aus/tus/els; empty = unknown"
+                      }
+                    },
+                    "required": [
+                      "Advisory",
+                      "Version"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "Name",
+                "NamespaceName",
+                "Version",
+                "VersionFormat"
+              ]
+            }
+          ]
+        },
+        "Link": {
+          "type": "string"
+        },
+        "Metadata": {
+          "type": "object",
+          "properties": {
+            "Issued": {
+              "type": "string",
+              "description": "date the vulnerability was published"
+            },
+            "Updated": {
+              "type": "string",
+              "description": "date the vulnerability was last updated"
+            },
+            "Withdrawn": {
+              "type": "string",
+              "description": "date the vulnerability was withdrawn"
+            },
+            "RefId": {
+              "type": "string"
+            },
+            "CVE": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Name": {
+                      "type": "string"
+                    },
+                    "Link": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Name"
+                  ]
+                }
+              ]
+            },
+            "NVD": {
+              "type": "object",
+              "properties": {
+                "CVSSv2": {
+                  "type": "object",
+                  "properties": {
+                    "Score": {
+                      "type": "number"
+                    },
+                    "Vectors": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "Score"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "Name": {
+          "type": "string"
+        },
+        "NamespaceName": {
+          "type": "string"
+        },
+        "Severity": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Description",
+        "FixedIn",
+        "Link",
+        "Metadata",
+        "Name",
+        "NamespaceName",
+        "Severity"
+      ]
+    }
+  },
+  "required": [
+    "Vulnerability"
+  ]
+}

--- a/src/vunnel/providers/rhel/__init__.py
+++ b/src/vunnel/providers/rhel/__init__.py
@@ -41,7 +41,11 @@ class Config:
 
 
 class Provider(provider.Provider):
-    __schema__ = schema.OSSchema()
+    # RHEL emits the additive Advisories field (the per-stream fix table for same-base multi-minor
+    # RHSAs), introduced in OS schema 1.1.2 (additive on top of upstream's 1.1.1 Arch addition).
+    # Pinned here rather than bumping the shared OS_SCHEMA_VERSION default so only this provider
+    # advances and other OS providers don't churn.
+    __schema__ = schema.OSSchema("1.1.2")
     __distribution_version__ = int(__schema__.major_version)
 
     def __init__(self, root: str, config: Config | None = None):

--- a/src/vunnel/providers/rhel/csaf_parser.py
+++ b/src/vunnel/providers/rhel/csaf_parser.py
@@ -3,6 +3,7 @@ import logging
 from packageurl import PackageURL
 
 from vunnel.providers.rhel.csaf_client import CSAFClient
+from vunnel.providers.rhel.product_id import parse_product_id
 from vunnel.utils.csaf_types import CSAFDoc
 from vunnel.workspace import Workspace
 
@@ -130,37 +131,50 @@ class CSAFParser:
         return platform_cpe, module, name, version
 
     # note: this is really taking an ar dict because of a circular import issue. It should be taking an AffectedRelease object.
-    def get_fix_info(self, cve_id: str, ar: dict[str, str | None], normalized_pkg_name: str) -> tuple[str | None, str | None]:
+    def get_fix_info(
+        self,
+        cve_id: str,
+        ar: dict[str, str | None],
+        normalized_pkg_name: str,
+    ) -> tuple[str | None, str | None, str | None, list[str]]:
         """
         Given a CVE ID, an affected release object, and the normalized name of the affected package,
         interrogate CSAF RHSA data to look for an advisory that tells us what version of the package is
         fixed, and the modularity of the package if any.
+
+        Returns a (version, module, product_id, channels) tuple. product_id is the matched CSAF full
+        product id (FPI), which -- unlike the version, product_name, or cpe -- encodes the target RHEL
+        minor stream; the caller uses it to recover the per-stream minor for same-base multi-RHSA
+        handling. ``channels`` is the sorted, deduped set of recognized channel tokens -- including the
+        explicit ``"ga"`` token for generally-available FPIs -- computed across ALL FPIs that ship this
+        exact (version, module) build (e.g. ``["ga"]``, ``["ga", "eus"]``, ``["aus", "eus"]``). It is
+        empty only when NO FPI resolved to a recognized channel (i.e. the channel set is unknown).
 
         The `ar` dict is expected to have the following
         """
         fix_id = ar.get("rhsa_id")
         if not fix_id:
             # This affected release does not reference an advisory; assume it isn't fixed
-            return None, None
+            return None, None, None, []
         doc = self.csaf_client.csaf_doc_for_rhsa(fix_id)
         if not doc:
             # There was no document available for the referenced RHSA. This is unexpected,
             # but logged in the csaf client.
-            return None, None
+            return None, None, None, []
 
         # The CSAF spec allows N vulnerabilities per document. Find the first one whose CVE matches
         # the CVE ID we're looking for fix info for.
         vuln = next((v for v in doc.vulnerabilities if v.cve == cve_id), None)
         if not vuln:
             self.logger.trace(f"{cve_id}: {fix_id} CSAF doc does not claim to fix this CVE")  # type: ignore[attr-defined]
-            return None, None
+            return None, None, None, []
 
         # There are multiple remediations in a CSAF doc, including ones that say things like "no fix available".
         # Choose the "vendor_fix" type remediation that corresponds to the advisory ID mentioned in the affected release.
         remediation = next((r for r in vuln.remediations if r.category == "vendor_fix" and r.url and r.url.endswith(fix_id)), None)
         if not remediation:
             self.logger.trace(f"{cve_id} no remediation obj for {fix_id}")  # type: ignore[attr-defined]
-            return None, None
+            return None, None, None, []
 
         # assume that one of the products listed as rebuilt due to the advisory indicates the first fixed
         # version of the package.
@@ -168,10 +182,67 @@ class CSAFParser:
         ar_plat_cpe = ar.get("platform_cpe")
         if not ar_plat_cpe:
             self.logger.trace(f"{cve_id} no platform cpe for {fix_id}")  # type: ignore[attr-defined]
-            return None, None
+            return None, None, None, []
         self.logger.trace(f"{cve_id} searching {fix_id} based on {ar_plat_cpe} and {normalized_pkg_name}")  # type: ignore[attr-defined]
 
-        return self.best_version_module_from_fpis(doc, fix_id, candidate_full_product_ids, normalized_pkg_name, ar_plat_cpe)
+        version, module, product_id = self.best_version_module_from_fpis(
+            doc,
+            fix_id,
+            candidate_full_product_ids,
+            normalized_pkg_name,
+            ar_plat_cpe,
+        )
+        # Compute the channel set by considering EVERY candidate FPI that ships this same
+        # (name, platform, version, module) build, not just the single "best" one selected above.
+        # One backported build is frequently delivered via several channels at once (e.g. GA + EUS),
+        # and each recognized channel -- including "ga" -- is preserved in the union.
+        channels = self.channels_from_fpis(
+            doc,
+            candidate_full_product_ids,
+            normalized_pkg_name,
+            ar_plat_cpe,
+            version,
+            module,
+        )
+        return version, module, product_id, channels
+
+    def channels_from_fpis(  # noqa: PLR0913
+        self,
+        doc: CSAFDoc,
+        candidate_product_ids: list[str],
+        normalized_pkg_name: str,
+        ar_plat_cpe: str,
+        version: str | None,
+        module: str | None,
+    ) -> list[str]:
+        """Compute the recognized channel set for a chosen (version, module) build.
+
+        Look at ALL candidate FPIs whose package name matches, whose platform CPE lines up, and which
+        resolve to the SAME (version, module) build that was selected as the fix. Each FPI's platform
+        prefix resolves to a recognized channel token -- ``"ga"`` for a generally-available build, or
+        an extended token (``eus``/``e4s``/``aus``/``tus``/``els``) -- or to ``None`` when unrecognized.
+
+        Return the sorted, deduped set of recognized channel tokens (including ``"ga"``) across the
+        matching FPIs. An FPI whose channel is ``None`` (unknown) contributes nothing; a build whose
+        FPIs are ALL unrecognized yields ``[]`` (unknown channel set), which is NOT "generally available".
+        """
+        if not version:
+            return []
+
+        channels: set[str] = set()
+        for fpi in candidate_product_ids:
+            plat, fpi_module, name, fpi_version = self.platform_module_name_version_from_fpi(doc, fpi)
+            if name != normalized_pkg_name or not plat or not plat.startswith(ar_plat_cpe):
+                continue
+            # only union channels for FPIs that ship the exact build we selected as the fix
+            if fpi_version != version or fpi_module != module:
+                continue
+            channel = parse_product_id(fpi).channel
+            if channel is None:
+                # unrecognized channel for this FPI -> contributes nothing to the recognized set
+                continue
+            channels.add(channel)
+        return sorted(channels)
 
     def best_version_module_from_fpis(
         self,
@@ -180,15 +251,16 @@ class CSAFParser:
         candidate_product_ids: list[str],
         normalized_pkg_name: str,
         ar_plat_cpe: str,
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[str | None, str | None, str | None]:
         """
         Loop over all candidate product IDs, that is, all product IDs that were patched by the RHSA in question,
         and ask the CSAF document for their platform, module, name, and version.
-        Return the first version and module for the first product ID whose package name matches the
+        Return the (version, module, product_id) for the first product ID whose package name matches the
         normalized package name from Hydra, and whose platform CPE starts with the platform CPE from Hydra.
+        The product_id (FPI) is returned so the caller can recover the target RHEL minor from it.
         """
 
-        backup_module, backup_version = None, None
+        backup_module, backup_version, backup_fpi = None, None, None
         for fpi in candidate_product_ids:
             plat, module, name, version = self.platform_module_name_version_from_fpi(doc, fpi)
             # use startswith because we see things like cpe:/a:redhat:enterprise_linux:8 in hydra returns
@@ -199,12 +271,12 @@ class CSAFParser:
                 # them if we can't find a better match.
                 if version and "ael" in version:
                     self.logger.trace(f"found alternative match for {fpi}, {name}, {plat} against {ar_plat_cpe}: {normalized_pkg_name}")  # type: ignore[attr-defined]
-                    backup_module, backup_version = module, version
+                    backup_module, backup_version, backup_fpi = module, version, fpi
                     continue
                 self.logger.trace(f"found match for {fpi}, {name}, {plat} against {ar_plat_cpe}: {normalized_pkg_name}")  # type: ignore[attr-defined]
-                return version, module
+                return version, module, fpi
         if backup_version:
             self.logger.trace(  # type: ignore[attr-defined]
                 f"returning alternative match {backup_version} (module: {backup_module}) for {fix_id} against {ar_plat_cpe}: {normalized_pkg_name}",
             )
-        return backup_version, backup_module
+        return backup_version, backup_module, backup_fpi

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -636,6 +636,10 @@ class Parser:
                         )
                     stream_advisories = tuple(built)
 
+                # Intentional gating asymmetry: the advisory summary below keys on distinct upstream
+                # bases, while the per-stream `advisories` table above keys on distinct full EVRs. For a
+                # same-base multi-minor fix these differ -- the summary keeps its historical "newest
+                # build + its advisory" shape (back-compat) and `advisories` is the complete per-stream list.
                 if len(distinct_base_fixes) > 1:
                     vulnerable_range = _build_vulnerable_range(distinct_base_fixes)
                     self.logger.debug(
@@ -961,7 +965,7 @@ class Parser:
                     # generally-available builds (e.g. ["ga"], ["ga","eus"], ["eus"], ["aus","eus"]);
                     # empty means the channel set is unknown. Emitted only when there are 2+ distinct
                     # fix streams; additive (OS schema
-                    # 1.1.1) and ignored by older grype, which continues to use Version. A downstream
+                    # 1.1.2) and ignored by older grype, which continues to use Version. A downstream
                     # matcher can use this to select the build matching the installed package's own minor.
                     if artifact.advisories:
                         record["Advisories"] = [

--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -20,6 +20,7 @@ from cvss import CVSS3
 from dateutil import parser as dt_parser
 
 from vunnel import utils
+from vunnel.providers.rhel.product_id import minor_from_dist_tag, parse_product_id
 from vunnel.providers.rhel.rhsa_provider import AffectedRelease, CSAFRHSAProvider
 from vunnel.tool import fixdate
 from vunnel.utils import http_wrapper as http
@@ -38,11 +39,16 @@ namespace = "rhel"
 
 FixedIn = namedtuple(
     "FixedIn",
-    ["package", "platform", "version", "module", "advisory", "vulnerable_range", "additional_advisories"],
-    defaults=[None, ()],
+    ["package", "platform", "version", "module", "advisory", "vulnerable_range", "additional_advisories", "advisories"],
+    defaults=[None, (), ()],
 )
 RHSAFixedIn = namedtuple("RHSAFixedIn", ["package", "version"])
 Advisory = namedtuple("Advisory", ["wont_fix", "rhsa_id", "link", "severity"])
+# StreamAdvisory carries one per-stream fix build for a (cve, package, major) group: the advisory
+# that shipped it, the full EVR (including dist tag), and the target RHEL minor + channel set parsed
+# from the advisory's CSAF product_id. Emitted in FixedIn.advisories ONLY when a group has 2+ distinct
+# fix streams, so a downstream matcher can pick the build matching the installed package's own minor.
+StreamAdvisory = namedtuple("StreamAdvisory", ["advisory", "version", "minor", "channels"])
 NamespacePayload = namedtuple("NamespacePayload", ["namespace", "payload"])
 
 
@@ -482,12 +488,16 @@ class Parser:
                     if f"{namespace}:{ar_obj.platform}" in self.skip_namespaces:  # no need to process deny-listed platforms
                         continue
 
+                    final_pid = None
+                    final_channels: list[str] = []
                     if ar_obj.name:
                         if ar_obj.rhsa_id:  # rhsa lookup for version information tends to make version consistent
-                            rhsa_version, rhsa_module = self._fetch_rhsa_fix_version(cve_id, ar_obj)
+                            rhsa_version, rhsa_module, rhsa_product_id, rhsa_channels = self._fetch_rhsa_fix_version(cve_id, ar_obj)
                             if rhsa_version:
                                 final_v = rhsa_version
                                 final_m = rhsa_module
+                                final_pid = rhsa_product_id
+                                final_channels = rhsa_channels
                             else:
                                 self.logger.debug(
                                     f"{cve_id}, platform={ar_obj.platform} : no matches found for {ar_obj.rhsa_id} and package={ar_obj.name} Falling back to CVE version {ar_obj.version}",  # noqa: E501
@@ -511,7 +521,11 @@ class Parser:
                         possible_packages = set().union(*platform_packages.values()).difference(platform_packages[ar_obj.platform])
 
                         for pkg_name in possible_packages:
-                            rhsa_version, rhsa_module = self._fetch_rhsa_fix_version(cve_id, ar_obj, override_package_name=pkg_name)
+                            rhsa_version, rhsa_module, rhsa_product_id, rhsa_channels = self._fetch_rhsa_fix_version(
+                                cve_id,
+                                ar_obj,
+                                override_package_name=pkg_name,
+                            )
 
                             if rhsa_version:
                                 self.logger.debug(
@@ -519,6 +533,8 @@ class Parser:
                                 )
                                 final_v = rhsa_version
                                 final_m = rhsa_module
+                                final_pid = rhsa_product_id
+                                final_channels = rhsa_channels
 
                                 platform_packages[ar_obj.platform].add(
                                     pkg_name,
@@ -544,6 +560,8 @@ class Parser:
 
                     ar_obj.version = final_v  # store the final_v in the object for future usage
                     ar_obj.module = final_m
+                    ar_obj.product_id = final_pid  # matched CSAF FPI; encodes the target RHEL minor
+                    ar_obj.channels = final_channels  # recognized channels delivering this build ("ga" + extended tiers; empty = unknown)
 
                     key = (ar_obj.name, ar_obj.platform, ar_obj.module)
                     bucket = collected_ar_objs.setdefault(key, [])
@@ -580,6 +598,44 @@ class Parser:
                 # drives matching downstream; this version is the single-constraint fallback.
                 canonical = distinct_base_fixes[-1]
 
+                # Build the stream-aware advisories table: one entry per DISTINCT fix build (full EVR,
+                # not just per upstream base), each with the target RHEL minor + the extended-support
+                # channels delivering it, recovered from its CSAF product_ids. This captures same-base
+                # multi-minor fixes (e.g. .el9_2 vs .el9_3
+                # builds of the same upstream) that the per-base reduction above intentionally collapses.
+                # Populated into FixedIn.advisories ONLY when there are 2+ distinct fix streams; for a
+                # single stream the top-level Version alone suffices (back-compat for old clients).
+                distinct_stream_fixes: list[AffectedRelease] = []
+                seen_stream_versions: set[str] = set()
+                for ar_obj in ar_objs:  # ascending by version
+                    if ar_obj.version in seen_stream_versions:
+                        continue
+                    seen_stream_versions.add(ar_obj.version)
+                    distinct_stream_fixes.append(ar_obj)
+
+                stream_advisories: tuple[StreamAdvisory, ...] = ()
+                if len(distinct_stream_fixes) > 1:
+                    built: list[StreamAdvisory] = []
+                    for ar_obj in reversed(distinct_stream_fixes):  # descending by version (newest first)
+                        info = parse_product_id(ar_obj.product_id)
+                        # The FPI is the authoritative source for the minor, but records resolved off
+                        # the CVE/Hydra path carry no FPI (product_id is None) so parse yields None.
+                        # Fall back to the minor encoded in the fix version's own ``.elN_M`` dist tag
+                        # so a Z-stream/EUS build (e.g. ``0:2.34-60.el9_2.7`` -> 2) still gets a minor;
+                        # a bare GA ``.elN`` build legitimately stays None (only the FPI can supply it).
+                        minor = info.minor if info.minor is not None else minor_from_dist_tag(ar_obj.version)
+                        built.append(
+                            StreamAdvisory(
+                                advisory=_advisory_from_rhsa(ar_obj.rhsa_id),
+                                version=ar_obj.version,
+                                minor=minor,
+                                # channels are unioned across all FPIs for this build during the RHSA lookup;
+                                # includes the explicit "ga" token for generally-available builds; empty = unknown.
+                                channels=ar_obj.channels,
+                            ),
+                        )
+                    stream_advisories = tuple(built)
+
                 if len(distinct_base_fixes) > 1:
                     vulnerable_range = _build_vulnerable_range(distinct_base_fixes)
                     self.logger.debug(
@@ -610,6 +666,7 @@ class Parser:
                         advisory=primary_advisory,
                         vulnerable_range=vulnerable_range,
                         additional_advisories=additional_advisories,
+                        advisories=stream_advisories,
                     ),
                 )
         finally:
@@ -896,6 +953,27 @@ class Parser:
                     # verbatim in preference to deriving "< Version" from the single fix version.
                     if artifact.vulnerable_range:
                         record["VulnerableRange"] = artifact.vulnerable_range
+
+                    # Advisories carries the full per-stream fix table for same-base multi-minor RHSAs:
+                    # every distinct fix build (including the one that became the top-level Version),
+                    # each with the target RHEL minor + the channels delivering it, recovered from the
+                    # CSAF product_ids. Channels lists every recognized channel including "ga" for
+                    # generally-available builds (e.g. ["ga"], ["ga","eus"], ["eus"], ["aus","eus"]);
+                    # empty means the channel set is unknown. Emitted only when there are 2+ distinct
+                    # fix streams; additive (OS schema
+                    # 1.1.1) and ignored by older grype, which continues to use Version. A downstream
+                    # matcher can use this to select the build matching the installed package's own minor.
+                    if artifact.advisories:
+                        record["Advisories"] = [
+                            {
+                                "Advisory": sa.advisory.rhsa_id or "",
+                                "Version": sa.version,
+                                "Minor": sa.minor,
+                                "Channels": sa.channels,
+                            }
+                            for sa in artifact.advisories
+                            if sa.version
+                        ]
 
                     result = self.fixdater.best(
                         vuln_id=cve_id,

--- a/src/vunnel/providers/rhel/product_id.py
+++ b/src/vunnel/providers/rhel/product_id.py
@@ -1,0 +1,196 @@
+"""Parse the target RHEL minor version (and extended-support channel) out of a CSAF/Hydra product_id.
+
+Red Hat's CSAF advisories identify a fixed build with a "full product id" (FPI) string. The FPI
+encodes which RHEL *minor* stream the build targets, but that minor is NOT present in the
+human-readable ``product_name`` ("Red Hat Enterprise Linux 9") nor in the platform CPE
+("cpe:/a:redhat:enterprise_linux:9") -- both of which collapse every minor of a major into one
+bucket. The minor is only recoverable from the FPI's platform prefix.
+
+Two FPI prefix formats exist and Red Hat is migrating from the first to the second, so both must be
+handled (detected per-record):
+
+OLD format -- the platform prefix is ``{Repo}-{MAJOR}.{MINOR}[.{Z}][.{markers}]``::
+
+    AppStream-9.5.0.GA:webkit2gtk3-0:2.44.3-2.el9.x86_64          -> minor 5,  channel "ga"
+    AppStream-8.2.0.Z.EUS:bind-32:9.11.13-6.el8_2.3.x86_64        -> minor 2,  channel "eus"
+    BaseOS-9.4.0.Z.MAIN.EUS:glibc-0:2.34-100.el9_4.x86_64         -> minor 4,  channel "eus"
+    AppStream-9.5.Z:foo-0:1-1.el9_5.x86_64                        -> minor 5,  channel "ga"
+    AppStream-8.4.0.Z.AUS:bar-0:1-1.el8_4.x86_64                  -> minor 4,  channel "aus"
+    AppStream-8.8.0.Z.ENS:foo-0:1-1.el8_8.x86_64                  -> minor 8,  channel None (unknown marker)
+    7Server-ELS:webkitgtk4-0:2.48.3-2.el7_9.x86_64               -> minor None, channel "els"
+
+NEW format -- the platform prefix is ``rhel-{MAJOR}.{MINOR}[-marker]``::
+
+    rhel-9.5::appstream:webkit2gtk3-0:2.44.3-2.el9                -> minor 5,  channel "ga"
+    rhel-8.6-eus::appstream:foo-0:1-1.el8_6                       -> minor 6,  channel "eus"
+
+The channel is TRI-STATE:
+
+* a recognized GENERAL marker yields ``"ga"`` (generally available): the GA compose (``.GA``), a
+  z-stream MAIN with no extended token (``.Z.MAIN``), and new-format ids with no extended marker
+  (``rhel-9.4::appstream:...``);
+* a recognized EXTENDED token yields that canonical lowercase token: ``eus``, ``e4s``, ``aus``,
+  ``tus`` (pinned-minor maintenance streams) or ``els`` (extended *lifecycle* support, major-only);
+* ANYTHING unrecognized -- an unexpected marker such as ``.Z.ENS``, garbage input, or a non-RHEL
+  product (e.g. OpenShift) -- yields ``None`` (unknown). ``None`` does NOT mean "generally available";
+  unknown is never assumed to be GA.
+
+The minor and the channel are independent: ELS yields ``minor=None`` (major-only stream) but a real
+``els`` channel, while GA/EUS/E4S/AUS/TUS yield both a minor and their channel token. If the minor
+cannot be determined the parser returns ``minor=None`` rather than guessing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+# Dot-separated tokens (old format) or hyphen suffix (new format) that mark a pinned-minor extended
+# maintenance stream. Matched case-insensitively as whole tokens and normalized to lowercase tokens.
+_EXTENDED_MARKERS = ("EUS", "E4S", "AUS", "TUS")
+
+# Recognized GENERAL (non-extended) markers. Their presence -- or, in the new format, the absence of
+# ANY marker -- means the build ships generally available and resolves to the explicit ``"ga"`` token.
+# ``GA`` is the GA compose; ``Z`` and ``MAIN`` appear in z-stream main-channel ids (e.g. ``.Z.MAIN``).
+# Any token NOT in this set and NOT an extended marker (e.g. ``ENS``) is unrecognized -> channel None.
+_GENERAL_MARKERS = ("GA", "Z", "MAIN")
+
+# OLD format platform prefix, e.g. "AppStream-9.5.0.GA", "BaseOS-9.4.0.Z.MAIN.EUS", "AppStream-9.5.Z".
+# Capture the repo label, then MAJOR.MINOR (minor optional in case only a major is present), then the
+# trailing marker tokens. The version-like part is "{MAJOR}.{MINOR}" optionally followed by ".{Z}"
+# and any number of ".{TOKEN}" markers.
+_OLD_PREFIX = re.compile(
+    r"^(?P<repo>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*?)-(?P<major>\d+)\.(?P<minor>\d+)(?P<rest>(?:\.[A-Za-z0-9]+)*)$",
+)
+
+# NEW format platform prefix, e.g. "rhel-9.5", "rhel-8.6-eus".
+_NEW_PREFIX = re.compile(
+    r"^rhel-(?P<major>\d+)\.(?P<minor>\d+)(?:-(?P<marker>[A-Za-z0-9]+))?$",
+)
+
+# RPM dist tag carried in a build's release, used as a fallback when the FPI is unavailable. The
+# minor is encoded in exactly two tag shapes:
+#   * the Z-stream/EUS form ".elN_M" -- the underscore is the minor separator (".el9_2" -> 2);
+#   * the modular form "+elN.M"     -- preceded by "+", a dot then carries the minor ("+el8.1.0" -> 1).
+# A bare GA tag ".elN" carries NO minor, and a GA respin suffix ".elN.M" (a DOT after a plain ".el",
+# e.g. "7.2-3.el7.1") is a rebuild counter, NOT a minor -- so neither yields one (only the FPI can
+# supply a GA build's minor). Two alternatives keep "_" (any tag) distinct from "." (modular "+el" only).
+_DIST_TAG_MINOR = re.compile(r"(?:(?:^|[.+])el\d+_(?P<zminor>\d+))|(?:\+el\d+\.(?P<modminor>\d+))")
+
+
+class ProductIdInfo(NamedTuple):
+    """Parsed view of a product_id: the target minor (or None) and the TRI-STATE channel.
+
+    ``channel`` is one of:
+
+    * ``"ga"`` -- a recognized GENERAL marker (the GA compose ``.GA``, a z-stream ``.Z.MAIN`` with no
+      extended token, or a new-format id with no extended marker); the build is generally available;
+    * a canonical lowercase extended token (``"eus"``, ``"e4s"``, ``"aus"``, ``"tus"``, ``"els"``)
+      when the FPI targets that extended-support channel;
+    * ``None`` (UNKNOWN) when no recognized marker was found -- an unexpected marker (e.g. ``.Z.ENS``),
+      garbage input, or a non-RHEL product. ``None`` does NOT mean "generally available".
+    """
+
+    minor: int | None
+    channel: str | None
+
+
+def _platform_prefix(product_id: str) -> str:
+    """Return the platform/stream prefix of an FPI.
+
+    NEW format uses ``::`` to separate the platform from the repo (``rhel-9.5::appstream:...``), so
+    for new-format ids the prefix is everything before the first ``::``.
+
+    OLD format uses a single ``:`` between platform and package (``AppStream-9.5.0.GA:webkit...``);
+    the prefix is everything before the first ``:``. Note ``::`` ALSO appears in old-format *modular*
+    ids, but only as a trailing module-name suffix (``...x86_64::squid:4``), so we must NOT split old
+    ids on ``::``. Distinguish purely by the ``rhel-`` marker that opens the new format.
+    """
+    if product_id.startswith("rhel-"):
+        return product_id.split("::", 1)[0]
+    return product_id.split(":", 1)[0]
+
+
+def _channel_from_tokens(tokens: list[str]) -> str | None:
+    """Resolve the TRI-STATE channel from a build's marker tokens.
+
+    * If any token is a recognized EXTENDED marker, return its canonical lowercase token (extended
+      wins over general -- e.g. ``.Z.MAIN.EUS`` is ``"eus"``).
+    * Otherwise, if every (non-numeric) token is a recognized GENERAL marker (``GA``/``Z``/``MAIN``),
+      the build is generally available -> ``"ga"``. Purely-numeric tokens (the z-stream position digit
+      in ``.0.GA``) are ignored for classification.
+    * Otherwise (an unrecognized token such as ``ENS`` is present), the channel is unknown -> ``None``.
+    """
+    # Drop purely-numeric tokens (e.g. the "0" in ".0.GA"); they carry no channel meaning.
+    upper = [t.upper() for t in tokens if not t.isdigit()]
+    for marker in _EXTENDED_MARKERS:
+        if marker in upper:
+            return marker.lower()
+    if upper and all(t in _GENERAL_MARKERS for t in upper):
+        return "ga"
+    return None
+
+
+def parse_product_id(product_id: str | None) -> ProductIdInfo:
+    """Parse the target RHEL minor and extended-support channel out of a CSAF/Hydra product_id (full product id).
+
+    Detects the OLD (``AppStream-9.5.0.GA:...``) and NEW (``rhel-9.5::...``) formats automatically and
+    returns a :class:`ProductIdInfo`. ``channel`` is TRI-STATE: ``"ga"`` for a recognized generally-
+    available build, a lowercase token (``eus``/``e4s``/``aus``/``tus``/``els``) for an extended-support
+    stream, or ``None`` (unknown) when no recognized marker was found. ``None`` is NOT assumed to be GA.
+    When the minor cannot be determined (empty/garbage input, or a major-only stream such as
+    ``7Server-ELS``), ``minor`` is ``None`` and we do not guess.
+    """
+    if not product_id:
+        return ProductIdInfo(minor=None, channel=None)
+
+    prefix = _platform_prefix(product_id)
+
+    # NEW format: rhel-{major}.{minor}[-marker]
+    new_match = _NEW_PREFIX.match(prefix)
+    if new_match:
+        minor = int(new_match.group("minor"))
+        marker = new_match.group("marker")
+        # No marker in the new format means generally available -> "ga"; a marker is resolved
+        # tri-state (extended token, or None when unrecognized).
+        channel = _channel_from_tokens([marker]) if marker else "ga"
+        return ProductIdInfo(minor=minor, channel=channel)
+
+    # OLD format: {Repo}-{major}.{minor}[.{Z}][.{markers}]
+    old_match = _OLD_PREFIX.match(prefix)
+    if old_match:
+        minor = int(old_match.group("minor"))
+        rest = old_match.group("rest") or ""
+        # rest looks like ".0.GA" or ".Z.MAIN.EUS"; split into dot tokens and resolve tri-state.
+        tokens = [t for t in rest.split(".") if t]
+        channel = _channel_from_tokens(tokens)
+        return ProductIdInfo(minor=minor, channel=channel)
+
+    # ELS: extended *lifecycle* support is a major-only stream (no minor in the prefix), but it IS an
+    # extended-support channel. Recognize it from the trailing "-ELS" marker even when no minor parses.
+    if re.search(r"(?:^|-)ELS(?::|$)", prefix, flags=re.IGNORECASE):
+        return ProductIdInfo(minor=None, channel="els")
+
+    # No recognizable minor or channel (garbage, or a non-RHEL product). Do not guess.
+    return ProductIdInfo(minor=None, channel=None)
+
+
+def minor_from_dist_tag(version: str | None) -> int | None:
+    """Recover the target RHEL minor from an RPM version's own ``.elN_M`` dist tag.
+
+    Used as a fallback when no FPI/product_id is available (e.g. fix builds resolved off the
+    CVE/Hydra path, which carry no FPI) so the minor can still be recovered from the facts already
+    present in the version string. The minor is only encoded in the Z-stream/EUS form ``.elN_M``
+    (``0:2.34-60.el9_2.7`` -> ``2``) or in a modular ``+elN.M`` tag (``...module+el8.1.0+...`` -> 1).
+
+    A bare GA build whose tag is just ``.elN`` (e.g. ``0:2.34-100.el9``) encodes NO minor -- only the
+    FPI can supply one for a GA build -- so this returns ``None`` for it rather than guessing. Returns
+    ``None`` for empty input or a version with no recognizable dist tag.
+    """
+    if not version:
+        return None
+    match = _DIST_TAG_MINOR.search(version)
+    if match:
+        minor = match.group("zminor") or match.group("modminor")
+        return int(minor)
+    return None

--- a/src/vunnel/providers/rhel/product_id.py
+++ b/src/vunnel/providers/rhel/product_id.py
@@ -18,6 +18,7 @@ OLD format -- the platform prefix is ``{Repo}-{MAJOR}.{MINOR}[.{Z}][.{markers}]`
     AppStream-8.4.0.Z.AUS:bar-0:1-1.el8_4.x86_64                  -> minor 4,  channel "aus"
     AppStream-8.8.0.Z.ENS:foo-0:1-1.el8_8.x86_64                  -> minor 8,  channel None (unknown marker)
     7Server-ELS:webkitgtk4-0:2.48.3-2.el7_9.x86_64               -> minor None, channel "els"
+    6Server-ELS.EXTENSION:bind-32:9.8.2-0.68.rc1.el6_10.17.x86_64 -> minor None, channel "els"
 
 NEW format -- the platform prefix is ``rhel-{MAJOR}.{MINOR}[-marker]``::
 
@@ -172,8 +173,9 @@ def parse_product_id(product_id: str | None) -> ProductIdInfo:
         return ProductIdInfo(minor=minor, channel=channel)
 
     # ELS: extended *lifecycle* support is a major-only stream (no minor in the prefix), but it IS an
-    # extended-support channel. Recognize it from the trailing "-ELS" marker even when no minor parses.
-    if re.search(r"(?:^|-)ELS(?::|$)", prefix, flags=re.IGNORECASE):
+    # extended-support channel. Recognize the "-ELS" marker even when no minor parses; it may end the
+    # prefix ("7Server-ELS") or be followed by a dotted repo segment ("6Server-ELS.EXTENSION" on RHEL 6).
+    if re.search(r"(?:^|-)ELS(?:[.:]|$)", prefix, flags=re.IGNORECASE):
         return ProductIdInfo(minor=None, channel="els")
 
     # No recognizable minor or channel (garbage, or a non-RHEL product). Do not guess.

--- a/src/vunnel/providers/rhel/product_id.py
+++ b/src/vunnel/providers/rhel/product_id.py
@@ -45,8 +45,13 @@ from __future__ import annotations
 import re
 from typing import NamedTuple
 
-# Dot-separated tokens (old format) or hyphen suffix (new format) that mark a pinned-minor extended
+# Dot-separated tokens (old format) or hyphen suffix (new format) that mark a pinned-MINOR extended
 # maintenance stream. Matched case-insensitively as whole tokens and normalized to lowercase tokens.
+# NOTE: ELS is intentionally NOT here. Extended Lifecycle Support is a MAJOR-only stream (e.g.
+# "7Server-ELS", no minor in the prefix), so it never appears as a versioned dot-token alongside a
+# minor the way these do. It is recognized by its own branch in parse_product_id (the trailing
+# "-ELS" marker) and yields minor=None, channel="els". Adding it here would be wrong -- these markers
+# are scanned only against a versioned prefix's tokens, where ELS does not occur.
 _EXTENDED_MARKERS = ("EUS", "E4S", "AUS", "TUS")
 
 # Recognized GENERAL (non-extended) markers. Their presence -- or, in the new format, the absence of

--- a/src/vunnel/providers/rhel/rhsa_provider.py
+++ b/src/vunnel/providers/rhel/rhsa_provider.py
@@ -29,9 +29,10 @@ class AffectedRelease:
         # it encodes the target RHEL minor stream, so it is what lets us tell same-base per-stream
         # fixes apart. Populated during the RHSA lookup; may be None for non-CSAF-sourced versions.
         self.product_id: str | None = product_id
-        # The sorted, deduped set of extended-support channel tokens (e.g. ["aus", "eus"]) that this
-        # exact build is delivered through. Empty means the build is generally available (shipped via a
-        # normal/GA/non-extended channel). Computed across all FPIs for the build during the RHSA lookup.
+        # The sorted, deduped set of recognized channel tokens (e.g. ["ga"], ["aus", "eus"]) that this
+        # exact build is delivered through. Generally-available builds carry the explicit "ga" token;
+        # an EMPTY list means the channel set is UNKNOWN (no FPI resolved to a recognized channel), NOT
+        # that the build is GA. Computed across all FPIs for the build during the RHSA lookup.
         self.channels: list[str] = channels or []
 
     def as_dict(self) -> dict[str, str | None]:

--- a/src/vunnel/providers/rhel/rhsa_provider.py
+++ b/src/vunnel/providers/rhel/rhsa_provider.py
@@ -15,6 +15,8 @@ class AffectedRelease:
         rhsa_id: str | None = None,
         module: str | None = None,
         package: str | None = None,
+        product_id: str | None = None,
+        channels: list[str] | None = None,
     ) -> None:
         self.name: str | None = name
         self.version: str | None = version
@@ -23,6 +25,14 @@ class AffectedRelease:
         self.module: str | None = module
         self.package: str | None = package  # the raw "package" field from Hydra JSON API
         self.platform_cpe: str | None = None  # the CPE for the platform, if available
+        # The matched CSAF full product id (FPI) that supplied this fix's version. Unlike platform/cpe
+        # it encodes the target RHEL minor stream, so it is what lets us tell same-base per-stream
+        # fixes apart. Populated during the RHSA lookup; may be None for non-CSAF-sourced versions.
+        self.product_id: str | None = product_id
+        # The sorted, deduped set of extended-support channel tokens (e.g. ["aus", "eus"]) that this
+        # exact build is delivered through. Empty means the build is generally available (shipped via a
+        # normal/GA/non-extended channel). Computed across all FPIs for the build during the RHSA lookup.
+        self.channels: list[str] = channels or []
 
     def as_dict(self) -> dict[str, str | None]:
         return {
@@ -33,6 +43,7 @@ class AffectedRelease:
             "module": self.module,
             "package": self.package,
             "platform_cpe": self.platform_cpe,
+            "product_id": self.product_id,
         }
 
 
@@ -76,14 +87,21 @@ class RHSAProvider(ABC):
         self.urls: list[str] = []
 
     @abstractmethod
-    def get_fixed_version_and_module(self, cve_id: str, ar: AffectedRelease, override_package_name: str | None) -> tuple[str | None, str | None]:
+    def get_fixed_version_and_module(
+        self,
+        cve_id: str,
+        ar: AffectedRelease,
+        override_package_name: str | None,
+    ) -> tuple[str | None, str | None, str | None, list[str]]:
         """
-        Retrieve the fixed version and module for a given RHSA ID, platform, and package name.
+        Retrieve the fixed version, module, matched product_id, and channel set for a given RHSA ID, platform, and package name.
 
         :param rhsa_id: The RHSA ID (e.g., "RHSA-2025:1234").
         :param platform: The platform (e.g., "RHEL 8").
         :param package_name: The name of the package (e.g., "httpd").
-        :return: A tuple containing the fixed version and module.
+        :return: A tuple of (fixed version, module, matched product_id, channels). The product_id encodes the
+            target RHEL minor stream and is used to disambiguate same-base per-stream fixes. channels is the
+            sorted set of extended-support channel tokens (empty when the build is generally available).
         """
 
 
@@ -121,17 +139,22 @@ class CSAFRHSAProvider(RHSAProvider):
         )
         self.urls.extend(self.csaf_parser.urls)
 
-    def get_fixed_version_and_module(self, cve_id: str, ar: AffectedRelease, override_package_name: str | None) -> tuple[str | None, str | None]:
+    def get_fixed_version_and_module(
+        self,
+        cve_id: str,
+        ar: AffectedRelease,
+        override_package_name: str | None,
+    ) -> tuple[str | None, str | None, str | None, list[str]]:
         """
-        Retrieve the fixed version and module for a given RHSA ID, platform, and package name.
+        Retrieve the fixed version, module, matched product_id, and channel set for a given RHSA ID, platform, and package name.
 
         :param cve_id: The CVE being parsed, (e.g., "CVE-2021-1234").
         :param ar: an AffectedRelease object
         :param override_package_name: an override package name (e.g., "httpd") to use instead of ar.name
-        :return: A tuple containing the fixed version and module.
+        :return: A tuple of (fixed version, module, matched product_id, channels).
         """
         normalized_package_name = override_package_name or ar.name
 
         if not normalized_package_name:
-            return None, None
+            return None, None, None, []
         return self.csaf_parser.get_fix_info(cve_id, ar.as_dict(), normalized_package_name)

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3509.json
@@ -55,5 +55,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3511.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3526.json
@@ -55,5 +55,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3533.json
@@ -55,5 +55,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3539.json
@@ -55,5 +55,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:5/cve-2017-3544.json
@@ -55,5 +55,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3509.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3511.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3526.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3533.json
@@ -65,5 +65,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3539.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2017-3544.json
@@ -65,5 +65,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2019-25059.json
@@ -36,5 +36,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16587.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2020-16588.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20298.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2021-20299.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1921.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1922.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1923.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1924.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2022-1925.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-4863.json
@@ -35,5 +35,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5129.json
@@ -35,5 +35,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:6/cve-2023-5217.json
@@ -35,5 +35,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3509.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3509.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3511.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3511.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3526.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3526.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3533.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3533.json
@@ -65,5 +65,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3539.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3539.json
@@ -65,5 +65,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3544.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2017-3544.json
@@ -65,5 +65,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2019-25059.json
@@ -36,5 +36,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16587.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2020-16588.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20298.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2021-20299.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1921.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1922.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1923.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1924.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2022-1925.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-4863.json
@@ -76,5 +76,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5129.json
@@ -76,5 +76,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:7/cve-2023-5217.json
@@ -76,5 +76,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-4863.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5129.json
@@ -85,5 +85,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8.6+eus/cve-2023-5217.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2019-25059.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16587.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16587.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16588.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2020-16588.json
@@ -36,5 +36,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20298.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20298.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20299.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2021-20299.json
@@ -35,5 +35,5 @@
       "Severity": "Low"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1921.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1922.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1923.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1924.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-1925.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-2309.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2022-2309.json
@@ -58,5 +58,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-4863.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5129.json
@@ -85,5 +85,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:8/cve-2023-5217.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-4863.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5129.json
@@ -85,5 +85,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9.0+eus/cve-2023-5217.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2019-25059.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2019-25059.json
@@ -35,5 +35,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1921.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1921.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1922.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1922.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1923.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1923.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1924.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1924.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1925.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-1925.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-2309.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2022-2309.json
@@ -45,5 +45,5 @@
       "Severity": "Medium"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-4863.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-4863.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5129.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5129.json
@@ -85,5 +85,5 @@
       "Severity": "Unknown"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5217.json
+++ b/tests/unit/providers/rhel/test-fixtures/snapshots/rhel:9/cve-2023-5217.json
@@ -85,5 +85,5 @@
       "Severity": "High"
     }
   },
-  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.0.json"
+  "schema": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-1.1.2.json"
 }

--- a/tests/unit/providers/rhel/test_csaf_parser.py
+++ b/tests/unit/providers/rhel/test_csaf_parser.py
@@ -180,3 +180,63 @@ def test_is_rpm_module_purl(purl: str, expected: bool):
 )
 def test_resolve_module_name_from_purl(purl: PackageURL, expected: str):
     assert resolve_module_name_from_purl(PackageURL.from_string(purl)) == expected
+
+
+class TestChannelsFromFpis:
+    # One backported build is frequently delivered via several channels at once. The published
+    # fixtures happen to ship each build via a single channel, so stub the FPI -> (platform, module,
+    # name, version) resolution and exercise the channel-union logic in channels_from_fpis directly.
+    VERSION = "32:9.11.13-6.el8_4.3"
+    OTHER_VERSION = "32:9.11.13-8.el8_6.1"
+    PLATFORM_CPE = "cpe:/a:redhat:enterprise_linux:8::appstream"
+
+    def _stub_resolution(self, csaf_parser):
+        def resolve(doc, fpi):
+            version = self.OTHER_VERSION if "el8_6" in fpi else self.VERSION
+            return self.PLATFORM_CPE, None, "bind", version
+
+        csaf_parser.platform_module_name_version_from_fpi = resolve
+
+    def test_unions_channels_across_fpis_shipping_the_same_build(self, csaf_parser):
+        self._stub_resolution(csaf_parser)
+        fpis = [
+            # the same exact build delivered via EUS, AUS, and a GA (z-stream MAIN) channel
+            "AppStream-8.4.0.Z.EUS:bind-32:9.11.13-6.el8_4.3.x86_64",
+            "AppStream-8.4.0.Z.AUS:bind-32:9.11.13-6.el8_4.3.x86_64",
+            "AppStream-8.4.0.Z.MAIN:bind-32:9.11.13-6.el8_4.3.x86_64",
+            # a DIFFERENT build (other version): its TUS channel must NOT be unioned in
+            "AppStream-8.6.0.Z.TUS:bind-32:9.11.13-8.el8_6.1.x86_64",
+            # same build but an unrecognized marker (ENS): contributes nothing
+            "AppStream-8.4.0.Z.ENS:bind-32:9.11.13-6.el8_4.3.x86_64",
+        ]
+        channels = csaf_parser.channels_from_fpis(
+            Mock(), fpis, "bind", "cpe:/a:redhat:enterprise_linux:8", self.VERSION, None,
+        )
+        assert channels == ["aus", "eus", "ga"]
+
+    def test_extended_only_build_yields_multiple_extended_channels(self, csaf_parser):
+        self._stub_resolution(csaf_parser)
+        fpis = [
+            "AppStream-8.4.0.Z.AUS:bind-32:9.11.13-6.el8_4.3.x86_64",
+            "AppStream-8.4.0.Z.EUS:bind-32:9.11.13-6.el8_4.3.x86_64",
+        ]
+        channels = csaf_parser.channels_from_fpis(
+            Mock(), fpis, "bind", "cpe:/a:redhat:enterprise_linux:8", self.VERSION, None,
+        )
+        assert channels == ["aus", "eus"]
+
+    def test_all_unrecognized_channels_yield_empty_unknown_set(self, csaf_parser):
+        self._stub_resolution(csaf_parser)
+        fpis = ["AppStream-8.4.0.Z.ENS:bind-32:9.11.13-6.el8_4.3.x86_64"]
+        channels = csaf_parser.channels_from_fpis(
+            Mock(), fpis, "bind", "cpe:/a:redhat:enterprise_linux:8", self.VERSION, None,
+        )
+        # empty means UNKNOWN, not generally available
+        assert channels == []
+
+    def test_no_version_yields_empty(self, csaf_parser):
+        self._stub_resolution(csaf_parser)
+        fpis = ["AppStream-8.4.0.Z.EUS:bind-32:9.11.13-6.el8_4.3.x86_64"]
+        assert csaf_parser.channels_from_fpis(
+            Mock(), fpis, "bind", "cpe:/a:redhat:enterprise_linux:8", None, None,
+        ) == []

--- a/tests/unit/providers/rhel/test_csaf_parser.py
+++ b/tests/unit/providers/rhel/test_csaf_parser.py
@@ -93,7 +93,7 @@ def test_best_version_module_from_fpis_package_name(csaf_parser, fixture_dir):
         "AppStream-8.8.0.Z.MAIN.EUS:rubygem-irb-1.2.6-139.module+el8.8.0+18745+f1bef313.noarch.rpm-ruby:2.7",
     ]
     doc = from_path(fixture_dir / "csaf/advisories/rhsa-2023_3821.json")
-    actual_version, actual_module = csaf_parser.best_version_module_from_fpis(
+    actual_version, actual_module, actual_product_id = csaf_parser.best_version_module_from_fpis(
         doc,
         "RHSA-2023:3821",
         fpis,
@@ -101,6 +101,8 @@ def test_best_version_module_from_fpis_package_name(csaf_parser, fixture_dir):
         "cpe:/a:redhat:enterprise_linux:8")
     assert actual_version == "0:2.7.8-139.module+el8.8.0+18745+f1bef313"
     assert actual_module == "ruby:2.7"
+    # the matched FPI is returned so the caller can recover the target minor from it
+    assert actual_product_id == "AppStream-8.8.0.Z.MAIN.EUS:ruby-2.7.8-139.module+el8.8.0+18745+f1bef313.src.rpm-ruby:2.7"
 
 def test_best_version_module_from_fpis_multi_platform(csaf_parser, fixture_dir, multi_platform_csaf_doc):
     fpis = [
@@ -114,11 +116,12 @@ def test_best_version_module_from_fpis_multi_platform(csaf_parser, fixture_dir, 
     ]
     platform_cpe = "cpe:/a:redhat:enterprise_linux:9"
     fix_id = "RHSA-2024:0811"
-    actual_version, actual_module = csaf_parser.best_version_module_from_fpis(
+    actual_version, actual_module, actual_product_id = csaf_parser.best_version_module_from_fpis(
         multi_platform_csaf_doc, fix_id, fpis, "sudo", platform_cpe,
     )
     assert actual_module is None
     assert actual_version == "0:1.9.5p2-10.el9_3"
+    assert actual_product_id == "AppStream-9.3.0.Z.MAIN:sudo-0:1.9.5p2-10.el9_3.src"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/providers/rhel/test_multi_rhsa.py
+++ b/tests/unit/providers/rhel/test_multi_rhsa.py
@@ -161,3 +161,30 @@ class TestCVE2024_8088:
         ids = [s["ID"] for s in summaries]
         # both RHSAs that touched this package are surfaced, newest fix first
         assert ids == ["RHSA-2024:9371", "RHSA-2024:6163"]
+
+    def test_emits_stream_aware_advisories_with_parsed_minors(self, hydra_cve, fixture_dir, tmpdir, auto_fake_fixdate_finder):
+        ws = workspace.Workspace(tmpdir, "test", create=True)
+        driver = Parser(workspace=ws, skip_namespaces=[])
+        driver.rhsa_provider = _wire_csaf_rhsa_provider(ws, fixture_dir)
+
+        record = self._python39_fixed_in(driver._parse_cve("CVE-2024-8088", hydra_cve))
+
+        # The stream-aware Advisories table carries BOTH fix builds (including the one that became the
+        # top-level Version), newest first, each with the target RHEL minor + the extended-support
+        # channels delivering it, recovered from its CSAF product_ids:
+        #   RHSA-2024:9371 -> AppStream-9.5.0.GA:...3.9.19-8.el9        -> minor 5, generally available (["ga"])
+        #   RHSA-2024:6163 -> AppStream-9.4.0.Z.MAIN.EUS:...3.9.18-3.el9_4.5 -> minor 4, channels ["eus"]
+        assert record["Advisories"] == [
+            {
+                "Advisory": "RHSA-2024:9371",
+                "Version": "0:3.9.19-8.el9",
+                "Minor": 5,
+                "Channels": ["ga"],
+            },
+            {
+                "Advisory": "RHSA-2024:6163",
+                "Version": "0:3.9.18-3.el9_4.5",
+                "Minor": 4,
+                "Channels": ["eus"],
+            },
+        ]

--- a/tests/unit/providers/rhel/test_product_id.py
+++ b/tests/unit/providers/rhel/test_product_id.py
@@ -1,0 +1,182 @@
+import pytest
+
+from vunnel.providers.rhel.product_id import ProductIdInfo, minor_from_dist_tag, parse_product_id
+
+
+class TestParseProductId:
+    @pytest.mark.parametrize(
+        ("product_id", "expected"),
+        [
+            # ------------------------------------------------------------------
+            # OLD format: {Repo}-{major}.{minor}[.{Z}][.{markers}]:{nevra}
+            # ------------------------------------------------------------------
+            # GA build (task example) -> generally available, explicit "ga" channel
+            (
+                "AppStream-9.5.0.GA:webkit2gtk3-0:2.44.3-2.el9.x86_64",
+                ProductIdInfo(minor=5, channel="ga"),
+            ),
+            # GA build, BaseOS repo
+            (
+                "BaseOS-8.10.0.GA:glibc-0:2.28-251.el8.x86_64",
+                ProductIdInfo(minor=10, channel="ga"),
+            ),
+            # z-stream (.elN_M) build, EUS channel
+            (
+                "AppStream-8.2.0.Z.EUS:bind-32:9.11.13-6.el8_2.3.x86_64",
+                ProductIdInfo(minor=2, channel="eus"),
+            ),
+            # z-stream, MAIN.EUS marker chain (BaseOS) -> eus
+            (
+                "BaseOS-9.4.0.Z.MAIN.EUS:glibc-0:2.34-100.el9_4.x86_64",
+                ProductIdInfo(minor=4, channel="eus"),
+            ),
+            # z-stream MAIN only (no extended-support marker -> generally available "ga")
+            (
+                "AppStream-8.9.0.Z.MAIN:webkit2gtk3-0:2.40.5-1.el8_9.1.x86_64",
+                ProductIdInfo(minor=9, channel="ga"),
+            ),
+            # z-stream ENS marker is UNRECOGNIZED (neither general nor extended) -> channel None (unknown)
+            (
+                "AppStream-8.8.0.Z.ENS:foo-0:1-1.el8_8.x86_64",
+                ProductIdInfo(minor=8, channel=None),
+            ),
+            # AUS channel
+            (
+                "AppStream-8.4.0.Z.AUS:httpd-0:2.4.37-21.el8_4.aarch64",
+                ProductIdInfo(minor=4, channel="aus"),
+            ),
+            # TUS channel
+            (
+                "AppStream-8.6.0.Z.TUS:kernel-0:4.18.0-372.el8_6.x86_64",
+                ProductIdInfo(minor=6, channel="tus"),
+            ),
+            # E4S channel
+            (
+                "AppStream-9.2.0.Z.E4S:sudo-0:1.9.5p2-9.el9_2.2.x86_64",
+                ProductIdInfo(minor=2, channel="e4s"),
+            ),
+            # two-number short form, GA -> "ga"
+            (
+                "AppStream-8.6.GA:foo-0:1.0-1.el8.x86_64",
+                ProductIdInfo(minor=6, channel="ga"),
+            ),
+            # two-number short form, Z only (general -> "ga")
+            (
+                "AppStream-9.5.Z:foo-0:1.0-1.el9_5.x86_64",
+                ProductIdInfo(minor=5, channel="ga"),
+            ),
+            # modular build (+elN.M dist tag) with EUS prefix marker; minor comes from prefix, not the +el tag
+            (
+                "AppStream-8.1.0.Z.EUS:libecap-0:1.0.1-2.module+el8.1.0+4044+36416a77.x86_64::squid:4",
+                ProductIdInfo(minor=1, channel="eus"),
+            ),
+            # modular GA build
+            (
+                "AppStream-9.4.0.GA:ruby-0:3.1.4-1.module+el9.4.0+1234+abcd.x86_64::ruby:3.1",
+                ProductIdInfo(minor=4, channel="ga"),
+            ),
+            # repo label containing a hyphen (e.g. "AppStream-NFV") still parses major.minor + channel
+            (
+                "AppStream-NFV-9.3.0.Z.EUS:foo-0:1-1.el9_3.x86_64",
+                ProductIdInfo(minor=3, channel="eus"),
+            ),
+            # ------------------------------------------------------------------
+            # NEW format: rhel-{major}.{minor}[-marker]::repo:{nevra}
+            # ------------------------------------------------------------------
+            # GA build (task example) -> generally available "ga"
+            (
+                "rhel-9.5::appstream:webkit2gtk3-0:2.44.3-2.el9",
+                ProductIdInfo(minor=5, channel="ga"),
+            ),
+            # z-stream-ish new-format build (no marker -> generally available "ga")
+            (
+                "rhel-9.4::baseos:glibc-0:2.34-100.el9_4",
+                ProductIdInfo(minor=4, channel="ga"),
+            ),
+            # new format with -eus marker (normalized to lowercase token)
+            (
+                "rhel-8.6-eus::appstream:httpd-0:2.4.37-21.el8_6",
+                ProductIdInfo(minor=6, channel="eus"),
+            ),
+            # new format with -e4s marker (case-insensitive, normalized to lowercase)
+            (
+                "rhel-9.2-e4s::appstream:sudo-0:1.9.5p2-9.el9_2.2",
+                ProductIdInfo(minor=2, channel="e4s"),
+            ),
+            # new format modular build -> "ga"
+            (
+                "rhel-9.4::appstream:ruby-0:3.1.4-1.module+el9.4.0+1234+abcd::ruby:3.1",
+                ProductIdInfo(minor=4, channel="ga"),
+            ),
+            # ------------------------------------------------------------------
+            # ELS: extended *lifecycle* support, major-only (no minor) but a real channel
+            # ------------------------------------------------------------------
+            (
+                "7Server-ELS:webkitgtk4-0:2.48.3-2.el7_9.x86_64",
+                ProductIdInfo(minor=None, channel="els"),
+            ),
+            ("NServer-ELS:foo-0:1-1.el7.x86_64", ProductIdInfo(minor=None, channel="els")),
+            # ------------------------------------------------------------------
+            # Unrecognized input -> channel None (UNKNOWN, not assumed GA); minor None when
+            # it cannot be recovered either. Do not guess.
+            # ------------------------------------------------------------------
+            # garbage / empty / None
+            ("", ProductIdInfo(minor=None, channel=None)),
+            (None, ProductIdInfo(minor=None, channel=None)),
+            ("not-a-product-id", ProductIdInfo(minor=None, channel=None)),
+            ("Red Hat OpenShift Container Platform 4.12", ProductIdInfo(minor=None, channel=None)),
+        ],
+    )
+    def test_parse_product_id(self, product_id, expected):
+        assert parse_product_id(product_id) == expected
+
+    def test_returns_namedtuple_fields(self):
+        info = parse_product_id("AppStream-9.5.0.GA:webkit2gtk3-0:2.44.3-2.el9.x86_64")
+        assert info.minor == 5
+        assert info.channel == "ga"
+
+    def test_unrecognized_marker_is_unknown_not_ga(self):
+        # an unexpected marker (ENS) is neither general nor extended -> channel None (unknown)
+        info = parse_product_id("AppStream-8.8.0.Z.ENS:foo-0:1-1.el8_8.x86_64")
+        assert info.minor == 8
+        assert info.channel is None
+
+    def test_channel_token_is_lowercase(self):
+        info = parse_product_id("AppStream-8.2.0.Z.EUS:bind-32:9.11.13-6.el8_2.3.x86_64")
+        assert info.channel == "eus"
+
+    def test_old_and_new_format_agree_on_minor(self):
+        old = parse_product_id("AppStream-9.5.0.GA:webkit2gtk3-0:2.44.3-2.el9.x86_64")
+        new = parse_product_id("rhel-9.5::appstream:webkit2gtk3-0:2.44.3-2.el9")
+        assert old.minor == new.minor == 5
+
+
+class TestMinorFromDistTag:
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            # Z-stream / EUS dist tag ".elN_M" -> M (the glibc CVE-2023-4813 case)
+            ("0:2.34-60.el9_2.7", 2),
+            ("0:2.34-100.el9_4", 4),
+            ("32:9.11.13-6.el8_2.3", 2),
+            ("4.18.0-372.el8_6", 6),
+            # release without epoch still parses
+            ("2.34-60.el9_2.7", 2),
+            # modular "+elN.M" dist tag -> M
+            ("0:1.0.1-2.module+el8.1.0+4044+36416a77", 1),
+            ("0:3.1.4-1.module+el9.4.0+1234+abcd", 4),
+            # bare GA tag ".elN" (no minor) -> None; only the FPI can supply a GA build's minor
+            ("0:2.34-100.el9", None),
+            ("0:2.44.3-2.el9", None),
+            ("1:2.27-34.base.el7", None),
+            # GA respin suffix ".elN.M" (a DOT after a plain ".el") is a rebuild counter, NOT a minor
+            ("7.2-3.el7.1", None),
+            ("2:0.12.1.2-2.209.el6.1", None),
+            # no recognizable dist tag / empty / None -> None
+            ("0:1.2.3-4", None),
+            ("", None),
+            (None, None),
+        ],
+    )
+    def test_minor_from_dist_tag(self, version, expected):
+        assert minor_from_dist_tag(version) == expected

--- a/tests/unit/providers/rhel/test_product_id.py
+++ b/tests/unit/providers/rhel/test_product_id.py
@@ -25,6 +25,11 @@ class TestParseProductId:
                 "AppStream-8.2.0.Z.EUS:bind-32:9.11.13-6.el8_2.3.x86_64",
                 ProductIdInfo(minor=2, channel="eus"),
             ),
+            # MULTI-DIGIT minor (RHEL 8.10) in an old-format z-stream prefix -> minor 10
+            (
+                "BaseOS-8.10.0.Z.MAIN:glibc-0:2.28-251.el8_10.5.x86_64",
+                ProductIdInfo(minor=10, channel="ga"),
+            ),
             # z-stream, MAIN.EUS marker chain (BaseOS) -> eus
             (
                 "BaseOS-9.4.0.Z.MAIN.EUS:glibc-0:2.34-100.el9_4.x86_64",
@@ -93,6 +98,11 @@ class TestParseProductId:
                 "rhel-9.4::baseos:glibc-0:2.34-100.el9_4",
                 ProductIdInfo(minor=4, channel="ga"),
             ),
+            # MULTI-DIGIT minor (RHEL 8.10) in the new format -> minor 10
+            (
+                "rhel-8.10::baseos:glibc-0:2.28-251.el8_10",
+                ProductIdInfo(minor=10, channel="ga"),
+            ),
             # new format with -eus marker (normalized to lowercase token)
             (
                 "rhel-8.6-eus::appstream:httpd-0:2.4.37-21.el8_6",
@@ -113,6 +123,12 @@ class TestParseProductId:
             # ------------------------------------------------------------------
             (
                 "7Server-ELS:webkitgtk4-0:2.48.3-2.el7_9.x86_64",
+                ProductIdInfo(minor=None, channel="els"),
+            ),
+            # RHEL 6 ELS with an .EXTENSION repo segment after the ELS marker (real bind example
+            # from RHSA-2025:23414) -> still minor None, channel "els"
+            (
+                "6Server-ELS.EXTENSION:bind-32:9.8.2-0.68.rc1.el6_10.17.x86_64",
                 ProductIdInfo(minor=None, channel="els"),
             ),
             ("NServer-ELS:foo-0:1-1.el7.x86_64", ProductIdInfo(minor=None, channel="els")),
@@ -160,6 +176,9 @@ class TestMinorFromDistTag:
             ("0:2.34-100.el9_4", 4),
             ("32:9.11.13-6.el8_2.3", 2),
             ("4.18.0-372.el8_6", 6),
+            # MULTI-DIGIT minor in the dist tag ".el8_10" (RHEL 8.10) -> 10
+            ("0:2.28-251.el8_10.5", 10),
+            ("2.28-251.el8_10", 10),
             # release without epoch still parses
             ("2.34-60.el9_2.7", 2),
             # modular "+elN.M" dist tag -> M

--- a/tests/unit/providers/rhel/test_rhel.py
+++ b/tests/unit/providers/rhel/test_rhel.py
@@ -7,7 +7,7 @@ import pytest
 
 from vunnel import result, workspace
 from vunnel.providers.rhel import Config, Provider
-from vunnel.providers.rhel.parser import Advisory, AffectedRelease, FixedIn, Parser
+from vunnel.providers.rhel.parser import Advisory, AffectedRelease, FixedIn, Parser, StreamAdvisory
 from vunnel.providers.rhel.rhsa_provider import RHSAProvider
 
 
@@ -30,10 +30,14 @@ class FakeRHSAProvider(RHSAProvider):
         package_name = override_package_name or ar.name
         if p:
             return next(
-                ((item["Version"], item.get("Module")) for item in p["Vulnerability"]["FixedIn"] if item["Name"] == package_name),
-                (None, None),
+                (
+                    (item["Version"], item.get("Module"), item.get("ProductID"), item.get("Channels", []))
+                    for item in p["Vulnerability"]["FixedIn"]
+                    if item["Name"] == package_name
+                ),
+                (None, None, None, []),
             )
-        return None, None
+        return None, None, None, []
 
 
 class TestParser:
@@ -634,6 +638,23 @@ class TestParser:
                         platform="7",
                         version="7.2-3.el7.1",
                         advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        # same-base multi-stream (el7 vs el7.1): the stream-aware advisories table carries
+                        # both builds. minor is None here because these package-only inputs have no CSAF
+                        # product_id to recover the target minor from.
+                        advisories=(
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="7.2-3.el7.1",
+                                minor=None,
+                                channels=[],
+                            ),
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="7.2-3.el7",
+                                minor=None,
+                                channels=[],
+                            ),
+                        ),
                     )
                 ],
             ),
@@ -671,6 +692,30 @@ class TestParser:
                             "|| >= 1:11.19.1, < 1:11.19.1-2.module+el8.1.0+6118+5aaa808b "
                             "|| >= 1:12.16.1, < 1:12.16.1-2.module+el8.1.0+6117+b25a342c"
                         ),
+                        # three distinct streams -> the stream-aware advisories table carries all three
+                        # builds (newest first), independent of the VulnerableRange representation.
+                        advisories=(
+                            # no FPI on these CVE-path records, but the modular "+el8.1.0" dist tag
+                            # supplies the minor (1) via the dist-tag fallback.
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="1:12.16.1-2.module+el8.1.0+6117+b25a342c",
+                                minor=1,
+                                channels=[],
+                            ),
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="1:11.19.1-2.module+el8.1.0+6118+5aaa808b",
+                                minor=1,
+                                channels=[],
+                            ),
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="1:10.19.0-2.module+el8.1.0+6118+5aaa808b",
+                                minor=1,
+                                channels=[],
+                            ),
+                        ),
                     )
                 ],
             ),
@@ -696,11 +741,72 @@ class TestParser:
                         platform="6",
                         version="2:0.12.1.2-2.209.el6_2.1",
                         advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        # same-base multi-stream (el6_1.9 vs el6_2.1) -> both carried in advisories.
+                        # No FPI on these CVE-path records, but the ".el6_M" dist tags supply the
+                        # minors (2 and 1) via the dist-tag fallback.
+                        advisories=(
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="2:0.12.1.2-2.209.el6_2.1",
+                                minor=2,
+                                channels=[],
+                            ),
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="2:0.12.1.2-2.160.el6_1.9",
+                                minor=1,
+                                channels=[],
+                            ),
+                        ),
+                    )
+                ],
+            ),
+            (
+                # glibc CVE-2023-4813 shape: two distinct fix builds on the SAME upstream base (2.34),
+                # resolved off the CVE/Hydra path so they carry NO FPI/product_id. The minor must still
+                # be recovered from each build's own ".elN_M" dist tag (the dist-tag fallback):
+                #   0:2.34-60.el9_2.7 -> minor 2 (Z-stream), 0:2.34-100.el9 -> GA, minor stays None.
+                {
+                    "affected_release": [
+                        {
+                            "product_name": "Red Hat Enterprise Linux 9",
+                            "package": "glibc-0:2.34-60.el9_2.7",
+                        },
+                        {
+                            "product_name": "Red Hat Enterprise Linux 9",
+                            "package": "glibc-0:2.34-100.el9",
+                        },
+                    ],
+                    "name": "CVE-2023-4813",
+                },
+                [
+                    FixedIn(
+                        module=None,
+                        package="glibc",
+                        platform="9",
+                        version="0:2.34-100.el9",
+                        advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                        advisories=(
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="0:2.34-100.el9",
+                                # bare GA ".el9" tag carries no minor; only the FPI could supply one.
+                                minor=None,
+                                channels=[],
+                            ),
+                            StreamAdvisory(
+                                advisory=Advisory(wont_fix=False, rhsa_id=None, link=None, severity=None),
+                                version="0:2.34-60.el9_2.7",
+                                # ".el9_2" Z-stream tag -> minor 2 via the dist-tag fallback.
+                                minor=2,
+                                channels=[],
+                            ),
+                        ),
                     )
                 ],
             ),
         ],
-        ids=["case1" , "case2", "case3", "case4", "case5", "case6", "case7"],
+        ids=["case1" , "case2", "case3", "case4", "case5", "case6", "case7", "case8"],
     )
     def test_parse_affected_releases(self, tmpdir, affected_releases, fixed_ins, mock_rhsa_dict_2):
         driver = Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
@@ -793,8 +899,8 @@ class TestParser:
     @pytest.mark.parametrize(
         "test_id,test_p,test_pkg,expected",
         [
-            ("RHSA-2019:2308", "7", "libguestfs-winsupport", ("0:7.2-3.el7", None)),
-            ("foo", "0", "bar", (None, None)),
+            ("RHSA-2019:2308", "7", "libguestfs-winsupport", ("0:7.2-3.el7", None, None, [])),
+            ("foo", "0", "bar", (None, None, None, [])),
         ],
     )
     def test_fetch_rhsa_fix_version(self, tmpdir, mock_rhsa_dict, test_id, test_p, test_pkg, expected):


### PR DESCRIPTION
Previously when two RHSAs covered the same (CVE ID, RHEL major version, RPM name) tuple, Vunnel would take the RHSA with the higher package version (epoch:version-release "EVR") so that downstream version comparison would occasionally produce a false positive (if someone had applied the RHSA with the lower EVR on the RPM) but could never produce a false negative (because any RPM with EVR greater than or equal to the higher RHSA EVR must have the fix applied.) This approach leads to false positives when the lower EVR RHSA has been applied.

Therefore, when confronted with the situation that multiple RHSAs (or RHBAs or RHEAs) apply to the same (CVE ID, RHEL major version, RPM name) tuple, attempt to guess the support channel (ga, eus, els, etc) and RHEL minor version (e.g. the 2 in RHEL 9.2) from the product IDs in RHEL's CSAF VEX formatted advisories.

Other vendors, such as SUSE, simply namespace every minor version completely, such that SLES 15.2 and SLES 15.3 just have different vulnerability sets. However, Red Hat lets fixes accumulate across minor versions, such that if a fix was applied in RHEL 9.4 a separate 9.5 fix is not expected in the data, so that approach is not available here.

Note that this approach depends on parsing RHEL minor version and support stream information out of the product ID field in CSAF VEX JSON. The spec does not support this parsing, and it will probably break at some point in the future. The product ID handling code does presently pass the current production and beta versions of RHEL CSAF VEX product IDs.