### PR TITLE
feat(providers): configurable plugin override modes for name collisions

### DIFF
--- a/src/vunnel/providers/__init__.py
+++ b/src/vunnel/providers/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import enum
 import logging
+import os
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
 
@@ -72,6 +74,23 @@ _providers: dict[str, type[provider.Provider]] = {
 }
 
 
+class PluginOverrideMode(str, enum.Enum):
+    # fail: a plugin registering a name that already exists as a different class raises (default, historical behavior)
+    FAIL = "fail"
+    # replace: the plugin wins over the built-in of the same name
+    REPLACE = "replace"
+    # ignore: the plugin is dropped when a built-in of the same name already exists (built-in wins)
+    IGNORE = "ignore"
+
+    @classmethod
+    def from_env(cls) -> PluginOverrideMode:
+        raw = os.environ.get("VUNNEL_PLUGIN_OVERRIDE_MODE", "").strip().lower()
+        try:
+            return cls(raw)
+        except ValueError:
+            return cls.FAIL
+
+
 def create(name: str, workspace_path: str, *args: Any, **kwargs: Any) -> provider.Provider:
     return _providers[name](workspace_path, *args, **kwargs)
 
@@ -84,13 +103,26 @@ def versions() -> dict[str, int]:
     return {n: p.version() for (n, p) in _providers.items()}
 
 
-def register(name: str, cls: type[provider.Provider]) -> None:
-    if name in _providers and _providers[name] != cls:
-        raise KeyError(f"provider {name!r} is already registered to another provider class: {_providers[name]!r}")
+def register(name: str, cls: type[provider.Provider], mode: PluginOverrideMode | None = None) -> None:
+    # plugins call register() themselves during load_plugins(), so the override mode is resolved here at call
+    # time from the environment (VUNNEL_PLUGIN_OVERRIDE_MODE) unless an explicit mode is passed. unset/unknown
+    # resolves to FAIL, preserving the historical behavior for any direct caller that doesn't opt in.
+    effective_mode = mode if mode is not None else PluginOverrideMode.from_env()
+    existing = _providers.get(name)
+    if existing is not None and existing != cls:
+        if effective_mode == PluginOverrideMode.REPLACE:
+            logging.warning(f"provider {name!r}: replacing {existing!r} with plugin {cls!r}")
+        elif effective_mode == PluginOverrideMode.IGNORE:
+            logging.warning(f"provider {name!r}: ignoring plugin {cls!r}, keeping existing {existing!r}")
+            return
+        else:
+            raise KeyError(f"provider {name!r} is already registered to another provider class: {existing!r}")
     _providers[name] = cls
 
 
 def load_plugins() -> None:
+    logging.debug(f"plugin override mode: {PluginOverrideMode.from_env().value}")
+
     plugins = entry_points(group="vunnel.plugins.providers")
 
     logging.debug(f"discovered plugins: {len(plugins)}")

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -614,9 +614,7 @@ def test_fetch_listing_document(mock_requests, tmpdir, dummy_provider):
 @patch("vunnel.provider.http.get")
 def test_prep_workspace_from_listing_entry(mock_requests, tmpdir, dummy_provider):
     provider = dummy_provider(populate=False)
-    tarfile_path, listing_url, entry, listing_path = listing_tar_entry(
-        tmpdir=tmpdir, port=8080, dummy_provider_factory=dummy_provider
-    )
+    tarfile_path, listing_url, entry, listing_path = listing_tar_entry(tmpdir=tmpdir, port=8080, dummy_provider_factory=dummy_provider)
 
     with open(tarfile_path, "rb") as f:
         content = f.read()
