### PR TITLE
fix: guard None reference links in wolfi/chainguard secdb parser

### DIFF
--- a/src/vunnel/providers/wolfi/parser.py
+++ b/src/vunnel/providers/wolfi/parser.py
@@ -67,7 +67,12 @@ class Parser(abc.ABC):
     def build_reference_links(self, vulnerability_id: str) -> list[str]:
         urls = []
         urls.append(f"{self.security_reference_url}/{vulnerability_id}")
-        urls.extend(vulnerability.build_reference_links(vulnerability_id))
+        # build_reference_links returns None for IDs it does not recognize
+        # (anything not CVE-/GHSA- prefixed, e.g. GO- IDs); guard it the same
+        # way the minimos provider does so such IDs import without crashing.
+        links = vulnerability.build_reference_links(vulnerability_id)
+        if links:
+            urls.extend(links)
         return urls
 
     @abc.abstractmethod

--- a/tests/unit/providers/wolfi/test_wolfi.py
+++ b/tests/unit/providers/wolfi/test_wolfi.py
@@ -126,7 +126,7 @@ class TestParser:
                 {
                     "pkg": {
                         "name": "coreutils",
-                        "secfixes": {"0": ["CVE-2016-2781"]},
+                        "secfixes": {"0": ["CVE-2016-2781", "GO-2026-5932"]},
                     },
                 },
                 {
@@ -217,8 +217,28 @@ class TestParser:
                 "CVE-2023-45283",
                 "CVE-2023-45284",
                 "GHSA-jq35-85cj-fj4p",
+                "GO-2026-5932",
             ],
         )
+
+    def test_build_reference_links_unknown_id_scheme(self, tmpdir):
+        # IDs without CVE-/GHSA- prefixes (e.g. GO- IDs, as published in the
+        # minimos and wolfi secdbs) have no generic reference links; the parser
+        # must fall back to just the distro security page instead of crashing.
+        p = SecDBParser(
+            workspace=workspace.Workspace(tmpdir, "test", create=True),
+            url="https://packages.wolfi.dev/os/security.json",
+            namespace="wolfi",
+        )
+
+        assert p.build_reference_links("GO-2026-5932") == [
+            f"{p.security_reference_url}/GO-2026-5932",
+        ]
+        assert p.build_reference_links("CVE-2016-2781") == [
+            f"{p.security_reference_url}/CVE-2016-2781",
+            "https://www.cve.org/CVERecord?id=CVE-2016-2781",
+            "https://nvd.nist.gov/vuln/detail/CVE-2016-2781",
+        ]
 
 
 def test_provider_schema(helpers, disable_get_requests, auto_fake_fixdate_finder):


### PR DESCRIPTION
Fixes the `wolfi` and `chainguard` providers crashing with `TypeError: 'NoneType' object is not iterable` when a secdb `secfixes` list contains a vulnerability ID that is not `CVE-` or `GHSA-` prefixed (for example Go vulnerability database IDs such as `GO-2026-5932`).

`vunnel.utils.vulnerability.build_reference_links()` returns `None` for ID schemes it does not recognize, and the wolfi parser (shared by the `chainguard` provider) called `urls.extend(...)` on that value without a guard. The `minimos` provider already guards the identical call, which is why the minimos secdb's `GO-` IDs import cleanly today while the same input shape crashes wolfi/chainguard. This change applies the same guard, so unknown ID schemes fall back to just the distro security page link.

Tests:
- New unit test for `build_reference_links` covering an unrecognized scheme (`GO-`) and the existing `CVE-` behavior.
- Added a `GO-` ID to the `_normalize` fixture so the end-to-end secdb parse covers a mixed CVE/GHSA/GO secfixes list (this reproduces the crash without the fix).

Fixes #1263
