### PR TITLE
fix(hummingbird): go back to stateless download in hummingbird provider

### DIFF
--- a/src/vunnel/providers/hummingbird/__init__.py
+++ b/src/vunnel/providers/hummingbird/__init__.py
@@ -57,7 +57,7 @@ class Provider(provider.Provider):
 
     @classmethod
     def tags(cls) -> list[str]:
-        return ["vulnerability", "os"]
+        return ["vulnerability", "os", "large"]
 
     def update(self, last_updated: datetime.datetime | None) -> tuple[list[str], int]:
         with timer(self.name(), self.logger):

--- a/src/vunnel/providers/hummingbird/csaf_client.py
+++ b/src/vunnel/providers/hummingbird/csaf_client.py
@@ -9,8 +9,6 @@ import shutil
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-import requests
-
 from vunnel.utils import http_wrapper as http
 from vunnel.utils.archive import extract
 
@@ -21,10 +19,12 @@ if TYPE_CHECKING:
 
 VEX_FEED_LATEST_URL = "https://security.access.redhat.com/data/csaf/v2/vex-feed/archive_latest.txt"
 
-TIMESTAMP_FILE = "archive_timestamp.txt"
-CHANGES_TIMESTAMP_FILE = "changes_timestamp.txt"
-
 ARCHIVE_SUFFIXES = (".tar", ".tar.zst", ".tar.gz", ".tar.xz", ".tar.bz2")
+
+# state files written by a previous incremental version of this client; they are
+# meaningless now that every run downloads the archive, but would otherwise
+# persist in the workspace (and any cached copies of it) forever
+LEGACY_STATE_FILES = ("archive_timestamp.txt", "changes_timestamp.txt")
 
 
 class CSAFVEXClient:
@@ -47,7 +47,6 @@ class CSAFVEXClient:
         if not skip_download:
             self._sync()
         else:
-            self._load_timestamp()
             self.logger.info("skipping downloads in hummingbird CSAF VEX client")
 
     @staticmethod
@@ -79,46 +78,11 @@ class CSAFVEXClient:
 
     # ── local paths ───────────────────────────────────────────────────
 
-    def _timestamp_path(self) -> str:
-        return os.path.join(self.workspace.input_path, TIMESTAMP_FILE)
-
-    def _changes_timestamp_path(self) -> str:
-        return os.path.join(self.workspace.input_path, CHANGES_TIMESTAMP_FILE)
-
     def _local_changes_path(self) -> str:
         return os.path.join(self.workspace.input_path, "changes.csv")
 
     def _local_deletions_path(self) -> str:
         return os.path.join(self.workspace.input_path, "deletions.csv")
-
-    # ── timestamp persistence ─────────────────────────────────────────
-
-    def _load_timestamp(self) -> None:
-        ts_path = self._timestamp_path()
-        if os.path.exists(ts_path):
-            with open(ts_path) as fh:
-                self.archive_mod_time = datetime.fromisoformat(fh.read().strip())
-            self.logger.debug(f"loaded archive timestamp: {self.archive_mod_time}")
-
-    def _save_timestamp(self, mod_time: datetime) -> None:
-        self.archive_mod_time = mod_time
-        with open(self._timestamp_path(), "w") as fh:
-            fh.write(mod_time.isoformat())
-
-    def _load_changes_timestamp(self) -> datetime | None:
-        ts_path = self._changes_timestamp_path()
-        if os.path.exists(ts_path):
-            with open(ts_path) as fh:
-                return datetime.fromisoformat(fh.read().strip())
-        return None
-
-    def _save_changes_timestamp(self, mod_time: datetime) -> None:
-        with open(self._changes_timestamp_path(), "w") as fh:
-            fh.write(mod_time.isoformat())
-
-    def _clear_changes_timestamp(self) -> None:
-        with contextlib.suppress(FileNotFoundError):
-            os.remove(self._changes_timestamp_path())
 
     # ── download helpers ──────────────────────────────────────────────
 
@@ -133,41 +97,18 @@ class CSAFVEXClient:
             return email.utils.parsedate_to_datetime(lm)
         return None
 
