### PR TITLE
chore(quality-gate): pass config file path

### DIFF
--- a/tests/quality/configure.py
+++ b/tests/quality/configure.py
@@ -738,7 +738,7 @@ def build_db(cfg: Config):
                     logging.warning(f"failed to fetch cache for {provider!r}, retrying: {e}")
                 else:
                     raise
-        subprocess.run([GRYPE_DB, "cache", "restore", "--path", cache_file], check=True)
+        subprocess.run([GRYPE_DB, "cache", "restore", "--path", cache_file, "-c", ".grype-db.yaml"], check=True)
         os.remove(cache_file)
 
     # run providers


### PR DESCRIPTION
Otherwise, when running in a development shell, which sets GRYPE_DB_CONFIG in the environment, the config file pointed to by that environment variable can override the one written by the quality gate and cause unexpected test behavior.