@@ -648,9 +646,7 @@ def test_prep_workspace_from_listing_entry(mock_requests, tmpdir, dummy_provider
 def test_fetch_or_use_results_archive(mock_requests, tmpdir, dummy_provider):
     port = 8080
 
-    tarfile_path, listing_url, entry, listing_path = listing_tar_entry(
-        tmpdir=tmpdir, port=port, dummy_provider_factory=dummy_provider
-    )
+    tarfile_path, listing_url, entry, listing_path = listing_tar_entry(tmpdir=tmpdir, port=port, dummy_provider_factory=dummy_provider)
     # fetch the tar file
     tarfile_bytes = None
     with open(tarfile_path, "rb") as f:
@@ -701,9 +697,7 @@ def test_fetch_or_use_results_archive(mock_requests, tmpdir, dummy_provider):
 def test_fetch_results_keeps_original_metadata(mock_requests, tmpdir, dummy_provider):
     port = 8080
 
-    tarfile_path, listing_url, entry, listing_path = listing_tar_entry(
-        tmpdir=tmpdir, port=port, dummy_provider_factory=dummy_provider
-    )
+    tarfile_path, listing_url, entry, listing_path = listing_tar_entry(tmpdir=tmpdir, port=port, dummy_provider_factory=dummy_provider)
     # fetch the tar file
     tarfile_bytes = None
     with open(tarfile_path, "rb") as f:
@@ -1186,3 +1180,99 @@ class TestProvidersWithTags:
         language_providers = providers.providers_with_tags(["language"])
         expected = sorted(set(all_names) - set(language_providers))
         assert result == expected
+
+
+class BuiltinCollisionProvider(provider.Provider):
+    def __init__(self):
+        pass
+
+    @classmethod
+    def name(cls) -> str:
+        return "collision-test"
+
+    def update(self, *args, **kwargs):
+        return [], 0
+
+
+class PluginCollisionProvider(provider.Provider):
+    def __init__(self):
+        pass
+
+    @classmethod
+    def name(cls) -> str:
+        return "collision-test"
+
+    def update(self, *args, **kwargs):
+        return [], 0
+
+
+class TestPluginOverrideMode:
+    @pytest.fixture()
+    def registry(self):
+        # snapshot and restore the module-level registry so tests don't leak state
+        from vunnel import providers
+
+        original = dict(providers._providers)
+        yield providers
+        providers._providers.clear()
+        providers._providers.update(original)
+
+    def test_from_env(self, monkeypatch):
+        from vunnel.providers import PluginOverrideMode
+
+        cases = {
+            "fail": PluginOverrideMode.FAIL,
+            "REPLACE": PluginOverrideMode.REPLACE,
+            "Ignore": PluginOverrideMode.IGNORE,
+            "bogus": PluginOverrideMode.FAIL,
+            "": PluginOverrideMode.FAIL,
+        }
+        for value, expected in cases.items():
+            monkeypatch.setenv("VUNNEL_PLUGIN_OVERRIDE_MODE", value)
+            assert PluginOverrideMode.from_env() == expected
+
+        monkeypatch.delenv("VUNNEL_PLUGIN_OVERRIDE_MODE", raising=False)
+        assert PluginOverrideMode.from_env() == PluginOverrideMode.FAIL
+
+    def test_collision_fail_raises(self, registry):
+        from vunnel.providers import PluginOverrideMode
+
+        registry.register("collision-test", BuiltinCollisionProvider)
+        with pytest.raises(KeyError):
+            registry.register("collision-test", PluginCollisionProvider, mode=PluginOverrideMode.FAIL)
+        assert registry.provider_class("collision-test") is BuiltinCollisionProvider
+
+    def test_collision_replace_plugin_wins(self, registry):
+        from vunnel.providers import PluginOverrideMode
+
+        registry.register("collision-test", BuiltinCollisionProvider)
+        registry.register("collision-test", PluginCollisionProvider, mode=PluginOverrideMode.REPLACE)
+        assert registry.provider_class("collision-test") is PluginCollisionProvider
+
+    def test_collision_ignore_builtin_wins(self, registry):
+        from vunnel.providers import PluginOverrideMode
+
+        registry.register("collision-test", BuiltinCollisionProvider)
+        registry.register("collision-test", PluginCollisionProvider, mode=PluginOverrideMode.IGNORE)
+        assert registry.provider_class("collision-test") is BuiltinCollisionProvider
+
+    def test_non_colliding_registers_in_any_mode(self, registry):
+        from vunnel.providers import PluginOverrideMode
+
+        for mode in (PluginOverrideMode.FAIL, PluginOverrideMode.REPLACE, PluginOverrideMode.IGNORE):
+            registry._providers.pop("collision-test", None)
+            registry.register("collision-test", PluginCollisionProvider, mode=mode)
+            assert registry.provider_class("collision-test") is PluginCollisionProvider
+
+    def test_env_var_used_when_no_explicit_mode(self, registry, monkeypatch):
+        # with no explicit mode, register() resolves from VUNNEL_PLUGIN_OVERRIDE_MODE
+        registry.register("collision-test", BuiltinCollisionProvider)
+        monkeypatch.setenv("VUNNEL_PLUGIN_OVERRIDE_MODE", "replace")
+        registry.register("collision-test", PluginCollisionProvider)
+        assert registry.provider_class("collision-test") is PluginCollisionProvider
+
+    def test_env_var_unset_defaults_to_fail(self, registry, monkeypatch):
+        monkeypatch.delenv("VUNNEL_PLUGIN_OVERRIDE_MODE", raising=False)
+        registry.register("collision-test", BuiltinCollisionProvider)
+        with pytest.raises(KeyError):
+            registry.register("collision-test", PluginCollisionProvider)


### PR DESCRIPTION
Add `VUNNEL_PLUGIN_OVERRIDE_MODE` ( with `fail`/`replace`/`ignore`) to control what happens when a provider plugin registers a name that already exists as a different built-in class. Default remains 'fail' (historical behavior). `register()` resolves the mode from the environment at call time since plugins call `register()` themselves during `load_plugins()`.