### PR TITLE
fix(hummingbird): better workspace disk space management

### DIFF
--- a/src/vunnel/providers/hummingbird/csaf_client.py
+++ b/src/vunnel/providers/hummingbird/csaf_client.py
@@ -5,6 +5,7 @@ import contextlib
 import csv
 import email.utils
 import os
+import shutil
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
 VEX_FEED_LATEST_URL = "https://security.access.redhat.com/data/csaf/v2/vex-feed/archive_latest.txt"
 
 TIMESTAMP_FILE = "archive_timestamp.txt"
+CHANGES_TIMESTAMP_FILE = "changes_timestamp.txt"
+
+ARCHIVE_SUFFIXES = (".tar", ".tar.zst", ".tar.gz", ".tar.xz", ".tar.bz2")
 
 
 class CSAFVEXClient:
@@ -78,6 +82,9 @@ class CSAFVEXClient:
     def _timestamp_path(self) -> str:
         return os.path.join(self.workspace.input_path, TIMESTAMP_FILE)
 
+    def _changes_timestamp_path(self) -> str:
+        return os.path.join(self.workspace.input_path, CHANGES_TIMESTAMP_FILE)
+
     def _local_changes_path(self) -> str:
         return os.path.join(self.workspace.input_path, "changes.csv")
 
@@ -98,13 +105,33 @@ class CSAFVEXClient:
         with open(self._timestamp_path(), "w") as fh:
             fh.write(mod_time.isoformat())
 
+    def _load_changes_timestamp(self) -> datetime | None:
+        ts_path = self._changes_timestamp_path()
+        if os.path.exists(ts_path):
+            with open(ts_path) as fh:
+                return datetime.fromisoformat(fh.read().strip())
+        return None
+
+    def _save_changes_timestamp(self, mod_time: datetime) -> None:
+        with open(self._changes_timestamp_path(), "w") as fh:
+            fh.write(mod_time.isoformat())
+
+    def _clear_changes_timestamp(self) -> None:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(self._changes_timestamp_path())
+
     # ── download helpers ──────────────────────────────────────────────
 
-    def _download_stream(self, url: str, path: str) -> None:
+    def _download_stream(self, url: str, path: str) -> datetime | None:
+        """Download url to path, returning the response Last-Modified (if any)."""
         with http.get(url, logger=self.logger, stream=True) as response, open(path, "wb") as fh:
             for chunk in response.iter_content(chunk_size=65536):
                 if chunk:
                     fh.write(chunk)
+            lm = response.headers.get("Last-Modified")
+        if lm:
+            return email.utils.parsedate_to_datetime(lm)
+        return None
 
     def _head_last_modified(self, url: str) -> datetime | None:
         """HEAD the URL and return Last-Modified as a tz-aware datetime, or None."""
@@ -119,6 +146,7 @@ class CSAFVEXClient:
 
     def _sync(self) -> None:
         os.makedirs(self.advisories_path, exist_ok=True)
+        self._remove_stray_files()
 
         archive_url = self._archive_url()
         self._load_timestamp()
@@ -144,53 +172,53 @@ class CSAFVEXClient:
         self._download_stream(self._deletions_url(), self._local_deletions_path())
         self._process_changes_and_deletions()
 
+    def _remove_stray_files(self) -> None:
+        # leftover archives or partial extractions from interrupted runs would
+        # otherwise persist in the workspace (and any cached copies of it) forever
+        tmp_dir = self._advisories_tmp_path()
+        if os.path.isdir(tmp_dir):
+            self.logger.warning(f"removing stray partial extraction: {tmp_dir}")
+            shutil.rmtree(tmp_dir)
+
+        for name in os.listdir(self.workspace.input_path):
+            if name.endswith(ARCHIVE_SUFFIXES):
+                self.logger.warning(f"removing stray archive: {name}")
+                with contextlib.suppress(OSError):
+                    os.remove(os.path.join(self.workspace.input_path, name))
+
+    def _advisories_tmp_path(self) -> str:
+        return self.advisories_path + ".tmp"
+
     def _download_archive(self, archive_url: str) -> None:
         archive_name = archive_url.rsplit("/", 1)[-1]
         archive_path = os.path.join(self.workspace.input_path, archive_name)
 
         self.logger.info(f"downloading archive: {archive_url}")
-        self._download_stream(archive_url, archive_path)
+        try:
+            remote_mod = self._download_stream(archive_url, archive_path)
 