-    def _head_last_modified(self, url: str) -> datetime | None:
-        """HEAD the URL and return Last-Modified as a tz-aware datetime, or None."""
-        resp = requests.head(url, timeout=30)
-        resp.raise_for_status()
-        lm = resp.headers.get("Last-Modified")
-        if lm:
-            return email.utils.parsedate_to_datetime(lm)
-        return None
-
     # ── core sync logic ───────────────────────────────────────────────
 
     def _sync(self) -> None:
         os.makedirs(self.advisories_path, exist_ok=True)
         self._remove_stray_files()
 
-        archive_url = self._archive_url()
-        self._load_timestamp()
+        # stateless flow: every run downloads and extracts the archive, then
+        # re-applies everything that changed since the archive was baked. this
+        # trades some redundant downloading for having no persisted state that
+        # can disagree with what is actually on disk.
+        self._download_archive(self._archive_url())
 
-        # decide whether we need to (re-)download the archive
-        need_download = False
-        if self.archive_mod_time is None:
-            self.logger.info("no local timestamp found - downloading archive")
-            need_download = True
-        else:
-            remote_mod = self._head_last_modified(archive_url)
-            if remote_mod and remote_mod > self.archive_mod_time:
-                self.logger.info(f"remote archive is newer ({remote_mod}) than local ({self.archive_mod_time}) - re-downloading")
-                need_download = True
-            else:
-                self.logger.info("archive is up to date")
-
-        if need_download:
-            self._download_archive(archive_url)
-
-        # always apply incremental updates
         self._download_stream(self._changes_url(), self._local_changes_path())
         self._download_stream(self._deletions_url(), self._local_deletions_path())
         self._process_changes_and_deletions()
@@ -186,6 +127,10 @@ class CSAFVEXClient:
                 with contextlib.suppress(OSError):
                     os.remove(os.path.join(self.workspace.input_path, name))
 
+        for name in LEGACY_STATE_FILES:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(os.path.join(self.workspace.input_path, name))
+
     def _advisories_tmp_path(self) -> str:
         return self.advisories_path + ".tmp"
 
@@ -197,19 +142,18 @@ class CSAFVEXClient:
         try:
             remote_mod = self._download_stream(archive_url, archive_path)
 
-            # extract to a temp dir and swap so a failed extraction can't
-            # destroy the existing advisories tree
+            # the downloaded archive supersedes the existing advisories tree, so
+            # remove the tree before extracting to keep peak disk usage at one
+            # tree plus the archive (instead of two trees plus the archive)
+            if os.path.isdir(self.advisories_path):
+                shutil.rmtree(self.advisories_path)
+
             self.logger.info("extracting archive")
             tmp_dir = self._advisories_tmp_path()
             extract(archive_path, tmp_dir)
-
-            if os.path.isdir(self.advisories_path):
-                shutil.rmtree(self.advisories_path)
             os.rename(tmp_dir, self.advisories_path)
 
-            self._save_timestamp(remote_mod or datetime.now(tz=UTC))
-            # the new tree supersedes any previously applied changes
-            self._clear_changes_timestamp()
+            self.archive_mod_time = remote_mod or datetime.now(tz=UTC)
         finally:
             # always clean up the archive file to save disk space
             with contextlib.suppress(OSError):
@@ -218,7 +162,7 @@ class CSAFVEXClient:
     def _process_changes_and_deletions(self) -> None:
         self._apply_deletions()
 
-        seen_files, years, newest_change = self._collect_pending_changes()
+        seen_files, years = self._collect_pending_changes()
 
         if not seen_files:
             self.logger.info("no changed files newer than archive")
@@ -229,11 +173,7 @@ class CSAFVEXClient:
         for year in years:
             os.makedirs(os.path.join(self.advisories_path, year), exist_ok=True)
 
-        any_failed = self._download_changed_files(seen_files)
-
-        # only advance the watermark when everything landed, so failed files are retried next run
-        if not any_failed and newest_change:
-            self._save_changes_timestamp(newest_change)
+        self._download_changed_files(seen_files)
 
     def _apply_deletions(self) -> None:
         with open(self._local_deletions_path(), newline="") as fh:
@@ -243,37 +183,24 @@ class CSAFVEXClient:
                 with contextlib.suppress(FileNotFoundError):
                     os.remove(os.path.join(self.advisories_path, deleted_fragment))
 
