### PR TITLE
feat(ubuntu): emit `ubuntu:X.YY+esm` channel records for plain Pro (ESM)

### DIFF
--- a/src/vunnel/providers/ubuntu/README.md
+++ b/src/vunnel/providers/ubuntu/README.md
@@ -405,7 +405,13 @@ it via config:
 providers:
   ubuntu:
     downconvert_osv_to_os: true   # default: false
+    downconvert_emit_esm: true    # default: true; only meaningful when downconvert_osv_to_os is on
 ```
+
+`downconvert_emit_esm` controls whether plain Ubuntu Pro (ESM) slices are
+emitted as `ubuntu:X.YY+esm` channel records. Set it `false` for the frozen-v5
+lane, whose build isn't validated against `+esm` channels — plain Pro then maps
+to `None` like the sub-tiers, and only base records are emitted.
 
 When the toggle is on:
 
@@ -422,7 +428,8 @@ When the toggle is on:
 | `upstream[0]` (`CVE-*`) | `Vulnerability.Name` |
 | `severity[type=Ubuntu].score` | `Vulnerability.Severity` (Negligible/Low/Medium/High/Critical, else Unknown) |
 | `Ubuntu:22.04:LTS` ecosystem | `NamespaceName: "ubuntu:22.04"` |
-| `Ubuntu:Pro:*` / FIPS / Realtime / BlueField | **dropped** — v3 never emitted these namespaces |
+| `Ubuntu:Pro:22.04:LTS` (plain ESM) | `NamespaceName: "ubuntu:22.04+esm"` — the `+esm` distro channel (mirrors RHEL EUS's `rhel:X.Y+eus`), carrying the real Pro fix version. Gated by `downconvert_emit_esm`. A plain-Pro slice with no fix emits no `+esm` record (the base wont-fix already discloses it) |
+| `Ubuntu:Pro:FIPS*` / Realtime / BlueField | **dropped** — their builds diverge from base, so their fixes can't resolve a base disclosure |
 | `ranges[].events[].fixed: "x.y.z"` | `FixedIn.Version: "x.y.z"`, `NoAdvisory: false` |
 | no `fixed` + `database_specific.anchore.status == "wont-fix"` | `FixedIn.Version: "None"`, `NoAdvisory: true` |
 | no `fixed`, no wont-fix marker | `FixedIn.Version: "None"`, `NoAdvisory: false` |

--- a/src/vunnel/providers/ubuntu/__init__.py
+++ b/src/vunnel/providers/ubuntu/__init__.py
@@ -28,6 +28,12 @@ class Config:
     # is no provenance for the inference and won't-fix annotations in the OS shape, so
     # downstream consumers lose that signal.
     downconvert_osv_to_os: bool = True
+    # Only meaningful when `downconvert_osv_to_os` is on: also emit `ubuntu:X.YY+esm`
+    # distro-channel records for plain Ubuntu Pro (ESM), carrying the real Pro fix
+    # version (mirrors RHEL EUS's `rhel:X.Y+eus`). Default on. Set False for the
+    # frozen-v5 lane: it needs the OS-shape down-convert but its build isn't validated
+    # against `+esm` channels, so it takes base records only.
+    downconvert_emit_esm: bool = True
 
 
 class Provider(provider.Provider):
@@ -68,6 +74,7 @@ class Provider(provider.Provider):
             download_timeout=self.config.request_timeout,
             logger=self.logger,
             downconvert_osv_to_os=self.config.downconvert_osv_to_os,
+            downconvert_emit_esm=self.config.downconvert_emit_esm,
         )
 
     @classmethod

--- a/src/vunnel/providers/ubuntu/os_downconvert.py
+++ b/src/vunnel/providers/ubuntu/os_downconvert.py
@@ -27,8 +27,11 @@ so their fixes can't resolve a base disclosure). The `include_esm` flag gates th
 The base wont-fix disclosure and the `+esm` fix are a paired split: the base
 `ubuntu:X.YY` record carries the `Version:"None"` wont-fix (synthesized by
 `_yield_base_with_inferences` when only Pro has data), and `ubuntu:X.YY+esm`
-carries the actual fix. Base-fixed CVEs (a fix in a standard pocket) never
-produce a `+esm` record — only Pro ecosystems do.
+carries the actual fix. In practice a base-fixed CVE (fix in a standard pocket)
+carries no `+esm` record: plain-Pro packages are byte-identical to base while
+base is supported, so no separate ESM fixed event exists until standard support
+ends. That's a property of Canonical's data, not something enforced here — any
+plain-Pro slice with a real fixed event yields a `+esm` record regardless.
 
 The `+esm` channel carries fixes only: a plain-Pro slice with no fixed event
 (wont-fix or still-pending on Pro) produces no `+esm` record at all. The base
@@ -252,15 +255,12 @@ def osv_to_os(payload: dict[str, Any], include_esm: bool = True) -> dict[str, An
     }
 
 
-def os_identifier_for(payload: dict[str, Any], include_esm: bool = True) -> str | None:
-    """Build the v3-shape `{namespace}/{cve_name.lower()}` identifier for a downconverted record.
+def os_identifier_for(os_payload: dict[str, Any]) -> str:
+    """Build the v3-shape `{namespace}/{cve_name.lower()}` identifier for an emitted OS payload.
 
-    Derived from `osv_to_os` so it returns an identifier exactly when a record
-    is emitted — withdrawn / no-upstream / dropped-tier / empty-`+esm` payloads
-    all resolve to None in one place, never drifting from the emitted record.
+    Takes the payload `osv_to_os` produced (not the OSV input) so the identifier
+    can't drift from the record it names — there's one construction, shared by
+    the parser's yield path.
     """
-    os_payload = osv_to_os(payload, include_esm=include_esm)
-    if os_payload is None:
-        return None
     vuln = os_payload["Vulnerability"]
     return f"{vuln['NamespaceName']}/{vuln['Name'].lower()}"

--- a/src/vunnel/providers/ubuntu/os_downconvert.py
+++ b/src/vunnel/providers/ubuntu/os_downconvert.py
@@ -17,10 +17,23 @@ The mapping mirrors v3's `map_parsed` behavior on equivalent inputs:
   no fixed event, no wont-fix      → FixedIn.Version="None", VendorAdvisory.NoAdvisory=False
   database_specific.anchore.fixes[0] → FixedIn.Available (Date/Kind)
 
-Pro/FIPS/Realtime/BlueField fragments are skipped entirely — v3 never emitted
-records for those namespaces. Pro-only-fix data still surfaces here because
-`_yield_base_with_inferences` has already merged wont-fix entries into the
-base ecosystem's affected[] list before this code runs.
+Plain Ubuntu Pro (ESM) fragments — `Ubuntu:Pro:X.YY:LTS` — are emitted as a
+distro channel: `ubuntu:X.YY+esm`, mirroring RHEL EUS's `rhel:X.Y+eus`. The
+real plain-Pro fix version flows through verbatim. FIPS / FIPS-updates /
+Realtime / Nvidia-BlueField still map to None (their builds diverge from base,
+so their fixes can't resolve a base disclosure). The `include_esm` flag gates the
+`+esm` emit; when off, plain Pro maps to None like the sub-tiers.
+
+The base wont-fix disclosure and the `+esm` fix are a paired split: the base
+`ubuntu:X.YY` record carries the `Version:"None"` wont-fix (synthesized by
+`_yield_base_with_inferences` when only Pro has data), and `ubuntu:X.YY+esm`
+carries the actual fix. Base-fixed CVEs (a fix in a standard pocket) never
+produce a `+esm` record — only Pro ecosystems do.
+
+The `+esm` channel carries fixes only: a plain-Pro slice with no fixed event
+(wont-fix or still-pending on Pro) produces no `+esm` record at all. The base
+`ubuntu:X.YY` wont-fix is the sole disclosure for those — an unfixed `+esm`
+record would just duplicate it with `Version:"None"`.
 """
 
 from __future__ import annotations
@@ -32,29 +45,40 @@ _UBUNTU_PKG_VERSION_FORMAT = "dpkg"
 _UBUNTU_CVE_URL = "https://ubuntu.com/security/{}"
 
 _BASE_ECO_RE = re.compile(r"^Ubuntu:(\d+\.\d+)(?::LTS)?$")
+# plain Ubuntu Pro (ESM) only: `Ubuntu:Pro:<ver>[:LTS]`, anchored so any extra
+# tier token (FIPS, FIPS-updates, Realtime, ...) or trailing segment fails to match.
+_PLAIN_PRO_ECO_RE = re.compile(r"^Ubuntu:Pro:(\d+\.\d+)(?::LTS)?$")
+
+_ESM_SUFFIX = "+esm"
 
 # v3 severity values, mirroring parser_legacy.Severity.json() output.
 _SEVERITY_NAMES = {"Negligible", "Low", "Medium", "High", "Critical", "Unknown"}
 
 
-def osv_ecosystem_to_os_namespace(ecosystem: str) -> str | None:
-    """Map an OSV ecosystem string to v3's `ubuntu:<version>` namespace.
+def osv_ecosystem_to_os_namespace(ecosystem: str, include_esm: bool = True) -> str | None:
+    """Map an OSV ecosystem string to a v3 `ubuntu:<version>[+esm]` namespace.
 
-    Only base Ubuntu releases qualify. Pro/FIPS/Realtime/BlueField return
-    None and are skipped by downconversion — v3 never emitted records for
-    those namespaces, and Pro-only-fix inference already layers wont-fix
-    entries onto the base ecosystem's affected[] list upstream.
+    Base Ubuntu releases map to `ubuntu:<version>`. Plain Ubuntu Pro (ESM)
+    maps to the `ubuntu:<version>+esm` distro channel (mirroring RHEL EUS's
+    `rhel:X.Y+eus`) when `include_esm` is set. FIPS/FIPS-updates/Realtime/
+    Nvidia-BlueField always return None — their builds diverge from base, so
+    their fixes can't resolve a base disclosure.
 
       Ubuntu:22.04:LTS              -> ubuntu:22.04
       Ubuntu:24.10                  -> ubuntu:24.10
-      Ubuntu:Pro:14.04:LTS          -> None
+      Ubuntu:Pro:14.04:LTS          -> ubuntu:14.04+esm   (None if include_esm=False)
+      Ubuntu:Pro:22.04:LTS          -> ubuntu:22.04+esm
       Ubuntu:Pro:FIPS:22.04:LTS     -> None
       Ubuntu:Nvidia-BlueField:22.04 -> None
     """
     m = _BASE_ECO_RE.match(ecosystem)
-    if m is None:
-        return None
-    return f"ubuntu:{m.group(1)}"
+    if m is not None:
+        return f"ubuntu:{m.group(1)}"
+    if include_esm:
+        pm = _PLAIN_PRO_ECO_RE.match(ecosystem)
+        if pm is not None:
+            return f"ubuntu:{pm.group(1)}+esm"
+    return None
 
 
 def _ubuntu_priority_to_severity(score: str) -> str:
@@ -133,12 +157,19 @@ def _fixed_in_for_affected(aff: dict[str, Any], namespace: str) -> list[dict[str
           -> FixedIn(Version="None", NoAdvisory=True)
       - no fix yet (no fixed events, no wont-fix marker)
           -> FixedIn(Version="None", NoAdvisory=False)
+
+    Exception: on a `+esm` channel a no-fix entry yields nothing. That channel
+    carries only real Pro fixes; the unfixed disclosure already lives on the
+    base `ubuntu:X.YY` record, so a `Version="None"` +esm entry would just
+    duplicate it.
     """
     package_name = (aff.get("package") or {}).get("name")
     if not package_name:
         return []
 
     fixed_versions = _fixed_versions_for_affected(aff)
+    if not fixed_versions and namespace.endswith(_ESM_SUFFIX):
+        return []
     if fixed_versions:
         out = []
         for v in fixed_versions:
@@ -166,7 +197,7 @@ def _fixed_in_for_affected(aff: dict[str, Any], namespace: str) -> list[dict[str
     ]
 
 
-def osv_to_os(payload: dict[str, Any]) -> dict[str, Any] | None:
+def osv_to_os(payload: dict[str, Any], include_esm: bool = True) -> dict[str, Any] | None:
     """Convert an OSV envelope payload into a v3-shape `{"Vulnerability": {...}}` dict.
 
     Returns None when the payload can't be downconverted:
@@ -192,7 +223,7 @@ def osv_to_os(payload: dict[str, Any]) -> dict[str, Any] | None:
     fixed_in: list[dict[str, Any]] = []
     for aff in payload.get("affected", []) or []:
         eco = (aff.get("package") or {}).get("ecosystem", "")
-        ns = osv_ecosystem_to_os_namespace(eco)
+        ns = osv_ecosystem_to_os_namespace(eco, include_esm=include_esm)
         if ns is None:
             continue
         # By the slicing invariant, every affected[] entry in a single envelope
@@ -202,6 +233,10 @@ def osv_to_os(payload: dict[str, Any]) -> dict[str, Any] | None:
         fixed_in.extend(_fixed_in_for_affected(aff, ns))
 
     if namespace is None:
+        return None
+    # a `+esm` channel with no real fix left is pure noise — the base wont-fix
+    # already disclosed it (see _fixed_in_for_affected), so emit no record.
+    if namespace.endswith(_ESM_SUFFIX) and not fixed_in:
         return None
 
     return {
@@ -217,14 +252,15 @@ def osv_to_os(payload: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-def os_identifier_for(payload: dict[str, Any]) -> str | None:
-    """Build the v3-shape `{namespace}/{cve_name.lower()}` identifier for a downconverted record."""
-    upstream = payload.get("upstream") or []
-    if not upstream or not upstream[0]:
+def os_identifier_for(payload: dict[str, Any], include_esm: bool = True) -> str | None:
+    """Build the v3-shape `{namespace}/{cve_name.lower()}` identifier for a downconverted record.
+
+    Derived from `osv_to_os` so it returns an identifier exactly when a record
+    is emitted — withdrawn / no-upstream / dropped-tier / empty-`+esm` payloads
+    all resolve to None in one place, never drifting from the emitted record.
+    """
+    os_payload = osv_to_os(payload, include_esm=include_esm)
+    if os_payload is None:
         return None
-    for aff in payload.get("affected", []) or []:
-        eco = (aff.get("package") or {}).get("ecosystem", "")
-        ns = osv_ecosystem_to_os_namespace(eco)
-        if ns is not None:
-            return f"{ns}/{upstream[0].lower()}"
-    return None
+    vuln = os_payload["Vulnerability"]
+    return f"{vuln['NamespaceName']}/{vuln['Name'].lower()}"

--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -15,7 +15,7 @@ from vunnel.utils import http_wrapper as http
 from vunnel.utils import osv
 
 from . import parser_legacy
-from .os_downconvert import os_identifier_for, osv_to_os
+from .os_downconvert import osv_to_os
 from .usn_fixdate_overlay import USNFixDateOverlay, usn_extra_candidates
 from .vex_overlay import VEXOverlay, distro_label_from_purl, source_package_from_purl
 
@@ -242,13 +242,14 @@ class Parser:
     _fragments_subdir_ = "fragments"
     _normalized_subdir_ = "normalized-cve-data"
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         workspace: Workspace,
         fixdater: fixdate.Finder | None = None,
         download_timeout: int = 125,
         logger: logging.Logger | None = None,
         downconvert_osv_to_os: bool = False,
+        downconvert_emit_esm: bool = True,
     ):
         self.workspace = workspace
         self.fixdater = fixdater if fixdater is not None else fixdate.default_finder(workspace)
@@ -258,6 +259,9 @@ class Parser:
         # are yielded. The legacy normalized-cve-data passthrough already emits OS shape,
         # so when this is enabled every yielded record is OS.
         self.downconvert_osv_to_os = downconvert_osv_to_os
+        # When downconverting, also emit `ubuntu:X.YY+esm` channel records for plain Pro
+        # (ESM). Default on; the frozen-v5 lane sets this off to take base records only.
+        self.downconvert_emit_esm = downconvert_emit_esm
 
         self.archive_path = os.path.join(workspace.input_path, self._archive_filename_)
         self.vex_archive_path = os.path.join(workspace.input_path, self._vex_archive_filename_)
@@ -669,12 +673,12 @@ class Parser:
         """
         os_schema = schema.OSSchema()
         for _osv_identifier, _osv_schema, osv_payload in self._iter_fragments():
-            os_payload = osv_to_os(osv_payload)
+            os_payload = osv_to_os(osv_payload, include_esm=self.downconvert_emit_esm)
             if os_payload is None:
                 continue
-            identifier = os_identifier_for(osv_payload)
-            if identifier is None:
-                continue
+            # identifier is derived from the emitted payload so it can't drift from it.
+            vuln = os_payload["Vulnerability"]
+            identifier = f"{vuln['NamespaceName']}/{vuln['Name'].lower()}"
             yield identifier, os_schema, os_payload
 
     def _load_usn_overlay(self) -> USNFixDateOverlay | None:

--- a/src/vunnel/providers/ubuntu/parser.py
+++ b/src/vunnel/providers/ubuntu/parser.py
@@ -15,7 +15,7 @@ from vunnel.utils import http_wrapper as http
 from vunnel.utils import osv
 
 from . import parser_legacy
-from .os_downconvert import osv_to_os
+from .os_downconvert import os_identifier_for, osv_to_os
 from .usn_fixdate_overlay import USNFixDateOverlay, usn_extra_candidates
 from .vex_overlay import VEXOverlay, distro_label_from_purl, source_package_from_purl
 
@@ -666,9 +666,10 @@ class Parser:
     def _iter_fragments_downconverted(self) -> Iterator[tuple[str, schema.Schema, dict[str, Any]]]:
         """Yield OSV fragment envelopes rewritten into v3 OS-schema records.
 
-        Pro/FIPS/Realtime/BlueField slices and any envelope without an upstream
-        CVE alias are dropped — v3 never emitted them. Pro-only-fix wont-fix
-        data still appears here because `_yield_base_with_inferences` already
+        Plain Pro (ESM) slices become `ubuntu:X.YY+esm` channel records (gated by
+        `downconvert_emit_esm`); FIPS/Realtime/BlueField slices and any envelope
+        without an upstream CVE alias are dropped — v3 never emitted them. Pro-only-fix
+        wont-fix data still appears here because `_yield_base_with_inferences` already
         merged it into the base ecosystem's affected[] list before this runs.
         """
         os_schema = schema.OSSchema()
@@ -676,10 +677,7 @@ class Parser:
             os_payload = osv_to_os(osv_payload, include_esm=self.downconvert_emit_esm)
             if os_payload is None:
                 continue
-            # identifier is derived from the emitted payload so it can't drift from it.
-            vuln = os_payload["Vulnerability"]
-            identifier = f"{vuln['NamespaceName']}/{vuln['Name'].lower()}"
-            yield identifier, os_schema, os_payload
+            yield os_identifier_for(os_payload), os_schema, os_payload
 
     def _load_usn_overlay(self) -> USNFixDateOverlay | None:
         """Build the (eco, src-pkg, fixed-ver) → USN-published-date index.

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -621,6 +621,7 @@ providers:
       skip_newer_archive_check: false
       user_agent: null
   ubuntu:
+    downconvert_emit_esm: true
     downconvert_osv_to_os: true
     request_timeout: 125
     runtime:

--- a/tests/unit/providers/ubuntu/test-fixtures/osv-esm-cases/cve/2014/UBUNTU-CVE-2014-2901.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/osv-esm-cases/cve/2014/UBUNTU-CVE-2014-2901.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "1.7.0",
+  "id": "UBUNTU-CVE-2014-2901",
+  "details": "wolfssl before 3.2.0 does not properly issue certificates for a server's hostname.",
+  "aliases": [],
+  "upstream": [
+    "CVE-2014-2901"
+  ],
+  "related": [],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+    },
+    {
+      "type": "Ubuntu",
+      "score": "medium"
+    }
+  ],
+  "published": "2019-11-21T23:15:00Z",
+  "modified": "2025-08-01T04:49:26Z",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:16.04:LTS",
+        "name": "wolfssl",
+        "purl": "pkg:deb/ubuntu/wolfssl@3.4.8+dfsg-1?arch=source&distro=esm-apps/xenial"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "3.4.8+dfsg-1"
+      ],
+      "ecosystem_specific": {}
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2014-2901"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2014-2901"
+    }
+  ],
+  "withdrawn": "2025-08-01T19:34:27Z"
+}

--- a/tests/unit/providers/ubuntu/test-fixtures/osv-esm-cases/cve/2014/UBUNTU-CVE-2014-9913.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/osv-esm-cases/cve/2014/UBUNTU-CVE-2014-9913.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": "1.7.0",
+  "id": "UBUNTU-CVE-2014-9913",
+  "details": "Buffer overflow in the list_files function in list.c in Info-Zip UnZip 6.0 allows remote attackers to cause a denial of service (crash) via vectors related to the compression method.",
+  "aliases": [],
+  "upstream": [
+    "CVE-2014-9913"
+  ],
+  "related": [
+    "USN-4672-1"
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+    },
+    {
+      "type": "Ubuntu",
+      "score": "negligible"
+    }
+  ],
+  "published": "2017-01-18T17:59:00Z",
+  "modified": "2025-09-08T16:43:17Z",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:14.04:LTS",
+        "name": "unzip",
+        "purl": "pkg:deb/ubuntu/unzip@6.0-9ubuntu1.6?arch=source&distro=trusty/esm"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.0-9ubuntu1.6"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "6.0-9ubuntu1",
+        "6.0-9ubuntu1.1",
+        "6.0-9ubuntu1.2",
+        "6.0-9ubuntu1.3",
+        "6.0-9ubuntu1.4",
+        "6.0-9ubuntu1.5"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "unzip",
+            "binary_version": "6.0-9ubuntu1.6"
+          }
+        ],
+        "availability": "Available with Ubuntu Pro (Infra-only): https://ubuntu.com/pro"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:16.04:LTS",
+        "name": "unzip",
+        "purl": "pkg:deb/ubuntu/unzip@6.0-20ubuntu1.1?arch=source&distro=xenial"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "6.0-20ubuntu1.1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "6.0-17ubuntu1",
+        "6.0-19ubuntu1",
+        "6.0-19ubuntu2",
+        "6.0-20ubuntu1"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "unzip",
+            "binary_version": "6.0-20ubuntu1.1"
+          }
+        ],
+        "availability": "No subscription required"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2014-9913"
+    },
+    {
+      "type": "REPORT",
+      "url": "http://www.openwall.com/lists/oss-security/2014/11/03/5"
+    },
+    {
+      "type": "REPORT",
+      "url": "http://openwall.com/lists/oss-security/2016/12/05/20"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://ubuntu.com/security/notices/USN-4672-1"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2014-9913"
+    }
+  ]
+}

--- a/tests/unit/providers/ubuntu/test-fixtures/osv-esm-cases/cve/2022/UBUNTU-CVE-2022-24823.json
+++ b/tests/unit/providers/ubuntu/test-fixtures/osv-esm-cases/cve/2022/UBUNTU-CVE-2022-24823.json
@@ -1,0 +1,334 @@
+{
+  "schema_version": "1.7.0",
+  "id": "UBUNTU-CVE-2022-24823",
+  "details": "Netty is an open-source, asynchronous event-driven network application framework. The package `io.netty:netty-codec-http` prior to version 4.1.77.Final contains an insufficient fix for CVE-2021-21290. When Netty's multipart decoders are used local information disclosure can occur via the local system temporary directory if temporary storing uploads on the disk is enabled. This only impacts applications running on Java version 6 and lower. Additionally, this vulnerability impacts code running on Unix-like systems, and very old versions of Mac OSX and Windows as they all share the system temporary directory between all users. Version 4.1.77.Final contains a patch for this vulnerability. As a workaround, specify one's own `java.io.tmpdir` when starting the JVM or use DefaultHttpDataFactory.setBaseDir(...) to set the directory to something that is only readable by the current user.",
+  "aliases": [],
+  "upstream": [
+    "CVE-2022-24823"
+  ],
+  "related": [
+    "USN-7284-1"
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    },
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+    },
+    {
+      "type": "Ubuntu",
+      "score": "low"
+    }
+  ],
+  "published": "2022-05-06T12:15:00Z",
+  "modified": "2026-06-08T16:11:47Z",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:14.04:LTS",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:3.2.6.Final-2+deb8u2ubuntu0.1~esm1?arch=source&distro=esm-infra-legacy/trusty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:3.2.6.Final-2",
+        "1:3.2.6.Final-2+deb8u2build0.14.04.1~esm1",
+        "1:3.2.6.Final-2+deb8u2ubuntu0.1~esm1"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:3.2.6.Final-2+deb8u2ubuntu0.1~esm1"
+          }
+        ]
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:16.04:LTS",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:4.0.34-1ubuntu0.1~esm2?arch=source&distro=esm-apps/xenial"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:4.0.34-1ubuntu0.1~esm2"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:3.2.6.Final-2",
+        "1:4.0.32-1",
+        "1:4.0.33-1",
+        "1:4.0.34-1",
+        "1:4.0.34-1ubuntu0.1~esm1"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:4.0.34-1ubuntu0.1~esm2"
+          }
+        ],
+        "availability": "Available with Ubuntu Pro: https://ubuntu.com/pro"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:18.04:LTS",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:4.1.7-4ubuntu0.1+esm3?arch=source&distro=esm-apps/bionic"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:4.1.7-4ubuntu0.1+esm3"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:4.1.7-4",
+        "1:4.1.7-4ubuntu0.1~esm1",
+        "1:4.1.7-4ubuntu0.1",
+        "1:4.1.7-4ubuntu0.1+esm1",
+        "1:4.1.7-4ubuntu0.1+esm2"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:4.1.7-4ubuntu0.1+esm3"
+          }
+        ],
+        "availability": "Available with Ubuntu Pro: https://ubuntu.com/pro"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:20.04:LTS",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:4.1.45-1ubuntu0.1~esm2?arch=source&distro=esm-apps/focal"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:4.1.45-1ubuntu0.1~esm2"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:4.1.33-1",
+        "1:4.1.33-2",
+        "1:4.1.33-3",
+        "1:4.1.45-1",
+        "1:4.1.45-1ubuntu0.1~esm1"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:4.1.45-1ubuntu0.1~esm2"
+          }
+        ],
+        "availability": "Available with Ubuntu Pro: https://ubuntu.com/pro"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:22.04:LTS",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:4.1.48-4+deb11u2ubuntu0.1~esm1?arch=source&distro=esm-apps/jammy"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:4.1.48-4+deb11u2ubuntu0.1~esm1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:4.1.48-4",
+        "1:4.1.48-4+deb11u1build0.22.04.1",
+        "1:4.1.48-4+deb11u2build0.22.04.1"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:4.1.48-4+deb11u2ubuntu0.1~esm1"
+          }
+        ],
+        "availability": "Available with Ubuntu Pro: https://ubuntu.com/pro"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:24.04:LTS",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:4.1.48-9ubuntu0.1~esm1?arch=source&distro=esm-apps/noble"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:4.1.48-9ubuntu0.1~esm1"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:4.1.48-7",
+        "1:4.1.48-8",
+        "1:4.1.48-9"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:4.1.48-9ubuntu0.1~esm1"
+          }
+        ],
+        "availability": "Available with Ubuntu Pro: https://ubuntu.com/pro"
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:25.10",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:4.1.48-10ubuntu0.25.10.2?arch=source&distro=questing"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:4.1.48-10",
+        "1:4.1.48-10ubuntu0.25.10.1",
+        "1:4.1.48-10ubuntu0.25.10.2"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:4.1.48-10ubuntu0.25.10.2"
+          }
+        ]
+      }
+    },
+    {
+      "package": {
+        "ecosystem": "Ubuntu:Pro:26.04:LTS",
+        "name": "netty",
+        "purl": "pkg:deb/ubuntu/netty@1:4.1.48-16ubuntu0.1~esm2?arch=source&distro=esm-apps/resolute"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1:4.1.48-10",
+        "1:4.1.48-11",
+        "1:4.1.48-12",
+        "1:4.1.48-13",
+        "1:4.1.48-14",
+        "1:4.1.48-16",
+        "1:4.1.48-16ubuntu0.1~esm2"
+      ],
+      "ecosystem_specific": {
+        "binaries": [
+          {
+            "binary_name": "libnetty-buffer-java",
+            "binary_version": "1:4.1.48-16ubuntu0.1~esm2"
+          },
+          {
+            "binary_name": "libnetty-common-java",
+            "binary_version": "1:4.1.48-16ubuntu0.1~esm2"
+          },
+          {
+            "binary_name": "libnetty-java",
+            "binary_version": "1:4.1.48-16ubuntu0.1~esm2"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2022-24823"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://github.com/netty/netty/commit/185f8b2756a36aaa4f973f1a2a025e7d981823f1"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://github.com/netty/netty/security/advisories/GHSA-269q-hmxg-m83q"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2022-24823"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://ubuntu.com/security/notices/USN-7284-1"
+    }
+  ]
+}

--- a/tests/unit/providers/ubuntu/test_ubuntu.py
+++ b/tests/unit/providers/ubuntu/test_ubuntu.py
@@ -1697,7 +1697,7 @@ class TestOSDowncoverter:
         assert fi["Version"] == "1.12.0-1~ubuntu16.04.3+esm1"
         assert fi["VersionFormat"] == "dpkg"
         assert fi["VendorAdvisory"] == {"NoAdvisory": False}
-        assert os_identifier_for(rec) == "ubuntu:16.04+esm/cve-2021-3782"
+        assert os_identifier_for(out) == "ubuntu:16.04+esm/cve-2021-3782"
 
     def test_plain_pro_epoch_fix_version_passthrough(self):
         # Real Canonical OSV data (CVE-2025-61985 openssh, focal esm-infra) — Pro-only fix
@@ -1717,7 +1717,7 @@ class TestOSDowncoverter:
         assert out["Vulnerability"]["FixedIn"][0]["Version"] == "1:8.2p1-4ubuntu0.13+esm1"
 
     def test_plain_pro_dropped_when_include_esm_off(self):
-        from vunnel.providers.ubuntu.os_downconvert import os_identifier_for, osv_to_os
+        from vunnel.providers.ubuntu.os_downconvert import osv_to_os
 
         rec = self._osv_record(id="UBUNTU-CVE-2021-3782", upstream=["CVE-2021-3782"])
         rec["affected"] = [
@@ -1727,14 +1727,13 @@ class TestOSDowncoverter:
             },
         ]
         assert osv_to_os(rec, include_esm=False) is None
-        assert os_identifier_for(rec, include_esm=False) is None
 
     def test_plain_pro_no_fix_emits_no_esm_record(self):
         # A plain-Pro slice with only `introduced:0` and no fixed event (real shape from
         # CVE-2016-20013's Pro slices) must NOT produce a `ubuntu:X.YY+esm` record. The
         # `+esm` channel carries fixes only; the unfixed disclosure lives on the base
         # `ubuntu:X.YY` record, so a Version="None" +esm entry would just duplicate it.
-        from vunnel.providers.ubuntu.os_downconvert import os_identifier_for, osv_to_os
+        from vunnel.providers.ubuntu.os_downconvert import osv_to_os
 
         rec = self._osv_record(id="UBUNTU-CVE-2016-20013", upstream=["CVE-2016-20013"])
         rec["affected"] = [
@@ -1744,7 +1743,6 @@ class TestOSDowncoverter:
             },
         ]
         assert osv_to_os(rec) is None
-        assert os_identifier_for(rec) is None
 
     def test_plain_pro_wont_fix_status_emits_no_esm_record(self):
         # Same as above but with an explicit wont-fix marker (what _annotate_wont_fix
@@ -1843,10 +1841,33 @@ class TestOSDowncoverter:
         assert by_name["linux-gcp"]["Version"] == "5.4.0-100.113"
 
     def test_identifier_for_returns_v3_shape(self):
-        from vunnel.providers.ubuntu.os_downconvert import os_identifier_for
+        from vunnel.providers.ubuntu.os_downconvert import os_identifier_for, osv_to_os
 
         rec = self._osv_record()
-        assert os_identifier_for(rec) == "ubuntu:22.04/cve-2024-1"
+        assert os_identifier_for(osv_to_os(rec)) == "ubuntu:22.04/cve-2024-1"
+
+    def test_esm_mixed_fixed_and_no_fix_packages_keeps_only_fixed(self):
+        # within a single `+esm` fragment, a fixed package survives while an unfixed one
+        # is dropped entirely — no Version="None" line leaks onto the channel (the inner
+        # per-entry guard) and the record still emits because a fix remains (the outer guard).
+        from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
+        rec = self._osv_record(id="UBUNTU-CVE-x", upstream=["CVE-2000-1"])
+        rec["affected"] = [
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": "fixed-pkg"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "1.0-1ubuntu0.1+esm1"}]}],
+            },
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": "unfixed-pkg"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+            },
+        ]
+        out = osv_to_os(rec)
+        assert out is not None
+        fixed_in = out["Vulnerability"]["FixedIn"]
+        assert [fi["Name"] for fi in fixed_in] == ["fixed-pkg"]
+        assert fixed_in[0]["Version"] == "1.0-1ubuntu0.1+esm1"
 
 
 class TestOSDowncoverterIntegration:

--- a/tests/unit/providers/ubuntu/test_ubuntu.py
+++ b/tests/unit/providers/ubuntu/test_ubuntu.py
@@ -207,6 +207,18 @@ def _seed_vex_archive(fresh_workspace, fixture_dir):
     )
 
 
+def _seed_esm_cases_archive(fresh_workspace, fixture_dir):
+    # Real Canonical OSV records (netty/unzip/wolfssl) kept in an isolated tree so
+    # they exercise the full parser without perturbing the exact-ordering/snapshot
+    # tests that read the main osv/ fixtures.
+    _build_sample_archive(
+        fixture_dir,
+        source_subdir="osv-esm-cases",
+        archive_prefix="osv",
+        dst_path=os.path.join(fresh_workspace.input_path, "osv-all.tar.xz"),
+    )
+
+
 @pytest.fixture
 def sample_vex_archive(tmp_path, fixture_dir):
     """Build a VEX tar.xz once per test and return its path.
@@ -425,8 +437,7 @@ class TestParserFixDateDeferredToYield:
         with result.SQLiteReader(path) as reader:
             env = next(e for e in reader.each() if "2013-2208" in e.identifier)
         for r in env.item["affected"][0]["ranges"]:
-            assert "anchore" not in r.get("database_specific", {}), \
-                "fragment payload should be raw OSV record, no fix-date patching at write time"
+            assert "anchore" not in r.get("database_specific", {}), "fragment payload should be raw OSV record, no fix-date patching at write time"
 
     def test_yielded_record_has_anchore_when_fixed_event_present(self, fresh_workspace, fixture_dir, fake_fixdate_finder):
         # On yield, patch_fix_date runs and populates database_specific.anchore
@@ -452,9 +463,11 @@ class TestParserFixDateDeferredToYield:
         # Configure the fake finder with a dict keyed by the upstream CVE only. If the
         # parser uses the UBUNTU-CVE id, the lookup falls through and no anchore.fixes
         # gets written; if it uses the upstream, the lookup hits.
-        fake_fixdate_finder(responses={
-            "CVE-2013-2208": [Result(date=datetime.date(2013, 7, 15), kind="first-observed", accurate=True)],
-        })
+        fake_fixdate_finder(
+            responses={
+                "CVE-2013-2208": [Result(date=datetime.date(2013, 7, 15), kind="first-observed", accurate=True)],
+            }
+        )
         _seed_archive(fresh_workspace, fixture_dir)
         p = Parser(workspace=fresh_workspace)
         p._write_fragments()
@@ -577,9 +590,9 @@ class TestParserIteration:
         assert ids == [
             "ubuntu-14.04-lts/ubuntu-cve-2013-2208",
             "ubuntu-14.04-lts/ubuntu-cve-2016-20013",
-            "ubuntu-14.04-lts/ubuntu-cve-2020-36325",   # ← inferred from Pro:14.04/jansson
+            "ubuntu-14.04-lts/ubuntu-cve-2020-36325",  # ← inferred from Pro:14.04/jansson
             "ubuntu-16.04-lts/ubuntu-cve-2016-20013",
-            "ubuntu-16.04-lts/ubuntu-cve-2021-3782",    # ← inferred from Pro:16.04/wayland
+            "ubuntu-16.04-lts/ubuntu-cve-2021-3782",  # ← inferred from Pro:16.04/wayland
             "ubuntu-16.04-lts/ubuntu-cve-2026-1403",
             "ubuntu-18.04-lts/ubuntu-cve-2016-20013",
             "ubuntu-18.04-lts/ubuntu-cve-2021-3782",
@@ -763,9 +776,7 @@ class TestParserLegacyPassthrough:
 
         # No fixdater call should reference CVE-2022-31258 (its only namespace is OSV-covered)
         bionic_filtered_calls = [c for c in calls if c[0] == "CVE-2022-31258"]
-        assert bionic_filtered_calls == [], (
-            f"expected zero fixdater calls for OSV-covered CVE-2022-31258, got {bionic_filtered_calls}"
-        )
+        assert bionic_filtered_calls == [], f"expected zero fixdater calls for OSV-covered CVE-2022-31258, got {bionic_filtered_calls}"
         # And calls for the EOL namespaces DO happen
         assert any(c[0] == "CVE-2012-5124" for c in calls)
         assert any(c[0] == "CVE-2013-6627" for c in calls)
@@ -826,6 +837,7 @@ class TestProviderUpdate:
             p.update(None)
 
         import json
+
         schemas = []
         for f in ws.result_files():
             with open(f) as fh:
@@ -858,6 +870,7 @@ class TestProviderUpdate:
 
         # check mixed-schema output
         import json
+
         schemas = []
         for f in ws.result_files():
             with open(f) as fh:
@@ -899,21 +912,30 @@ class TestVEXHelpers:
     """Pure-function tests for the VEX module."""
 
     def test_distro_label_from_purl(self):
-        assert distro_label_from_purl(
-            "pkg:deb/ubuntu/glibc@2.39-0ubuntu8.7?arch=source&distro=noble",
-        ) == "noble"
+        assert (
+            distro_label_from_purl(
+                "pkg:deb/ubuntu/glibc@2.39-0ubuntu8.7?arch=source&distro=noble",
+            )
+            == "noble"
+        )
         # ESM/Pro channels use compound distro labels
-        assert distro_label_from_purl(
-            "pkg:deb/ubuntu/eglibc@2.19-0ubuntu6.15+esm4?arch=source&distro=esm-infra-legacy/trusty",
-        ) == "esm-infra-legacy/trusty"
+        assert (
+            distro_label_from_purl(
+                "pkg:deb/ubuntu/eglibc@2.19-0ubuntu6.15+esm4?arch=source&distro=esm-infra-legacy/trusty",
+            )
+            == "esm-infra-legacy/trusty"
+        )
         # No distro qualifier → None
         assert distro_label_from_purl("pkg:deb/ubuntu/foo@1.0") is None
         assert distro_label_from_purl("") is None
 
     def test_source_package_from_purl(self):
-        assert source_package_from_purl(
-            "pkg:deb/ubuntu/glibc@2.39-0ubuntu8.7?arch=source&distro=noble",
-        ) == "glibc"
+        assert (
+            source_package_from_purl(
+                "pkg:deb/ubuntu/glibc@2.39-0ubuntu8.7?arch=source&distro=noble",
+            )
+            == "glibc"
+        )
         assert source_package_from_purl("not-a-purl") is None
         assert source_package_from_purl("") is None
 
@@ -925,20 +947,22 @@ class TestVEXHelpers:
         )
         assert is_wont_fix_action(decided) is True
 
-        no_longer_supported = (
-            "This package (for the given release) is no longer supported. "
-            "CVE Notes: ..."
-        )
+        no_longer_supported = "This package (for the given release) is no longer supported. CVE Notes: ..."
         assert is_wont_fix_action(no_longer_supported) is True
 
     def test_is_wont_fix_action_rejects_needs_fixing(self):
-        assert is_wont_fix_action(
-            "This package (for the given release) is vulnerable to the CVE and needs fixing.",
-        ) is False
-        assert is_wont_fix_action(
-            "This package (for the given release) is vulnerable to the CVE, "
-            "needs fixing, and it is being actively worked on.",
-        ) is False
+        assert (
+            is_wont_fix_action(
+                "This package (for the given release) is vulnerable to the CVE and needs fixing.",
+            )
+            is False
+        )
+        assert (
+            is_wont_fix_action(
+                "This package (for the given release) is vulnerable to the CVE, needs fixing, and it is being actively worked on.",
+            )
+            is False
+        )
         assert is_wont_fix_action(None) is False
         assert is_wont_fix_action("") is False
         assert is_wont_fix_action("some random text") is False
@@ -1161,9 +1185,13 @@ class TestSyntheticBaseAffectedBuilder:
         pkg = {"ecosystem": "Ubuntu:Pro:20.04:LTS", "name": name}
         if purl:
             pkg["purl"] = "pkg:deb/ubuntu/glibc@2.31?arch=source&distro=esm-infra/focal"
-        return {"package": pkg, "ecosystem_specific": eco_spec, "ranges": [
-            {"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "2.31+esm1"}]},
-        ]}
+        return {
+            "package": pkg,
+            "ecosystem_specific": eco_spec,
+            "ranges": [
+                {"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "2.31+esm1"}]},
+            ],
+        }
 
     def test_rebases_ecosystem(self):
         out = _build_synthetic_base_affected(self._template(), "Ubuntu:20.04:LTS")
@@ -1288,10 +1316,7 @@ class TestProOnlyInferenceIntegration:
                     continue
                 for src in inf.get("source_ecosystems", []):
                     for marker in forbidden_sources:
-                        assert marker not in src, (
-                            f"inference fired off a sub-tier source ({src}); "
-                            "pro_to_base_ecosystem should have excluded this"
-                        )
+                        assert marker not in src, f"inference fired off a sub-tier source ({src}); pro_to_base_ecosystem should have excluded this"
 
     def test_inference_survives_frozen_base_fragment(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
         # Headline post-EOL scenario: imagine base 14.04 dropped from OSV but Pro:14.04
@@ -1352,6 +1377,7 @@ class TestUSNFixDateOverlay:
 
     def test_empty_overlay_lookups_return_none(self):
         from vunnel.providers.ubuntu.usn_fixdate_overlay import USNFixDateOverlay
+
         overlay = USNFixDateOverlay()
         assert overlay.lookup("any", "any", "any") is None
         assert len(overlay) == 0
@@ -1385,6 +1411,7 @@ class TestUSNOverlayIntegration:
         p = Parser(workspace=fresh_workspace)
         # _iter_fragments reads self._usn_overlay; populate it as get() would
         from vunnel.providers.ubuntu.usn_fixdate_overlay import USNFixDateOverlay
+
         p._usn_overlay = USNFixDateOverlay.from_archive(p.archive_path)
         p._write_fragments()
 
@@ -1412,6 +1439,7 @@ class TestUSNOverlayIntegration:
         # CVE-2013-2208 fixes tpp@1.3.1-3 on Ubuntu:14.04:LTS; no USN in our fixture
         # ships that tuple, so the overlay lookup misses and the fixdater fallback applies.
         from vunnel.providers.ubuntu.usn_fixdate_overlay import USNFixDateOverlay
+
         p._usn_overlay = USNFixDateOverlay.from_archive(p.archive_path)
         p._write_fragments()
 
@@ -1419,9 +1447,7 @@ class TestUSNOverlayIntegration:
         payload = yielded["ubuntu-14.04-lts/ubuntu-cve-2013-2208"]
         fixes = payload["affected"][0]["ranges"][0]["database_specific"]["anchore"]["fixes"]
         tpp_fix = next(f for f in fixes if f["version"] == "1.3.1-3")
-        assert tpp_fix["date"] == "2013-07-15", (
-            f"missing USN tuple should fall through to first-observed mock; got {tpp_fix['date']}"
-        )
+        assert tpp_fix["date"] == "2013-07-15", f"missing USN tuple should fall through to first-observed mock; got {tpp_fix['date']}"
         # And not carrying any USN advisory provenance.
         assert tpp_fix["kind"] == "first-observed"
 
@@ -1443,24 +1469,55 @@ class TestOSDowncoverterHelpers:
 
     def test_base_ecosystem_to_namespace(self):
         from vunnel.providers.ubuntu.os_downconvert import osv_ecosystem_to_os_namespace
+
         assert osv_ecosystem_to_os_namespace("Ubuntu:22.04:LTS") == "ubuntu:22.04"
         assert osv_ecosystem_to_os_namespace("Ubuntu:24.04:LTS") == "ubuntu:24.04"
+        # non-LTS releases carry no `:LTS` suffix (real spellings seen in the feed).
         assert osv_ecosystem_to_os_namespace("Ubuntu:24.10") == "ubuntu:24.10"
         assert osv_ecosystem_to_os_namespace("Ubuntu:25.04") == "ubuntu:25.04"
+        assert osv_ecosystem_to_os_namespace("Ubuntu:25.10") == "ubuntu:25.10"
+        # both bare and `:LTS` spellings of the same release occur in the data.
+        assert osv_ecosystem_to_os_namespace("Ubuntu:26.04") == "ubuntu:26.04"
+        assert osv_ecosystem_to_os_namespace("Ubuntu:26.04:LTS") == "ubuntu:26.04"
 
-    def test_pro_and_subtiers_skipped(self):
+    def test_plain_pro_maps_to_esm_channel(self):
         from vunnel.providers.ubuntu.os_downconvert import osv_ecosystem_to_os_namespace
-        # v3 never emitted Vulnerability records for Pro/FIPS/Realtime/BlueField namespaces;
-        # they have no entry in cve-tracker's codename map. Pro-only-fix data still surfaces
-        # in OS output because inference layers it into the base ecosystem's affected[] list
-        # upstream of this code.
-        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:14.04:LTS") is None
-        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:16.04:LTS") is None
+
+        # plain Ubuntu Pro (ESM) maps to the `ubuntu:X.YY+esm` distro channel,
+        # mirroring RHEL EUS's `rhel:X.Y+eus`. LTS suffix optional.
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:14.04:LTS") == "ubuntu:14.04+esm"
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:16.04:LTS") == "ubuntu:16.04+esm"
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:22.04:LTS") == "ubuntu:22.04+esm"
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:25.10") == "ubuntu:25.10+esm"
+
+    def test_subtiers_skipped(self):
+        from vunnel.providers.ubuntu.os_downconvert import osv_ecosystem_to_os_namespace
+
+        # FIPS / FIPS-updates / Realtime / Nvidia-BlueField rebuild against divergent
+        # code (crypto modules, PREEMPT_RT kernel, separate product) — their fixes can't
+        # resolve a base disclosure, so they never get a channel. The anchored plain-Pro
+        # regex rejects any extra tier token or trailing segment by construction.
         assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:FIPS:22.04:LTS") is None
         assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:FIPS-updates:20.04:LTS") is None
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:FIPS-preview:22.04:LTS") is None
         assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:Realtime:24.04:LTS") is None
         assert osv_ecosystem_to_os_namespace("Ubuntu:Nvidia-BlueField:22.04:LTS") is None
+        # two real trap grammars from the feed put the tier token AFTER the version, so a
+        # naive matcher can misread them: `Ubuntu:Pro:...:Realtime:Kernel` still starts with
+        # `Ubuntu:Pro:` (would look like plain Pro), and `Ubuntu:...:for:NVIDIA:BlueField`
+        # starts with `Ubuntu:<ver>` (would look like a base release). Both must drop.
+        # Sources: CVE-2022-50031, CVE-2025-38213.
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:22.04:LTS:Realtime:Kernel") is None
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:24.04:LTS:Realtime:Kernel") is None
+        assert osv_ecosystem_to_os_namespace("Ubuntu:22.04:LTS:for:NVIDIA:BlueField") is None
         assert osv_ecosystem_to_os_namespace("Garbage") is None
+
+    def test_include_esm_flag_off_maps_plain_pro_to_none(self):
+        from vunnel.providers.ubuntu.os_downconvert import osv_ecosystem_to_os_namespace
+
+        # with the emit gate off, plain Pro is dropped like the sub-tiers; base is unaffected.
+        assert osv_ecosystem_to_os_namespace("Ubuntu:Pro:22.04:LTS", include_esm=False) is None
+        assert osv_ecosystem_to_os_namespace("Ubuntu:22.04:LTS", include_esm=False) == "ubuntu:22.04"
 
 
 class TestOSDowncoverter:
@@ -1486,11 +1543,13 @@ class TestOSDowncoverter:
 
     def test_withdrawn_record_is_skipped(self):
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record(withdrawn="2025-09-12T17:13:25Z")
         assert osv_to_os(rec) is None
 
     def test_fixed_event_yields_fixedin_with_version(self):
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         out = osv_to_os(self._osv_record())
         assert out is not None
         vuln = out["Vulnerability"]
@@ -1515,6 +1574,7 @@ class TestOSDowncoverter:
         # Once `patch_fix_date` has run, database_specific.anchore.fixes[] holds the
         # date+kind that downconversion should surface as the v3 `Available` field.
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record()
         rec["affected"][0]["ranges"][0]["database_specific"] = {
             "anchore": {"fixes": [{"version": "1.1.1f-1ubuntu2.20", "date": "2022-09-15", "kind": "advisory"}]},
@@ -1530,6 +1590,7 @@ class TestOSDowncoverter:
         # OR what _build_synthetic_base_affected writes when Pro-only-fix inference
         # synthesizes a base entry.
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record()
         rec["affected"] = [
             {
@@ -1550,6 +1611,7 @@ class TestOSDowncoverter:
         # "affected but no fix yet" — neither wont-fix nor a released fix version.
         # v3 represented this as Version="None", NoAdvisory=False.
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record()
         rec["affected"] = [
             {
@@ -1565,6 +1627,7 @@ class TestOSDowncoverter:
 
     def test_severity_handling_falls_back_to_unknown(self):
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         # missing severity entirely
         rec = self._osv_record()
         rec.pop("severity", None)
@@ -1578,6 +1641,7 @@ class TestOSDowncoverter:
 
     def test_severity_capitalizes_canonical_priority(self):
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record()
         for score, expected in [
             ("negligible", "Negligible"),
@@ -1592,13 +1656,15 @@ class TestOSDowncoverter:
     def test_no_upstream_returns_none(self):
         # No CVE-* id to use as Vulnerability.Name → cannot produce a v3-shape record.
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record()
         rec.pop("upstream", None)
         assert osv_to_os(rec) is None
 
-    def test_pro_only_record_returns_none(self):
-        # Pro/FIPS/Realtime/BlueField fragments don't get downconverted.
+    def test_subtier_record_returns_none(self):
+        # FIPS/Realtime/BlueField fragments don't get downconverted (divergent builds).
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record()
         rec["affected"] = [
             {
@@ -1608,10 +1674,148 @@ class TestOSDowncoverter:
         ]
         assert osv_to_os(rec) is None
 
+    def test_plain_pro_emits_esm_channel_with_verbatim_fix_version(self):
+        # Real Canonical OSV data (CVE-2021-3782 wayland, xenial esm-infra) — a genuine
+        # Pro-only fix. Source: https://ubuntu.com/security/cves/CVE-2021-3782.json
+        # The `~esm`/`+esm` suffix must survive verbatim; VersionFormat stays dpkg.
+        from vunnel.providers.ubuntu.os_downconvert import os_identifier_for, osv_to_os
+
+        rec = self._osv_record(id="UBUNTU-CVE-2021-3782", upstream=["CVE-2021-3782"])
+        rec["affected"] = [
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": "wayland"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "1.12.0-1~ubuntu16.04.3+esm1"}]}],
+            },
+        ]
+        out = osv_to_os(rec)
+        assert out is not None
+        vuln = out["Vulnerability"]
+        assert vuln["NamespaceName"] == "ubuntu:16.04+esm"
+        fi = vuln["FixedIn"][0]
+        assert fi["Name"] == "wayland"
+        assert fi["NamespaceName"] == "ubuntu:16.04+esm"
+        assert fi["Version"] == "1.12.0-1~ubuntu16.04.3+esm1"
+        assert fi["VersionFormat"] == "dpkg"
+        assert fi["VendorAdvisory"] == {"NoAdvisory": False}
+        assert os_identifier_for(rec) == "ubuntu:16.04+esm/cve-2021-3782"
+
+    def test_plain_pro_epoch_fix_version_passthrough(self):
+        # Real Canonical OSV data (CVE-2025-61985 openssh, focal esm-infra) — Pro-only fix
+        # with an epoch. Source: https://ubuntu.com/security/cves/CVE-2025-61985.json
+        from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
+        rec = self._osv_record(id="UBUNTU-CVE-2025-61985", upstream=["CVE-2025-61985"])
+        rec["affected"] = [
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:20.04:LTS", "name": "openssh"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "1:8.2p1-4ubuntu0.13+esm1"}]}],
+            },
+        ]
+        out = osv_to_os(rec)
+        assert out is not None
+        assert out["Vulnerability"]["NamespaceName"] == "ubuntu:20.04+esm"
+        assert out["Vulnerability"]["FixedIn"][0]["Version"] == "1:8.2p1-4ubuntu0.13+esm1"
+
+    def test_plain_pro_dropped_when_include_esm_off(self):
+        from vunnel.providers.ubuntu.os_downconvert import os_identifier_for, osv_to_os
+
+        rec = self._osv_record(id="UBUNTU-CVE-2021-3782", upstream=["CVE-2021-3782"])
+        rec["affected"] = [
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": "wayland"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "1.12.0-1~ubuntu16.04.3+esm1"}]}],
+            },
+        ]
+        assert osv_to_os(rec, include_esm=False) is None
+        assert os_identifier_for(rec, include_esm=False) is None
+
+    def test_plain_pro_no_fix_emits_no_esm_record(self):
+        # A plain-Pro slice with only `introduced:0` and no fixed event (real shape from
+        # CVE-2016-20013's Pro slices) must NOT produce a `ubuntu:X.YY+esm` record. The
+        # `+esm` channel carries fixes only; the unfixed disclosure lives on the base
+        # `ubuntu:X.YY` record, so a Version="None" +esm entry would just duplicate it.
+        from vunnel.providers.ubuntu.os_downconvert import os_identifier_for, osv_to_os
+
+        rec = self._osv_record(id="UBUNTU-CVE-2016-20013", upstream=["CVE-2016-20013"])
+        rec["affected"] = [
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": "glibc"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+            },
+        ]
+        assert osv_to_os(rec) is None
+        assert os_identifier_for(rec) is None
+
+    def test_plain_pro_wont_fix_status_emits_no_esm_record(self):
+        # Same as above but with an explicit wont-fix marker (what _annotate_wont_fix
+        # stamps): a wont-fix Pro slice still yields no `+esm` record — no Version="None".
+        from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
+        rec = self._osv_record(id="UBUNTU-CVE-2016-20013", upstream=["CVE-2016-20013"])
+        rec["affected"] = [
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": "glibc"},
+                "database_specific": {"anchore": {"status": "wont-fix"}},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+            },
+        ]
+        assert osv_to_os(rec) is None
+
+    def test_esm_apps_and_infra_share_the_same_channel(self):
+        # esm-apps and esm-infra are both plain Ubuntu:Pro:X.YY ecosystems (the channel lives
+        # in the purl, which the namespace mapping does not consult) — so both resolve to the
+        # same `ubuntu:X.YY+esm`. Real fixes: cobbler (esm-apps) & harfbuzz (esm-infra), xenial.
+        from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
+        def _one(name, fixed, purl):
+            rec = self._osv_record(id="UBUNTU-CVE-x", upstream=["CVE-2000-1"])
+            rec["affected"] = [
+                {
+                    "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": name, "purl": purl},
+                    "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": fixed}]}],
+                },
+            ]
+            return osv_to_os(rec)
+
+        apps = _one("cobbler", "2.4.1-0ubuntu2+esm1", "pkg:deb/ubuntu/cobbler@2.4.1?arch=source&distro=esm-apps/xenial")
+        infra = _one("harfbuzz", "1.0.1-1ubuntu0.1+esm1", "pkg:deb/ubuntu/harfbuzz@1.0.1?arch=source&distro=esm-infra/xenial")
+        assert apps["Vulnerability"]["NamespaceName"] == "ubuntu:16.04+esm"
+        assert infra["Vulnerability"]["NamespaceName"] == "ubuntu:16.04+esm"
+        assert apps["Vulnerability"]["FixedIn"][0]["Version"] == "2.4.1-0ubuntu2+esm1"
+        assert infra["Vulnerability"]["FixedIn"][0]["Version"] == "1.0.1-1ubuntu0.1+esm1"
+
+    @pytest.mark.parametrize(
+        "fixed",
+        [
+            "1:2.2.2+dfsg-1ubuntu1+esm5",  # epoch + multi +esm (CVE-2022-35229)
+            "1:1.3-1ubuntu0.1~esm1",  # epoch + ~esm (CVE-2019-15531)
+            "1.8.3-1~ubuntu0.1+esm1",  # ~ubuntu backport + +esm (CVE-2017-5838)
+            "2.6.8-1~ubuntu14.04.0~esm1",  # ~ubuntu + ~esm tilde form (CVE-2019-10899)
+            "2:4.7.6+dfsg~ubuntu-0ubuntu2.29+esm1",  # epoch + +dfsg~ubuntu + +esm (CVE-2022-42898)
+            "1.0.0~rc7+git20190403.029124da-0ubuntu1~16.04.4+esm4",  # rc + git + backport + esm (CVE-2022-29162)
+        ],
+    )
+    def test_weird_pro_fix_versions_pass_through_verbatim(self, fixed):
+        # Real Pro fix strings from the feed must survive byte-for-byte; VersionFormat stays dpkg.
+        from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
+        rec = self._osv_record(id="UBUNTU-CVE-x", upstream=["CVE-2000-1"])
+        rec["affected"] = [
+            {
+                "package": {"ecosystem": "Ubuntu:Pro:16.04:LTS", "name": "pkg"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": fixed}]}],
+            },
+        ]
+        out = osv_to_os(rec)
+        fi = out["Vulnerability"]["FixedIn"][0]
+        assert fi["Version"] == fixed
+        assert fi["VersionFormat"] == "dpkg"
+
     def test_multiple_packages_become_multiple_fixedin(self):
         # Sliced by ecosystem, an envelope still has one affected[] entry per source
         # package. Each becomes one FixedIn (in input order).
         from vunnel.providers.ubuntu.os_downconvert import osv_to_os
+
         rec = self._osv_record()
         rec["affected"] = [
             {
@@ -1640,6 +1844,7 @@ class TestOSDowncoverter:
 
     def test_identifier_for_returns_v3_shape(self):
         from vunnel.providers.ubuntu.os_downconvert import os_identifier_for
+
         rec = self._osv_record()
         assert os_identifier_for(rec) == "ubuntu:22.04/cve-2024-1"
 
@@ -1665,9 +1870,10 @@ class TestOSDowncoverterIntegration:
             # Identifier shape: ubuntu:X.YY/cve-...
             assert identifier.startswith("ubuntu:"), identifier
 
-        # Every Pro/FIPS/BlueField slice should be filtered out — only base namespaces remain.
+        # Every namespace is either a base `ubuntu:X.YY` or a plain-Pro `ubuntu:X.YY+esm`
+        # channel. FIPS/Realtime/BlueField slices are still filtered out entirely.
         namespaces = {p["Vulnerability"]["NamespaceName"] for _, _, p in records}
-        assert all(ns.startswith("ubuntu:") and ":Pro" not in ns and "-" not in ns.split(":")[1] for ns in namespaces), namespaces
+        assert all(ns.startswith("ubuntu:") and ":Pro" not in ns and "-" not in ns.split(":")[1].split("+")[0] for ns in namespaces), namespaces
 
     def test_inferred_wont_fix_lands_in_downconverted_output(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
         # The Pro-only-fix inference path synthesizes base envelopes with
@@ -1691,6 +1897,167 @@ class TestOSDowncoverterIntegration:
         assert wayland["Version"] == "None"
         assert wayland["VendorAdvisory"]["NoAdvisory"] is True
 
+    def test_plain_pro_dual_emit_base_wontfix_and_esm_fix(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
+        # Real fixture CVE-2021-3782 (wayland) has a Pro-only fix on Ubuntu:Pro:16.04:LTS
+        # (1.12.0-1~ubuntu16.04.3+esm1) and NO base 16.04 entry. Downconvert must emit the
+        # paired split: base `ubuntu:16.04` carries the synthesized Version="None" wont-fix,
+        # and `ubuntu:16.04+esm` carries the real, verbatim ESM fix version.
+        _seed_archive(fresh_workspace, fixture_dir)
+        _seed_vex_archive(fresh_workspace, fixture_dir)
+
+        p = Parser(workspace=fresh_workspace, downconvert_osv_to_os=True)
+        with patch.object(p, "_download_archive"), patch.object(p, "_download_vex_archive"):
+            records = list(p.get())
+        by_id = {i: payload for i, _, payload in records}
+
+        base = by_id.get("ubuntu:16.04/cve-2021-3782")
+        assert base is not None, sorted(by_id)
+        base_wayland = next(fi for fi in base["Vulnerability"]["FixedIn"] if fi["Name"] == "wayland")
+        assert base_wayland["Version"] == "None"
+        assert base_wayland["VendorAdvisory"]["NoAdvisory"] is True
+
+        esm = by_id.get("ubuntu:16.04+esm/cve-2021-3782")
+        assert esm is not None, sorted(by_id)
+        assert esm["Vulnerability"]["NamespaceName"] == "ubuntu:16.04+esm"
+        esm_wayland = next(fi for fi in esm["Vulnerability"]["FixedIn"] if fi["Name"] == "wayland")
+        assert esm_wayland["Version"] == "1.12.0-1~ubuntu16.04.3+esm1"
+        assert esm_wayland["VersionFormat"] == "dpkg"
+        assert esm_wayland["NamespaceName"] == "ubuntu:16.04+esm"
+
+        # A base CVE fixed in a standard pocket must NOT get a +esm record. Wayland is
+        # released in the standard pocket on 18.04/20.04/22.04 (no Pro slice for them).
+        assert "ubuntu:18.04+esm/cve-2021-3782" not in by_id
+        assert "ubuntu:20.04+esm/cve-2021-3782" not in by_id
+        assert "ubuntu:22.04+esm/cve-2021-3782" not in by_id
+
+    def test_include_esm_flag_off_suppresses_esm_records(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
+        # VUN-4: the gate off drops every +esm record while base records (incl. the
+        # synthesized base wont-fix) are untouched.
+        _seed_archive(fresh_workspace, fixture_dir)
+        _seed_vex_archive(fresh_workspace, fixture_dir)
+
+        p = Parser(workspace=fresh_workspace, downconvert_osv_to_os=True, downconvert_emit_esm=False)
+        with patch.object(p, "_download_archive"), patch.object(p, "_download_vex_archive"):
+            records = list(p.get())
+        ids = {i for i, _, _ in records}
+        assert not any("+esm" in i for i in ids), sorted(i for i in ids if "+esm" in i)
+        # base wont-fix disclosure still present
+        assert "ubuntu:16.04/cve-2021-3782" in ids
+
+    def test_real_multi_release_esm_fanout_netty(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
+        # Real Canonical record CVE-2022-24823 (netty). Source: ubuntu.com/security/CVE-2022-24823.json.
+        # One CVE spanning 7 Pro releases: 5 carry real Pro fixes (16/18/20/22/24), 14.04 and 26.04
+        # are Pro-tracked-but-unfixed, plus a base non-LTS 25.10 slice. Exercises: multi-release
+        # `+esm` fanout, verbatim passthrough of epoch / `~esm` / `+esm` / `+deb11u2` fix strings,
+        # no-`+esm` for the unfixed Pro slices, and no `+esm` for the base non-LTS release.
+        _seed_esm_cases_archive(fresh_workspace, fixture_dir)
+        _seed_vex_archive(fresh_workspace, fixture_dir)
+
+        p = Parser(workspace=fresh_workspace, downconvert_osv_to_os=True)
+        with patch.object(p, "_download_archive"), patch.object(p, "_download_vex_archive"):
+            records = list(p.get())
+        by_id = {i: payload for i, _, payload in records}
+
+        # the 5 fixed Pro releases each emit a `+esm` record with the real fix version verbatim.
+        expected_esm = {
+            "ubuntu:16.04+esm/cve-2022-24823": "1:4.0.34-1ubuntu0.1~esm2",
+            "ubuntu:18.04+esm/cve-2022-24823": "1:4.1.7-4ubuntu0.1+esm3",
+            "ubuntu:20.04+esm/cve-2022-24823": "1:4.1.45-1ubuntu0.1~esm2",
+            "ubuntu:22.04+esm/cve-2022-24823": "1:4.1.48-4+deb11u2ubuntu0.1~esm1",
+            "ubuntu:24.04+esm/cve-2022-24823": "1:4.1.48-9ubuntu0.1~esm1",
+        }
+        for ident, version in expected_esm.items():
+            rec = by_id.get(ident)
+            assert rec is not None, sorted(i for i in by_id if "+esm" in i)
+            fi = next(f for f in rec["Vulnerability"]["FixedIn"] if f["Name"] == "netty")
+            assert fi["Version"] == version
+            assert fi["VersionFormat"] == "dpkg"
+            assert fi["VendorAdvisory"] == {"NoAdvisory": False}
+
+        # unfixed Pro slices (14.04, 26.04) and the base non-LTS 25.10 slice get no `+esm` record.
+        assert "ubuntu:14.04+esm/cve-2022-24823" not in by_id
+        assert "ubuntu:26.04+esm/cve-2022-24823" not in by_id
+        assert "ubuntu:25.10+esm/cve-2022-24823" not in by_id
+        # the emitted `+esm` set for this CVE is exactly the 5 fixed releases — no extras.
+        assert {i for i in by_id if "+esm" in i and "2022-24823" in i} == set(expected_esm)
+
+    def test_real_mixed_base_and_esm_fix_unzip(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
+        # Real record CVE-2014-9913 (unzip): fixed in Pro on 14.04 (`6.0-9ubuntu1.6`) and in the
+        # standard pocket on 16.04 (`6.0-20ubuntu1.1`). The Pro release emits both a base wont-fix
+        # and a `+esm` fix; the base-fixed release emits only a base record — never a `+esm`.
+        _seed_esm_cases_archive(fresh_workspace, fixture_dir)
+        _seed_vex_archive(fresh_workspace, fixture_dir)
+
+        p = Parser(workspace=fresh_workspace, downconvert_osv_to_os=True)
+        with patch.object(p, "_download_archive"), patch.object(p, "_download_vex_archive"):
+            records = list(p.get())
+        by_id = {i: payload for i, _, payload in records}
+
+        esm = by_id.get("ubuntu:14.04+esm/cve-2014-9913")
+        assert esm is not None, sorted(by_id)
+        esm_fi = next(f for f in esm["Vulnerability"]["FixedIn"] if f["Name"] == "unzip")
+        assert esm_fi["Version"] == "6.0-9ubuntu1.6"
+
+        base16 = by_id.get("ubuntu:16.04/cve-2014-9913")
+        assert base16 is not None, sorted(by_id)
+        base16_fi = next(f for f in base16["Vulnerability"]["FixedIn"] if f["Name"] == "unzip")
+        assert base16_fi["Version"] == "6.0-20ubuntu1.1"
+
+        # 16.04 is fixed in the standard pocket (no Pro slice) — no `+esm` channel record.
+        assert "ubuntu:16.04+esm/cve-2014-9913" not in by_id
+
+    def test_real_withdrawn_pro_record_dropped_wolfssl(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
+        # Real withdrawn record CVE-2014-2901 (wolfssl) carrying a plain-Pro slice. Withdrawn
+        # records are retractions with no OS-schema equivalent — dropped before any `+esm` emit.
+        _seed_esm_cases_archive(fresh_workspace, fixture_dir)
+        _seed_vex_archive(fresh_workspace, fixture_dir)
+
+        p = Parser(workspace=fresh_workspace, downconvert_osv_to_os=True)
+        with patch.object(p, "_download_archive"), patch.object(p, "_download_vex_archive"):
+            records = list(p.get())
+        ids = {i for i, _, _ in records}
+        assert not any("2014-2901" in i for i in ids), sorted(i for i in ids if "2014-2901" in i)
+
+    def test_real_no_fix_pro_slices_emit_no_esm_records(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
+        # Real fixture CVE-2016-20013: its plain-Pro slices (14/16/18/20) are all `introduced:0`
+        # with no fixed event. None may produce a `+esm` record — the base wont-fix is the sole
+        # disclosure. Regression guard for the "+esm Version=None noise" the channel used to emit.
+        _seed_archive(fresh_workspace, fixture_dir)
+        _seed_vex_archive(fresh_workspace, fixture_dir)
+
+        p = Parser(workspace=fresh_workspace, downconvert_osv_to_os=True)
+        with patch.object(p, "_download_archive"), patch.object(p, "_download_vex_archive"):
+            records = list(p.get())
+        ids = {i for i, _, _ in records}
+        assert not any("+esm" in i and "2016-20013" in i for i in ids), \
+            sorted(i for i in ids if "+esm" in i and "2016-20013" in i)
+        # the base disclosure is still present.
+        assert "ubuntu:14.04/cve-2016-20013" in ids
+
+    def test_provider_config_emit_esm_off_drops_esm_records(self, helpers, fixture_dir, auto_fake_fixdate_finder):
+        # Frozen-v5 lane, end-to-end: downconvert on but `downconvert_emit_esm` off through the
+        # real Config -> Provider -> Parser plumbing. No `+esm` record lands on disk.
+        import json
+
+        ws = helpers.provider_workspace_helper(name=Provider.name())
+        c = Config()
+        c.runtime.result_store = result.StoreStrategy.FLAT_FILE
+        c.downconvert_osv_to_os = True
+        c.downconvert_emit_esm = False
+
+        p = Provider(root=str(ws.root), config=c)
+        _stage_workspace_for_update(str(ws.root), fixture_dir)
+
+        with patch.object(p.parser, "_download_archive"), patch.object(p.parser, "_download_vex_archive"):
+            p.update(None)
+
+        namespaces = []
+        for f in ws.result_files():
+            with open(f) as fh:
+                namespaces.append(json.load(fh)["item"]["Vulnerability"]["NamespaceName"])
+        assert namespaces, "expected downconverted records"
+        assert not any(ns.endswith("+esm") for ns in namespaces), sorted(set(namespaces))
+
     def test_default_still_yields_osv_records(self, fresh_workspace, fixture_dir, auto_fake_fixdate_finder):
         # Sanity: with the toggle off (default), OSV envelopes flow through unchanged.
         _seed_archive(fresh_workspace, fixture_dir)
@@ -1707,6 +2074,7 @@ class TestOSDowncoverterIntegration:
         # End-to-end through Provider.update with the Config flag on, exercising
         # the actual Provider plumbing (not just Parser.__init__).
         import json
+
         ws = helpers.provider_workspace_helper(name=Provider.name())
         c = Config()
         c.runtime.result_store = result.StoreStrategy.FLAT_FILE


### PR DESCRIPTION
The ubuntu OSV->OS down-convert previously dropped every Ubuntu Pro tier (mapped Ubuntu:Pro:* to None), so ESM fixes never made it into the legacy OS-schema output. Now plain ESM (Ubuntu:Pro:X.YY:LTS) maps to a distro channel ubuntu:X.YY+esm carrying the real Pro fix version, mirroring how the rhel provider emits rhel:X.Y+eus.

The disclosure/resolution split falls out for free: the base ubuntu:X.YY record keeps its synthesized Version:"None" wont-fix row, and the sibling Pro fragment now emits ubuntu:X.YY+esm with the actual fix (verbatim, dpkg). A CVE already fixed in a standard pocket never produces a +esm record.

Scope is plain ESM only. FIPS / FIPS-updates / Realtime / Nvidia-BlueField stay mapped to None. Their builds diverge from base so their fix versions can't soundly resolve a base disclosure. An anchored regex rejects any extra tier token by construction.

Gated by a new include_esm config (default on). The frozen-v5 lane sets it off to take the OS-shape down-convert without +esm channels until its build is validated against them.