### PR TITLE
fix(rhel): drop unused skip_if_exists parameter from _sync_cves

### DIFF
--- a/src/vunnel/providers/rhel/parser.py
+++ b/src/vunnel/providers/rhel/parser.py
@@ -208,8 +208,12 @@ class Parser:
                 with open(os.path.join(dir_path, file), encoding="utf-8") as fp:
                     yield orjson.loads(fp.read())
 
-    # TODO: ALEX, should skip_if_exists be hooked up here? (currently unused)
-    def _sync_cves(self, skip_if_exists=False, do_full_sync=True):  # noqa: PLR0915, PLR0912, C901
+    # note: this intentionally does not take skip_if_exists. Skipping a CVE purely because a file
+    # is already on disk would drop upstream updates; instead _process_minimal_cve() compares the
+    # minimal CVE from the API against the copy on disk and only downloads the full CVE when the
+    # two differ (or when either file is missing), which avoids the same round trips without
+    # sacrificing correctness.
+    def _sync_cves(self, do_full_sync=True):  # noqa: PLR0915, PLR0912, C901
         """
         Download minimal or summary cve and compare it to persisted state on disk. If no persisted state is found or a
         a change is detected, full cve is downloaded
@@ -1048,7 +1052,7 @@ class Parser:
             full_dir = os.path.join(self.cve_dir_path, self.__full_dir_name__)
             if not self.skip_download:
                 # download cves
-                self._sync_cves(skip_if_exists)
+                self._sync_cves()
 
             # normalize cve files
             self.logger.debug(f"normalizing CVEs from {full_dir}")


### PR DESCRIPTION
Closes #17

## Answering the TODO

`_sync_cves()` carried `# TODO: ALEX, should skip_if_exists be hooked up here? (currently unused)`. This proposes the answer "no", and removes the unused parameter instead.

Honoring `skip_if_exists` here would mean skipping a CVE because a file already exists on disk, which silently drops upstream updates for every CVE already fetched once.

The round trips it was meant to save are already avoided in a safe way: `_process_minimal_cve()` compares the minimal CVE returned by the API with the copy on disk and only downloads the full CVE when the two differ, or when either the minimal or full file is missing. That is strictly better — it skips the same downloads without ever missing a change.

## Change

- drop the unused `skip_if_exists` parameter from `_sync_cves()` and its single call site in `get()`
- replace the TODO with a comment explaining why the flag does not apply here

`skip_if_exists` remains honored where it does have meaning: `get()` still receives it from `config.runtime.skip_if_exists` and passes it to `_init_rhsa_data()`.

No behavior change — the parameter was never read.

Happy to flip this the other way and wire the flag up instead if you'd prefer that semantics.