-        self.logger.info("extracting archive")
-        extract(archive_path, self.advisories_path)
+            # extract to a temp dir and swap so a failed extraction can't
+            # destroy the existing advisories tree
+            self.logger.info("extracting archive")
+            tmp_dir = self._advisories_tmp_path()
+            extract(archive_path, tmp_dir)
 
-        # persist the remote Last-Modified as our timestamp
-        remote_mod = self._head_last_modified(archive_url)
-        if remote_mod:
-            self._save_timestamp(remote_mod)
-        else:
-            # fallback: use current time
-            self._save_timestamp(datetime.now(tz=UTC))
+            if os.path.isdir(self.advisories_path):
+                shutil.rmtree(self.advisories_path)
+            os.rename(tmp_dir, self.advisories_path)
 
-        # clean up the archive file to save disk space
-        with contextlib.suppress(OSError):
-            os.remove(archive_path)
+            self._save_timestamp(remote_mod or datetime.now(tz=UTC))
+            # the new tree supersedes any previously applied changes
+            self._clear_changes_timestamp()
+        finally:
+            # always clean up the archive file to save disk space
+            with contextlib.suppress(OSError):
+                os.remove(archive_path)
 
     def _process_changes_and_deletions(self) -> None:
-        # ── deletions ──
-        deletions_path = self._local_deletions_path()
-        with open(deletions_path, newline="") as fh:
-            reader = csv.reader(fh)
-            for row in reader:
-                deleted_fragment = row[0]
-                with contextlib.suppress(FileNotFoundError):
-                    os.remove(os.path.join(self.advisories_path, deleted_fragment))
+        self._apply_deletions()
 
-        # ── changes ──
-        changes_path = self._local_changes_path()
-        seen_files: set[str] = set()
-        years: set[str] = set()
-        with open(changes_path, newline="") as fh:
-            reader = csv.reader(fh)
-            for row in reader:
-                changed_file = row[0]
-                date_str = row[1]
-                change_date = datetime.fromisoformat(date_str)
-                if self.archive_mod_time and change_date < self.archive_mod_time:
-                    break
-                seen_files.add(changed_file)
-                year = changed_file.split("/")[0]
-                years.add(year)
+        seen_files, years, newest_change = self._collect_pending_changes()
 
         if not seen_files:
             self.logger.info("no changed files newer than archive")
@@ -201,6 +229,51 @@ class CSAFVEXClient:
         for year in years:
             os.makedirs(os.path.join(self.advisories_path, year), exist_ok=True)
 