-    def _collect_pending_changes(self) -> tuple[set[str], set[str], datetime | None]:
-        """Read changes.csv (newest first) and return (files, years, newest change date) not yet applied."""
-        # skip changes already applied by a previous run (the watermark), falling
-        # back to the archive timestamp when no changes have been applied yet
-        watermark = self.archive_mod_time
-        changes_applied = self._load_changes_timestamp()
-        if changes_applied and (watermark is None or changes_applied > watermark):
-            watermark = changes_applied
-
+    def _collect_pending_changes(self) -> tuple[set[str], set[str]]:
+        """Read changes.csv (newest first) and return (files, years) for entries newer than the archive."""
         seen_files: set[str] = set()
         years: set[str] = set()
-        newest_change: datetime | None = None
         with open(self._local_changes_path(), newline="") as fh:
             reader = csv.reader(fh)
             for row in reader:
                 changed_file = row[0]
-                date_str = row[1]
-                change_date = datetime.fromisoformat(date_str)
-                if watermark and change_date < watermark:
+                change_date = datetime.fromisoformat(row[1])
+                if self.archive_mod_time and change_date < self.archive_mod_time:
                     break
-                if newest_change is None or change_date > newest_change:
-                    newest_change = change_date
                 seen_files.add(changed_file)
-                year = changed_file.split("/")[0]
-                years.add(year)
+                years.add(changed_file.split("/")[0])
 
-        return seen_files, years, newest_change
+        return seen_files, years
 
-    def _download_changed_files(self, seen_files: set[str]) -> bool:
-        """Download the given advisory fragments in parallel, returning True if any failed."""
-        any_failed = False
+    def _download_changed_files(self, seen_files: set[str]) -> None:
+        """Download the given advisory fragments in parallel; failures are logged and retried next run."""
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures = {
                 executor.submit(
@@ -286,6 +213,4 @@ class CSAFVEXClient:
             concurrent.futures.wait(futures.keys())
             for future, changed_file in futures.items():
                 if future.exception() is not None:
-                    any_failed = True
                     self.logger.warning(f"failed to download {changed_file}: {future.exception()}")
-        return any_failed

--- a/tests/unit/providers/hummingbird/test_csaf_client.py
+++ b/tests/unit/providers/hummingbird/test_csaf_client.py
@@ -77,23 +77,6 @@ def serve(monkeypatch, responses: dict, requested: list[str] | None = None) -> N
     monkeypatch.setattr(csaf_client.http, "get", fake_get)
 
 
-def serve_head(monkeypatch, last_modified: str | None) -> None:
-    class HeadResponse:
-        headers = {"Last-Modified": last_modified} if last_modified else {}
-
-        def raise_for_status(self):
-            pass
-
-    monkeypatch.setattr(csaf_client.requests, "head", lambda *a, **k: HeadResponse())
-
-
-def forbid_head(monkeypatch) -> None:
-    def fail(*a, **k):
-        raise AssertionError("unexpected HEAD request")
-
-    monkeypatch.setattr(csaf_client.requests, "head", fail)
-
-
 def make_client(workspace: FakeWorkspace) -> CSAFVEXClient:
     return CSAFVEXClient(workspace=workspace, logger=logging.getLogger("test"), latest_url=FEED_URL)
 
@@ -110,289 +93,167 @@ def advisory_path(workspace: FakeWorkspace, fragment: str) -> str:
     return os.path.join(workspace.input_path, "advisories", fragment)
 
 
-BASE_RESPONSES = {
-    FEED_URL: ARCHIVE_NAME.encode(),
-    CHANGES_URL: b"",
-    DELETIONS_URL: b"",
-}
+def base_responses(archive_files: dict[str, str] | None = None) -> dict:
+    if archive_files is None:
+        archive_files = {"2026/cve-2026-0001.json": "{}"}
+    return {
+        FEED_URL: ARCHIVE_NAME.encode(),
+        ARCHIVE_URL: (tar_zst_bytes(archive_files), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
+        CHANGES_URL: b"",
+        DELETIONS_URL: b"",
+    }
 
 
 class TestArchiveDownload:
-    def test_first_run_downloads_and_extracts(self, tmp_path, monkeypatch):
+    def test_downloads_and_extracts(self, tmp_path, monkeypatch):
         ws = FakeWorkspace(tmp_path)
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-            },
-        )
-        forbid_head(monkeypatch)  # no local timestamp means no staleness check is needed
+        serve(monkeypatch, base_responses())
 
         client = make_client(ws)
 
         assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
         assert client.archive_mod_time == ARCHIVE_MOD_TIME
 
-    def test_timestamp_comes_from_get_response(self, tmp_path, monkeypatch):
+    def test_archive_downloaded_every_run(self, tmp_path, monkeypatch):
+        # stateless: even with a fully populated advisories tree the archive is
+        # always re-downloaded and the tree is rebuilt from it
         ws = FakeWorkspace(tmp_path)
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-            },
-        )
-        forbid_head(monkeypatch)
+        write_input(ws, "advisories/2025/cve-2025-0001.json", "{}")
+        requested: list[str] = []
+        serve(monkeypatch, base_responses(), requested)
 
         make_client(ws)
 
