### PR TITLE
Skip Amazon RSS items whose title does not parse

### DIFF
--- a/src/vunnel/providers/amazon/parser.py
+++ b/src/vunnel/providers/amazon/parser.py
@@ -83,6 +83,18 @@ class Parser:
             self.logger.exception("error downloading amazon linux vulnerability feeds")
             raise
 
+    def _parse_title(self, text: str | None) -> tuple[str | None, str | None]:
+        """Return the (ALAS id, severity) pair from an RSS item title, or (None, None)
+        when the title does not have the expected shape. A single malformed item should
+        be dropped rather than aborting the whole feed."""
+        title = text.strip() if text else ""
+        found = re.search(self._title_pattern_, title)
+        if not found:
+            self.logger.warning(f"skipping RSS item with unexpected title: {title!r}")
+            return None, None
+
+        return found.group(1), found.group(2)
+
     def _parse_rss(self, file_path):
         self.logger.debug(f"parsing RSS data from {file_path}")
         alas_summaries = []
@@ -93,9 +105,7 @@ class Parser:
                 processing = True
             elif processing and event == "end":
                 if element.tag == "title":
-                    found = re.search(self._title_pattern_, element.text.strip())
-                    alas_id = found.group(1)
-                    sev = found.group(2)
+                    alas_id, sev = self._parse_title(element.text)
                 elif element.tag == "description":
                     desc_str = element.text.strip()
                     cves = re.sub(self._whitespace_pattern_, "", desc_str).split(",") if desc_str else []
@@ -111,7 +121,8 @@ class Parser:
             if not processing and event == "end":
                 element.clear()
 
-        return sorted(alas_summaries)
+        # items whose title did not parse carry a None id and are dropped here
+        return sorted(summary for summary in alas_summaries if summary.id)
 
     def _alas_response_handler(self, response):
         if response.status_code == 403:

--- a/tests/unit/providers/amazon/test-fixtures/mock_rss_malformed_title
+++ b/tests/unit/providers/amazon/test-fixtures/mock_rss_malformed_title
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+    <title>Amazon Linux AMI Security Bulletins</title>
+    <description>Amazon Linux AMI Security Bulletins</description>
+    <link>https://alas.aws.amazon.com</link>
+    <language>en-us</language>
+    <ttl>35</ttl>
+
+    <item>
+        <title>Amazon Linux Security Advisory</title>
+        <description>CVE-2099-0001</description>
+        <pubDate>Mon, 01 Jan 2099 00:00:00 GMT</pubDate>
+        <link>https://alas.aws.amazon.com/ALAS-2099-0001.html</link>
+    </item>
+
+    <item>
+        <title></title>
+        <description>CVE-2099-0002</description>
+        <pubDate>Mon, 01 Jan 2099 00:00:00 GMT</pubDate>
+        <link>https://alas.aws.amazon.com/ALAS-2099-0002.html</link>
+    </item>
+
+    <item>
+        <title>ALAS-2099-1000 (medium): openssl</title>
+        <description>CVE-2099-1000</description>
+        <pubDate>Mon, 01 Jan 2099 00:00:00 GMT</pubDate>
+        <link>https://alas.aws.amazon.com/ALAS-2099-1000.html</link>
+    </item>
+
+</channel>
+</rss>

--- a/tests/unit/providers/amazon/test_amazon.py
+++ b/tests/unit/providers/amazon/test_amazon.py
@@ -26,6 +26,15 @@ class TestParser:
 
         # TODO: beef up these assertions (should cover the full data shape)
 
+    def test_rss_parsing_skips_malformed_titles(self, tmpdir, helpers):
+        # a single item whose title does not match the ALAS pattern used to raise
+        # AttributeError on the None match and abort the whole Amazon feed
+        mock_data_path = helpers.local_dir("test-fixtures/mock_rss_malformed_title")
+        p = parser.Parser(workspace=workspace.Workspace(tmpdir, "test", create=True))
+        summaries = p._parse_rss(mock_data_path)
+
+        assert [alas.id for alas in summaries] == ["ALAS-2099-1000"]
+
     def test_html_parsing(self, helpers):
         new_packages = [
             "java-1.8.0-openjdk-javadoc-1.8.0.161-0.b14.amzn2.noarch",


### PR DESCRIPTION
`Parser._parse_rss` reads each RSS item title like this:

```python
found = re.search(self._title_pattern_, element.text.strip())
alas_id = found.group(1)
sev = found.group(2)
```

Neither the match nor `element.text` is checked. A title that does not carry the `ALAS-... (severity):` shape gives `found is None` and raises `AttributeError: 'NoneType' object has no attribute 'group'`, and an empty `<title></title>` raises on `.strip()` of `None` before that.

What makes it worth fixing is where it happens. Parsing runs before any advisory is yielded, and nothing wraps the loop, so the exception propagates out through `_get` and `get` and takes down the entire provider run. One malformed item means the whole Amazon Linux namespace (AL1, AL2, AL2023) is missing from that build rather than one advisory being dropped. The failure mode is a crash but the consequence is silent false negatives downstream.

The fix pulls the title handling into `_parse_title`, which logs and returns `(None, None)` when the title does not match, and the summary list drops those entries at the end. That matches how the mariner and sles providers already skip a record they cannot read instead of failing the run.

Test uses a small fixture feed with three items: one title that does not match the pattern, one empty title, and one valid `ALAS-2099-1000`. Before the change the test raises the `AttributeError` above; after it, only the valid advisory comes back. `pytest tests/unit/providers/amazon` is 8 passed, and the wider `tests/unit/providers` run goes from 565 to 566 passed with the same 29 pre-existing collection errors in the rhel csaf tests, which fail identically on an unmodified tree here.

I kept `_parse_rss` under the repo's complexity limit by moving the title logic out rather than adding a branch inline, so `ruff check` reports the same single pre-existing finding for this file as main does.