+        any_failed = self._download_changed_files(seen_files)
+
+        # only advance the watermark when everything landed, so failed files are retried next run
+        if not any_failed and newest_change:
+            self._save_changes_timestamp(newest_change)
+
+    def _apply_deletions(self) -> None:
+        with open(self._local_deletions_path(), newline="") as fh:
+            reader = csv.reader(fh)
+            for row in reader:
+                deleted_fragment = row[0]
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(os.path.join(self.advisories_path, deleted_fragment))
+
+    def _collect_pending_changes(self) -> tuple[set[str], set[str], datetime | None]:
+        """Read changes.csv (newest first) and return (files, years, newest change date) not yet applied."""
+        # skip changes already applied by a previous run (the watermark), falling
+        # back to the archive timestamp when no changes have been applied yet
+        watermark = self.archive_mod_time
+        changes_applied = self._load_changes_timestamp()
+        if changes_applied and (watermark is None or changes_applied > watermark):
+            watermark = changes_applied
+
+        seen_files: set[str] = set()
+        years: set[str] = set()
+        newest_change: datetime | None = None
+        with open(self._local_changes_path(), newline="") as fh:
+            reader = csv.reader(fh)
+            for row in reader:
+                changed_file = row[0]
+                date_str = row[1]
+                change_date = datetime.fromisoformat(date_str)
+                if watermark and change_date < watermark:
+                    break
+                if newest_change is None or change_date > newest_change:
+                    newest_change = change_date
+                seen_files.add(changed_file)
+                year = changed_file.split("/")[0]
+                years.add(year)
+
+        return seen_files, years, newest_change
+
+    def _download_changed_files(self, seen_files: set[str]) -> bool:
+        """Download the given advisory fragments in parallel, returning True if any failed."""
+        any_failed = False
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures = {
                 executor.submit(
@@ -213,4 +286,6 @@ class CSAFVEXClient:
             concurrent.futures.wait(futures.keys())
             for future, changed_file in futures.items():
                 if future.exception() is not None:
+                    any_failed = True
                     self.logger.warning(f"failed to download {changed_file}: {future.exception()}")
+        return any_failed

--- a/src/vunnel/utils/archive.py
+++ b/src/vunnel/utils/archive.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import shutil
 import tarfile
-import tempfile
 from pathlib import Path
 
 import zstandard
@@ -13,7 +12,7 @@ def extract(path: str, destination_dir: str) -> None:
     if os.path.exists(destination_dir):
         shutil.rmtree(destination_dir)
 
-    if path.endswith(".tar.zst"):
+    if str(path).endswith(".tar.zst"):
         return _extract_tar_zst(path, destination_dir)
 
     # open for reading with transparent compression (supports gz, bz2, and xz)
@@ -27,12 +26,15 @@ def _extract_tar_zst(path: str, unarchive_path: str) -> None:
     archive_path = Path(path).expanduser()
     dctx = zstandard.ZstdDecompressor(max_window_size=2147483648)
 
-    with tempfile.TemporaryFile(suffix=".tar") as ofh:
-        with archive_path.open("rb") as ifh:
-            dctx.copy_stream(ifh, ofh)
-        ofh.seek(0)
-        with tarfile.open(fileobj=ofh, mode="r") as z:
-            return _safe_extract_tar(z, unarchive_path)
+    # stream decompression directly into tar extraction so the decompressed
+    # tarball is never materialized on disk; read_across_frames matches the
+    # whole-stream semantics of copy_stream for multi-frame archives
+    with (
+        archive_path.open("rb") as ifh,
+        dctx.stream_reader(ifh, read_across_frames=True) as reader,
+        tarfile.open(fileobj=reader, mode="r|") as z,
+    ):
+        return _safe_extract_tar(z, unarchive_path)
 
 
 def _safe_extract_tar(tar: tarfile.TarFile, destination_dir: str) -> None:

--- a/tests/unit/providers/hummingbird/test_csaf_client.py
+++ b/tests/unit/providers/hummingbird/test_csaf_client.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tarfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import zstandard
+
+from vunnel.providers.hummingbird import csaf_client
+from vunnel.providers.hummingbird.csaf_client import CSAFVEXClient
+
+FEED_BASE = "https://example.com/feed"
+FEED_URL = f"{FEED_BASE}/archive_latest.txt"
+ARCHIVE_NAME = "vex-archive.tar.zst"
+ARCHIVE_URL = f"{FEED_BASE}/{ARCHIVE_NAME}"
+CHANGES_URL = f"{FEED_BASE}/changes.csv"
+DELETIONS_URL = f"{FEED_BASE}/deletions.csv"
+
+ARCHIVE_LAST_MODIFIED = "Fri, 03 Jul 2026 00:00:00 GMT"
+ARCHIVE_MOD_TIME = datetime.fromisoformat("2026-07-03T00:00:00+00:00")
+
+
+class FakeWorkspace:
+    def __init__(self, tmp_path: Path):
+        self.input_path = str(tmp_path / "input")
+        os.makedirs(self.input_path, exist_ok=True)
+
+
+class FakeResponse:
+    def __init__(self, content: bytes, headers: dict[str, str] | None = None):
+        self.content = content
+        self.headers = headers or {}
+
+    @property
+    def text(self) -> str:
+        return self.content.decode()
+
+    def iter_content(self, chunk_size: int = 65536):
+        yield self.content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def tar_zst_bytes(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return zstandard.ZstdCompressor().compress(buf.getvalue())
+
+
+def serve(monkeypatch, responses: dict, requested: list[str] | None = None) -> None:
+    """Fake http.get: responses maps url -> bytes | (bytes, headers) | Exception."""
+
+    def fake_get(url, logger=None, stream=False, **kwargs):
+        if requested is not None:
+            requested.append(url)
+        if url not in responses:
+            raise AssertionError(f"unexpected request: {url}")
+        entry = responses[url]
+        if isinstance(entry, Exception):
+            raise entry
+        content, headers = entry if isinstance(entry, tuple) else (entry, {})
+        return FakeResponse(content, headers)
+
+    monkeypatch.setattr(csaf_client.http, "get", fake_get)
+
+
+def serve_head(monkeypatch, last_modified: str | None) -> None:
+    class HeadResponse:
+        headers = {"Last-Modified": last_modified} if last_modified else {}
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(csaf_client.requests, "head", lambda *a, **k: HeadResponse())
+
+
+def forbid_head(monkeypatch) -> None:
+    def fail(*a, **k):
+        raise AssertionError("unexpected HEAD request")
+
+    monkeypatch.setattr(csaf_client.requests, "head", fail)
+
+
+def make_client(workspace: FakeWorkspace) -> CSAFVEXClient:
+    return CSAFVEXClient(workspace=workspace, logger=logging.getLogger("test"), latest_url=FEED_URL)
+
+
+def write_input(workspace: FakeWorkspace, name: str, content: str = "") -> str:
+    path = os.path.join(workspace.input_path, name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(content)
+    return path
+
+
+def advisory_path(workspace: FakeWorkspace, fragment: str) -> str:
+    return os.path.join(workspace.input_path, "advisories", fragment)
+
+
+BASE_RESPONSES = {
+    FEED_URL: ARCHIVE_NAME.encode(),
+    CHANGES_URL: b"",
+    DELETIONS_URL: b"",
+}
+
+
+class TestArchiveDownload:
+    def test_first_run_downloads_and_extracts(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+            },
+        )
+        forbid_head(monkeypatch)  # no local timestamp means no staleness check is needed
+
+        client = make_client(ws)
+
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+        assert client.archive_mod_time == ARCHIVE_MOD_TIME
+
+    def test_timestamp_comes_from_get_response(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+            },
+        )
+        forbid_head(monkeypatch)
+
+        make_client(ws)
+
+        with open(os.path.join(ws.input_path, csaf_client.TIMESTAMP_FILE)) as fh:
+            assert datetime.fromisoformat(fh.read().strip()) == ARCHIVE_MOD_TIME
+
+    def test_archive_file_removed_after_extraction(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+            },
+        )
+        forbid_head(monkeypatch)
+
+        make_client(ws)
+
+        assert not os.path.exists(os.path.join(ws.input_path, ARCHIVE_NAME))
+
+    def test_up_to_date_archive_not_downloaded(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        requested: list[str] = []
+        serve(monkeypatch, BASE_RESPONSES, requested)
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert ARCHIVE_URL not in requested
+        assert CHANGES_URL in requested
+        assert DELETIONS_URL in requested
+
+    def test_newer_remote_archive_is_downloaded(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        client = make_client(ws)
+
+        assert client.archive_mod_time == ARCHIVE_MOD_TIME
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+
+
+class TestFailureCleanup:
+    def test_archive_removed_when_extraction_fails(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (b"not a zst archive", {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+            },
+        )
+        forbid_head(monkeypatch)
+
+        with pytest.raises(Exception):
+            make_client(ws)
+
+        assert not os.path.exists(os.path.join(ws.input_path, ARCHIVE_NAME))
+        assert not os.path.exists(os.path.join(ws.input_path, csaf_client.TIMESTAMP_FILE))
+
+    def test_failed_extraction_preserves_existing_advisories(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
+        write_input(ws, "advisories/2025/cve-2025-0001.json", "{}")
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (b"not a zst archive", {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        with pytest.raises(Exception):
+            make_client(ws)
+
+        assert os.path.exists(advisory_path(ws, "2025/cve-2025-0001.json"))
+
+
+class TestStrayFileCleanup:
+    def test_stray_archives_and_partial_extractions_removed(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        write_input(ws, "leaked-archive.tar.zst", "stale bytes")
+        write_input(ws, "advisories.tmp/2026/cve-2026-0001.json", "{}")
+        serve(monkeypatch, BASE_RESPONSES)
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert not os.path.exists(os.path.join(ws.input_path, "leaked-archive.tar.zst"))
+        assert not os.path.exists(os.path.join(ws.input_path, "advisories.tmp"))
+
+    def test_stray_cleanup_keeps_other_input_files(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        write_input(ws, "advisories/2026/cve-2026-0001.json", "{}")
+        serve(monkeypatch, BASE_RESPONSES)
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+        assert os.path.exists(os.path.join(ws.input_path, csaf_client.TIMESTAMP_FILE))
+
+
+class TestChangesAndDeletions:
+    def test_changes_newer_than_archive_downloaded(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        changes = b"2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n2026/cve-2026-0001.json,2026-07-01T00:00:00+00:00\n"
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                CHANGES_URL: changes,
+                f"{FEED_BASE}/2026/cve-2026-0002.json": b"{}",
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0002.json"))
+        assert not os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+
+    def test_watermark_saved_after_changes_applied(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        changes = b"2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                CHANGES_URL: changes,
+                f"{FEED_BASE}/2026/cve-2026-0002.json": b"{}",
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        with open(os.path.join(ws.input_path, csaf_client.CHANGES_TIMESTAMP_FILE)) as fh:
+            assert datetime.fromisoformat(fh.read().strip()) == datetime.fromisoformat("2026-07-03T12:00:00+00:00")
+
+    def test_watermark_skips_already_applied_changes(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        write_input(ws, csaf_client.CHANGES_TIMESTAMP_FILE, "2026-07-04T00:00:00+00:00")
+        changes = b"2026/cve-2026-0003.json,2026-07-04T06:00:00+00:00\n2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
+        requested: list[str] = []
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                CHANGES_URL: changes,
+                f"{FEED_BASE}/2026/cve-2026-0003.json": b"{}",
+            },
+            requested,
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert f"{FEED_BASE}/2026/cve-2026-0003.json" in requested
+        assert f"{FEED_BASE}/2026/cve-2026-0002.json" not in requested
+
+    def test_watermark_not_advanced_when_a_download_fails(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        changes = b"2026/cve-2026-0003.json,2026-07-04T06:00:00+00:00\n2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                CHANGES_URL: changes,
+                f"{FEED_BASE}/2026/cve-2026-0003.json": b"{}",
+                f"{FEED_BASE}/2026/cve-2026-0002.json": RuntimeError("boom"),
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert not os.path.exists(os.path.join(ws.input_path, csaf_client.CHANGES_TIMESTAMP_FILE))
+
+    def test_archive_refresh_resets_watermark(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
+        # a stale watermark newer than the fresh archive must not mask changes since that archive
+        write_input(ws, csaf_client.CHANGES_TIMESTAMP_FILE, "2026-07-04T00:00:00+00:00")
+        changes = b"2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+                CHANGES_URL: changes,
+                f"{FEED_BASE}/2026/cve-2026-0002.json": b"{}",
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0002.json"))
+        with open(os.path.join(ws.input_path, csaf_client.CHANGES_TIMESTAMP_FILE)) as fh:
+            assert datetime.fromisoformat(fh.read().strip()) == datetime.fromisoformat("2026-07-03T12:00:00+00:00")
+
+    def test_archive_refresh_replaces_advisory_tree(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
+        write_input(ws, "advisories/2025/cve-2025-0001.json", "{}")
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+        assert not os.path.exists(advisory_path(ws, "2025/cve-2025-0001.json"))
+
+    def test_deletions_remove_files(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
+        write_input(ws, "advisories/2026/cve-2026-0009.json", "{}")
+        serve(
+            monkeypatch,
+            {
+                **BASE_RESPONSES,
+                DELETIONS_URL: b"2026/cve-2026-0009.json\n",
+            },
+        )
+        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+
+        make_client(ws)
+
+        assert not os.path.exists(advisory_path(ws, "2026/cve-2026-0009.json"))

--- a/tests/unit/utils/test_archive.py
+++ b/tests/unit/utils/test_archive.py
@@ -53,6 +53,29 @@ def test_extract_tar_zst():
             assert (Path(extract_dir) / "test_file.txt").read_text() == "Test content"
 
 
+def test_extract_tar_zst_nested_paths():
+    # exercise the streaming decompression path with nested directories
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        src_dir = Path(tmp_dir) / "src" / "2026"
+        src_dir.mkdir(parents=True)
+        (src_dir / "cve-2026-0001.json").write_text("{}")
+        (src_dir / "cve-2026-0002.json").write_text('{"a": 1}')
+
+        tar_path = Path(tmp_dir) / "advisories.tar"
+        zst_path = Path(tmp_dir) / "advisories.tar.zst"
+        with tarfile.open(tar_path, "w") as tar:
+            tar.add(Path(tmp_dir) / "src", arcname=".")
+        with open(tar_path, "rb") as tar, open(zst_path, "wb") as zst:
+            cctx = zstandard.ZstdCompressor()
+            cctx.copy_stream(tar, zst)
+
+        extract_dir = Path(tmp_dir) / "out"
+        archive.extract(str(zst_path), str(extract_dir))
+
+        assert (extract_dir / "2026" / "cve-2026-0001.json").read_text() == "{}"
+        assert (extract_dir / "2026" / "cve-2026-0002.json").read_text() == '{"a": 1}'
+
+
 @patch("vunnel.utils.archive._extract_tar_zst")
 @patch("vunnel.utils.archive._safe_extract_tar")
 @patch("tarfile.open")


### PR DESCRIPTION
Fix some disk space issues with hummingbird provider. Previously, the hummingbird provider allowed old archives to accumulate in the input directory, decompressed the whole .tar.zst archive to disk before extracting, and only used the changes.csv as a coarse "before or after the last big download" gate. Instead, clean up old archives on start up, untar directly from the zstd decompression stream, and keep track of the last run, only re-fetching VEX files that have changed since the last time they were fetched.