-        with open(os.path.join(ws.input_path, csaf_client.TIMESTAMP_FILE)) as fh:
-            assert datetime.fromisoformat(fh.read().strip()) == ARCHIVE_MOD_TIME
+        assert ARCHIVE_URL in requested
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+        assert not os.path.exists(advisory_path(ws, "2025/cve-2025-0001.json"))
 
     def test_archive_file_removed_after_extraction(self, tmp_path, monkeypatch):
         ws = FakeWorkspace(tmp_path)
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-            },
-        )
-        forbid_head(monkeypatch)
+        serve(monkeypatch, base_responses())
 
         make_client(ws)
 
         assert not os.path.exists(os.path.join(ws.input_path, ARCHIVE_NAME))
 
-    def test_up_to_date_archive_not_downloaded(self, tmp_path, monkeypatch):
+    def test_no_state_files_written(self, tmp_path, monkeypatch):
         ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
-        requested: list[str] = []
-        serve(monkeypatch, BASE_RESPONSES, requested)
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+        serve(monkeypatch, base_responses())
 
         make_client(ws)
 
-        assert ARCHIVE_URL not in requested
-        assert CHANGES_URL in requested
-        assert DELETIONS_URL in requested
-
-    def test_newer_remote_archive_is_downloaded(self, tmp_path, monkeypatch):
-        ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
-
-        client = make_client(ws)
-
-        assert client.archive_mod_time == ARCHIVE_MOD_TIME
-        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+        for name in csaf_client.LEGACY_STATE_FILES:
+            assert not os.path.exists(os.path.join(ws.input_path, name))
 
 
 class TestFailureCleanup:
     def test_archive_removed_when_extraction_fails(self, tmp_path, monkeypatch):
         ws = FakeWorkspace(tmp_path)
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (b"not a zst archive", {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-            },
-        )
-        forbid_head(monkeypatch)
+        responses = base_responses()
+        responses[ARCHIVE_URL] = (b"not a zst archive", {"Last-Modified": ARCHIVE_LAST_MODIFIED})
+        serve(monkeypatch, responses)
 
         with pytest.raises(Exception):
             make_client(ws)
 
         assert not os.path.exists(os.path.join(ws.input_path, ARCHIVE_NAME))
-        assert not os.path.exists(os.path.join(ws.input_path, csaf_client.TIMESTAMP_FILE))
 
