### PR TITLE
fixdate: prefer first-observed over an advisory's published date

### DIFF
--- a/src/vunnel/tool/fixdate/finder.py
+++ b/src/vunnel/tool/fixdate/finder.py
@@ -142,17 +142,21 @@ class Finder:
         ecosystem: str | None = None,
         candidates: list[Result] | None = None,
     ) -> Result | None:
-        results = []
-
         ecosystem = self._normalize_ecosystem(ecosystem)
 
         if not fix_version or fix_version in ("None", "0"):
             # if we don't have a fix version, we can't determine a fix date
             return None
 
-        # add high quality candidates first
+        # split candidates by confidence. accurate candidates (e.g. a provider's real ship date)
+        # are trusted alongside strategy results; inaccurate candidates (e.g. an advisory's own
+        # `published` date, which routinely predates the fix) are a last resort only, ranked below
+        # any first-observed date.
+        accurate_candidates: list[Result] = []
+        inaccurate_candidates: list[Result] = []
         if candidates:
-            results.extend([c for c in candidates if c.accurate and c.date])
+            accurate_candidates = [c for c in candidates if c.accurate and c.date]
+            inaccurate_candidates = [c for c in candidates if not c.accurate and c.date]
 
         # Use cached database lookups
         strategy_results, first_observed_results = self._cached_find_from_strategies(
@@ -161,21 +165,20 @@ class Finder:
             fix_version,
             ecosystem,
         )
-        results.extend(strategy_results)
 
-        # add low quality candidates last
-        if candidates:
-            results.extend([c for c in candidates if not c.accurate and c.date])
+        # high-quality results, in priority order: accurate candidates, then strategies.
+        high_quality = accurate_candidates + list(strategy_results)
 
-        # we should select the date from the set of finders that is the highest quality (earlier in the s
-        # results list) but should never be after the first observed date. However, first observed dates are not always
-        # accurate, so we should only enforce this if we have an accurate first observed date (not part of the
-        # first group of observed fixes).
+        # we should select the highest-quality date (earliest in high_quality) but never one after
+        # the first observed date. First observed dates are not always accurate, so we only enforce
+        # that ceiling when we have an accurate first observed date (not part of the first group of
+        # observed fixes).
         #
         # ...If the first observed date is accurate, then follow these rules:
-        # - If a s date is after the first observed date, we should discard it.
-        # - If no s candidates are before the first observed date, we should return the first observed dates.
-        # - If there is no first observed dates, we should return the best s candidates we have.
+        # - If a high-quality date is after the first observed date, we should discard it.
+        # - If none are before the first observed date, we should return the first observed date.
+        # An inaccurate candidate is never preferred over first-observed data; it is only used when
+        # there is no first-observed date at all.
 
         accurate_first_observed = [r for r in first_observed_results if r.accurate]
 
@@ -184,17 +187,18 @@ class Finder:
             first_accurate_observed_date = accurate_first_observed[0].date
 
             if first_accurate_observed_date is not None:
-                filtered_results = [r for r in results if r.date is not None and r.date <= first_accurate_observed_date]
+                filtered_results = [r for r in high_quality if r.date is not None and r.date <= first_accurate_observed_date]
             else:
                 filtered_results = []
             if filtered_results:
-                # return the best/first valid candidates relative to the best first observed date
+                # return the best/first valid candidate relative to the best first observed date
                 return filtered_results[0]
-            # return the first observed date instead of any other candidate
+            # return the first observed date instead of any lower-confidence candidate
             return accurate_first_observed[0]
 
-        # ... If we don't have an accurate first observed date, then treat that as a last resort option
-        results.extend(first_observed_results)
+        # no accurate first observed date: prefer high-quality results, then any first-observed date,
+        # and only then fall back to inaccurate candidates (e.g. the advisory published date).
+        results = high_quality + list(first_observed_results) + inaccurate_candidates
 
         if results:
             # return the best/first candidate we have

--- a/tests/unit/tool/test_finder.py
+++ b/tests/unit/tool/test_finder.py
@@ -71,6 +71,51 @@ class TestFinder:
         assert result == low_quality
         assert result.date == datetime.date(2023, 1, 2)
 
+    def test_best_inaccurate_candidate_does_not_beat_accurate_first_observed(self):
+        """An inaccurate candidate earlier than an accurate first observed date must not win.
+
+        Regression: govulndb's only candidate is the advisory's `published` date
+        (kind="advisory", accurate=False), which routinely predates the fix. It used to be
+        preferred because it sorts before the (later, real) first-observed date; now the
+        first-observed date wins and the published date is only a last resort.
+        """
+        strategy = self.create_mock_strategy([])
+
+        # real fix ship date, observed by a later build (accurate)
+        first_observed_result = self.create_result("2026-08-13", "first_observed", accurate=True)
+        first_observed = self.create_mock_strategy([first_observed_result])
+
+        finder = Finder([strategy], first_observed)
+
+        # advisory published date: months before the fix existed
+        advisory = self.create_result("2026-05-22", "advisory", accurate=False)
+
+        result = finder.best("GO-2026-5026", "stdlib", "1.25.13", candidates=[advisory])
+
+        assert result == first_observed_result
+        assert result.date == datetime.date(2026, 8, 13)
+
+    def test_best_inaccurate_candidate_does_not_beat_inaccurate_first_observed(self):
+        """Even a not-yet-accurate first observed date beats an inaccurate candidate.
+
+        On the first build that sees a fix, the first-observed date is recorded as
+        accurate=None. It is still a better signal than the advisory published date, so it
+        must be preferred over the inaccurate candidate.
+        """
+        strategy = self.create_mock_strategy([])
+
+        first_observed_result = self.create_result("2026-08-15", "first_observed", accurate=False)
+        first_observed = self.create_mock_strategy([first_observed_result])
+
+        finder = Finder([strategy], first_observed)
+
+        advisory = self.create_result("2026-05-22", "advisory", accurate=False)
+
+        result = finder.best("GO-2026-5026", "stdlib", "1.25.13", candidates=[advisory])
+
+        assert result == first_observed_result
+        assert result.date == datetime.date(2026, 8, 15)
+
     def test_best_with_strategy_results(self):
         """Test that strategy results are included in the prioritization."""
         strategy_result = self.create_result("2023-01-03", "strategy")


### PR DESCRIPTION
Finder.best() ranked inaccurate candidates (an advisory's own `published` date, kind="advisory", accurate=False) above first-observed dates. Because a published date routinely predates the fix, it sorted earlier and won in both selection branches, so records whose only candidate is the advisory date (e.g. govulndb GO-* records) reported a fix-availability date months before the fix actually shipped.

Rank inaccurate candidates as a true last resort: accurate candidates and strategy results keep their precedence, but an inaccurate candidate is now used only when there is no first-observed date at all.

Add regression tests covering both branches (accurate and not-yet-accurate first-observed) with a candidate that predates the observed fix.