-    def test_failed_extraction_preserves_existing_advisories(self, tmp_path, monkeypatch):
+    def test_failed_extraction_recovers_on_next_run(self, tmp_path, monkeypatch):
+        # a failed extraction may leave no advisories tree behind, but the next
+        # run re-downloads the archive unconditionally and rebuilds it
         ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
         write_input(ws, "advisories/2025/cve-2025-0001.json", "{}")
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (b"not a zst archive", {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+        responses = base_responses()
+        responses[ARCHIVE_URL] = (b"not a zst archive", {"Last-Modified": ARCHIVE_LAST_MODIFIED})
+        serve(monkeypatch, responses)
 
         with pytest.raises(Exception):
             make_client(ws)
 
-        assert os.path.exists(advisory_path(ws, "2025/cve-2025-0001.json"))
+        serve(monkeypatch, base_responses())
+
+        client = make_client(ws)
+
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
+        assert client.archive_mod_time == ARCHIVE_MOD_TIME
 
 
 class TestStrayFileCleanup:
     def test_stray_archives_and_partial_extractions_removed(self, tmp_path, monkeypatch):
         ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
         write_input(ws, "leaked-archive.tar.zst", "stale bytes")
         write_input(ws, "advisories.tmp/2026/cve-2026-0001.json", "{}")
-        serve(monkeypatch, BASE_RESPONSES)
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+        serve(monkeypatch, base_responses())
 
         make_client(ws)
 
         assert not os.path.exists(os.path.join(ws.input_path, "leaked-archive.tar.zst"))
         assert not os.path.exists(os.path.join(ws.input_path, "advisories.tmp"))
 
-    def test_stray_cleanup_keeps_other_input_files(self, tmp_path, monkeypatch):
+    def test_legacy_state_files_removed(self, tmp_path, monkeypatch):
+        # timestamp files from the previous incremental flow linger in cached
+        # workspaces; they must be scrubbed so they don't persist forever
         ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
-        write_input(ws, "advisories/2026/cve-2026-0001.json", "{}")
-        serve(monkeypatch, BASE_RESPONSES)
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+        for name in csaf_client.LEGACY_STATE_FILES:
+            write_input(ws, name, "2026-06-01T00:00:00+00:00")
+        serve(monkeypatch, base_responses())
 
         make_client(ws)
 
-        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
-        assert os.path.exists(os.path.join(ws.input_path, csaf_client.TIMESTAMP_FILE))
+        for name in csaf_client.LEGACY_STATE_FILES:
+            assert not os.path.exists(os.path.join(ws.input_path, name))
 
 
 class TestChangesAndDeletions:
     def test_changes_newer_than_archive_downloaded(self, tmp_path, monkeypatch):
         ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
         changes = b"2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n2026/cve-2026-0001.json,2026-07-01T00:00:00+00:00\n"
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                CHANGES_URL: changes,
-                f"{FEED_BASE}/2026/cve-2026-0002.json": b"{}",
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
-
-        make_client(ws)
-
-        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0002.json"))
-        assert not os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
-
-    def test_watermark_saved_after_changes_applied(self, tmp_path, monkeypatch):
-        ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
-        changes = b"2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                CHANGES_URL: changes,
-                f"{FEED_BASE}/2026/cve-2026-0002.json": b"{}",
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
-
-        make_client(ws)
-
-        with open(os.path.join(ws.input_path, csaf_client.CHANGES_TIMESTAMP_FILE)) as fh:
-            assert datetime.fromisoformat(fh.read().strip()) == datetime.fromisoformat("2026-07-03T12:00:00+00:00")
-
-    def test_watermark_skips_already_applied_changes(self, tmp_path, monkeypatch):
-        ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
-        write_input(ws, csaf_client.CHANGES_TIMESTAMP_FILE, "2026-07-04T00:00:00+00:00")
-        changes = b"2026/cve-2026-0003.json,2026-07-04T06:00:00+00:00\n2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
+        responses = base_responses(archive_files={"2026/cve-2026-9999.json": "{}"})
+        responses[CHANGES_URL] = changes
+        responses[f"{FEED_BASE}/2026/cve-2026-0002.json"] = b"{}"
         requested: list[str] = []
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                CHANGES_URL: changes,
-                f"{FEED_BASE}/2026/cve-2026-0003.json": b"{}",
-            },
-            requested,
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
-
-        make_client(ws)
-
-        assert f"{FEED_BASE}/2026/cve-2026-0003.json" in requested
-        assert f"{FEED_BASE}/2026/cve-2026-0002.json" not in requested
-
-    def test_watermark_not_advanced_when_a_download_fails(self, tmp_path, monkeypatch):
-        ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
-        changes = b"2026/cve-2026-0003.json,2026-07-04T06:00:00+00:00\n2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                CHANGES_URL: changes,
-                f"{FEED_BASE}/2026/cve-2026-0003.json": b"{}",
-                f"{FEED_BASE}/2026/cve-2026-0002.json": RuntimeError("boom"),
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
-
-        make_client(ws)
-
-        assert not os.path.exists(os.path.join(ws.input_path, csaf_client.CHANGES_TIMESTAMP_FILE))
-
-    def test_archive_refresh_resets_watermark(self, tmp_path, monkeypatch):
-        ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
-        # a stale watermark newer than the fresh archive must not mask changes since that archive
-        write_input(ws, csaf_client.CHANGES_TIMESTAMP_FILE, "2026-07-04T00:00:00+00:00")
-        changes = b"2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-                CHANGES_URL: changes,
-                f"{FEED_BASE}/2026/cve-2026-0002.json": b"{}",
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+        serve(monkeypatch, responses, requested)
 
         make_client(ws)
 
         assert os.path.exists(advisory_path(ws, "2026/cve-2026-0002.json"))
-        with open(os.path.join(ws.input_path, csaf_client.CHANGES_TIMESTAMP_FILE)) as fh:
-            assert datetime.fromisoformat(fh.read().strip()) == datetime.fromisoformat("2026-07-03T12:00:00+00:00")
+        assert f"{FEED_BASE}/2026/cve-2026-0001.json" not in requested
 
-    def test_archive_refresh_replaces_advisory_tree(self, tmp_path, monkeypatch):
+    def test_changes_reapplied_every_run(self, tmp_path, monkeypatch):
+        # stateless: there is no watermark, so all changes since the archive was
+        # baked are re-downloaded on every run
         ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, "2026-06-01T00:00:00+00:00")
-        write_input(ws, "advisories/2025/cve-2025-0001.json", "{}")
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                ARCHIVE_URL: (tar_zst_bytes({"2026/cve-2026-0001.json": "{}"}), {"Last-Modified": ARCHIVE_LAST_MODIFIED}),
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+        changes = b"2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
+        responses = base_responses(archive_files={"2026/cve-2026-9999.json": "{}"})
+        responses[CHANGES_URL] = changes
+        responses[f"{FEED_BASE}/2026/cve-2026-0002.json"] = b"{}"
+        requested: list[str] = []
+        serve(monkeypatch, responses, requested)
+
+        make_client(ws)
+        make_client(ws)
+
+        assert requested.count(f"{FEED_BASE}/2026/cve-2026-0002.json") == 2
+
+    def test_failed_change_download_does_not_fail_run(self, tmp_path, monkeypatch):
+        ws = FakeWorkspace(tmp_path)
+        changes = b"2026/cve-2026-0003.json,2026-07-04T06:00:00+00:00\n2026/cve-2026-0002.json,2026-07-03T12:00:00+00:00\n"
+        responses = base_responses(archive_files={"2026/cve-2026-9999.json": "{}"})
+        responses[CHANGES_URL] = changes
+        responses[f"{FEED_BASE}/2026/cve-2026-0003.json"] = b"{}"
+        responses[f"{FEED_BASE}/2026/cve-2026-0002.json"] = RuntimeError("boom")
+        serve(monkeypatch, responses)
 
         make_client(ws)
 
-        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0001.json"))
-        assert not os.path.exists(advisory_path(ws, "2025/cve-2025-0001.json"))
+        assert os.path.exists(advisory_path(ws, "2026/cve-2026-0003.json"))
+        assert not os.path.exists(advisory_path(ws, "2026/cve-2026-0002.json"))
 
     def test_deletions_remove_files(self, tmp_path, monkeypatch):
         ws = FakeWorkspace(tmp_path)
-        write_input(ws, csaf_client.TIMESTAMP_FILE, ARCHIVE_MOD_TIME.isoformat())
-        write_input(ws, "advisories/2026/cve-2026-0009.json", "{}")
-        serve(
-            monkeypatch,
-            {
-                **BASE_RESPONSES,
-                DELETIONS_URL: b"2026/cve-2026-0009.json\n",
-            },
-        )
-        serve_head(monkeypatch, ARCHIVE_LAST_MODIFIED)
+        responses = base_responses(archive_files={"2026/cve-2026-0009.json": "{}"})
+        responses[DELETIONS_URL] = b"2026/cve-2026-0009.json\n"
+        serve(monkeypatch, responses)
 
         make_client(ws)
 


### PR DESCRIPTION
Previous work attempted to make the hummingbird provider a little bit faster by more caching in the input directory, but this has possible failure modes and raises the disk space requirements. Instead, just always recreate the input directory by downloading the archive and then following changes.csv and deletions.txt for information about what needs to change after the archive.

Additionally, unlink the archive extraction dir before re-extracting to prevent disk space exhaustion, and tag vunnel as "large" to give it a bit more space.