### PR TITLE
Use reliable GO sources for fix available dates

### DIFF
--- a/src/vunnel/providers/govulndb/go_release_dates.py
+++ b/src/vunnel/providers/govulndb/go_release_dates.py
@@ -42,6 +42,11 @@ GO_GIT_URL = "https://go.googlesource.com/go"
 # module names in the go vuln db that map to Go toolchain release tags rather
 # than proxy module versions
 STDLIB_MODULES = {"stdlib", "toolchain"}
+USER_AGENT = "vunnel/1.0 (govulndb-provider; +https://github.com/anchore/vunnel)"
+
+
+class GoReleaseDateLookupError(RuntimeError):
+    """Raised when an authoritative Go release-date source cannot be queried."""
 
 
 class GoReleaseDateOverlay:
@@ -52,9 +57,18 @@ class GoReleaseDateOverlay:
     tuple never re-hit the network.
     """
 
-    def __init__(self, logger: logging.Logger | None = None):
+    def __init__(
+        self,
+        logger: logging.Logger | None = None,
+        timeout: int = http.DEFAULT_TIMEOUT,
+        retries: int = 3,
+        backoff_in_seconds: int = 3,
+    ):
         self._cache: dict[tuple[str, str], date | None] = {}
         self.logger = logger if logger is not None else logging.getLogger(self.__class__.__name__)
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff_in_seconds = backoff_in_seconds
 
     def lookup(self, module: str, version: str) -> date | None:
         """Return the release date for a Go (module, version), or None on miss."""
@@ -96,8 +110,7 @@ class GoReleaseDateOverlay:
         try:
             return orjson.loads(resp.content)
         except orjson.JSONDecodeError:
-            self.logger.warning(f"failed to parse JSON from {url}")
-            return None
+            raise GoReleaseDateLookupError(f"failed to parse JSON from {url}") from None
 
     def _get_gitiles_json(self, url: str) -> dict[str, Any] | None:
         # gitiles prefixes JSON with a `)]}'` XSS-guard line that must be stripped
@@ -110,8 +123,7 @@ class GoReleaseDateOverlay:
         try:
             return orjson.loads(body)
         except orjson.JSONDecodeError:
-            self.logger.warning(f"failed to parse gitiles JSON from {url}")
-            return None
+            raise GoReleaseDateLookupError(f"failed to parse gitiles JSON from {url}") from None
 
     def _get(self, url: str) -> requests.Response | None:
         try:
@@ -120,11 +132,14 @@ class GoReleaseDateOverlay:
             return http.get(
                 url,
                 self.logger,
+                retries=self.retries,
+                backoff_in_seconds=self.backoff_in_seconds,
+                timeout=self.timeout,
                 status_handler=lambda r: None if r.status_code in (200, 404, 410) else r.raise_for_status(),
+                user_agent=USER_AGENT,
             )
         except Exception as e:
-            self.logger.warning(f"go release-date lookup failed for {url}: {e}")
-            return None
+            raise GoReleaseDateLookupError(f"go release-date lookup failed for {url}: {e}") from e
 
 
 def _stdlib_version_to_tag(version: str) -> str:

--- a/src/vunnel/providers/govulndb/go_release_dates.py
+++ b/src/vunnel/providers/govulndb/go_release_dates.py
@@ -1,0 +1,201 @@
+"""Resolve authoritative release dates for Go module/stdlib versions, used as
+an accurate fix-availability date source for the go.dev OSV records.
+
+go.dev's OSV records carry no per-fix date, and the advisory's own `published`
+field is a disclosure timestamp, not a fix-ship date. But for Go the fix
+*version* is enough to recover the real fix date, because every published Go
+artifact has a knowable release date:
+
+- **Modules** (incl. the extended stdlib `golang.org/x/...` and third-party
+  modules like `google.golang.org/protobuf`): the Go module proxy exposes the
+  tag date per version at `.../@v/v<version>.info` -> `.Time`. This is the git
+  tag time of the release, which is the moment the fixed version became
+  available. It is authoritative and covers every module version.
+
+- **stdlib / toolchain** (module name `stdlib` or `toolchain`, fixed versions
+  like `1.21.5`): the toolchain isn't a proxy module in a useful form, so we
+  read the `go<version>` tag commit date from the golang/go git mirror at
+  go.googlesource.com. Spot-check: `go1.21.5` -> 2023-12-05, the real release
+  day.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
+
+import orjson
+
+from vunnel.utils import http_wrapper as http
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import requests
+
+    from vunnel.tool import fixdate as _fixdate
+
+MODULE_PROXY_URL = "https://proxy.golang.org"
+GO_GIT_URL = "https://go.googlesource.com/go"
+
+# module names in the go vuln db that map to Go toolchain release tags rather
+# than proxy module versions
+STDLIB_MODULES = {"stdlib", "toolchain"}
+
+
+class GoReleaseDateOverlay:
+    """`(module, version) -> release date` resolver backed by the Go module
+    proxy (modules) and the golang/go git mirror (stdlib/toolchain).
+
+    Results are memoized, negatives included, so repeated lookups for the same
+    tuple never re-hit the network.
+    """
+
+    def __init__(self, logger: logging.Logger | None = None):
+        self._cache: dict[tuple[str, str], date | None] = {}
+        self.logger = logger if logger is not None else logging.getLogger(self.__class__.__name__)
+
+    def lookup(self, module: str, version: str) -> date | None:
+        """Return the release date for a Go (module, version), or None on miss."""
+        if not module or not version:
+            return None
+
+        key = (module, version)
+        if key in self._cache:
+            return self._cache[key]
+
+        result = self._lookup_stdlib(version) if module in STDLIB_MODULES else self._lookup_module(module, version)
+
+        self._cache[key] = result
+        return result
+
+    def _lookup_module(self, module: str, version: str) -> date | None:
+        escaped = _escape_module_path(module)
+        v = version if version.startswith("v") else f"v{version}"
+        url = f"{MODULE_PROXY_URL}/{escaped}/@v/{v}.info"
+        payload = self._get_json(url)
+        if not payload:
+            return None
+        return _parse_iso_date(payload.get("Time"))
+
+    def _lookup_stdlib(self, version: str) -> date | None:
+        tag = _stdlib_version_to_tag(version)
+        url = f"{GO_GIT_URL}/+/refs/tags/{tag}?format=JSON"
+        payload = self._get_gitiles_json(url)
+        if not payload:
+            return None
+        # committer time is the release commit on the release branch
+        committer = payload.get("committer") or payload.get("author") or {}
+        return _parse_gitiles_time(committer.get("time"))
+
+    def _get_json(self, url: str) -> dict[str, Any] | None:
+        resp = self._get(url)
+        if resp is None or resp.status_code != 200:
+            return None
+        try:
+            return orjson.loads(resp.content)
+        except orjson.JSONDecodeError:
+            self.logger.warning(f"failed to parse JSON from {url}")
+            return None
+
+    def _get_gitiles_json(self, url: str) -> dict[str, Any] | None:
+        # gitiles prefixes JSON with a `)]}'` XSS-guard line that must be stripped
+        resp = self._get(url)
+        if resp is None or resp.status_code != 200:
+            return None
+        body = resp.content
+        if body.startswith(b")]}'"):
+            body = body.split(b"\n", 1)[1]
+        try:
+            return orjson.loads(body)
+        except orjson.JSONDecodeError:
+            self.logger.warning(f"failed to parse gitiles JSON from {url}")
+            return None
+
+    def _get(self, url: str) -> requests.Response | None:
+        try:
+            # treat 404/410 as an ordinary miss (unknown version) rather than an
+            # error to retry on; only real failures should retry/raise
+            return http.get(
+                url,
+                self.logger,
+                status_handler=lambda r: None if r.status_code in (200, 404, 410) else r.raise_for_status(),
+            )
+        except Exception as e:
+            self.logger.warning(f"go release-date lookup failed for {url}: {e}")
+            return None
+
+
+def _stdlib_version_to_tag(version: str) -> str:
+    """Map a go vuln db stdlib version to its golang/go release tag.
+
+    Point releases map straight across (`1.25.13` -> `go1.25.13`,
+    `1.27.0` -> `go1.27.0`). Prereleases use the toolchain's compact tag form:
+    the trailing `.0` patch is dropped and the prerelease loses its dots, so
+    `1.27.0-rc.3` -> `go1.27rc3` and `1.20.0-beta.1` -> `go1.20beta1`. The go
+    vuln db lists these RCs as fixed versions because an upcoming minor's RC is
+    often the first shipped artifact carrying a fix.
+    """
+    v = version[2:] if version.startswith("go") else version
+    if "-" in v:
+        base, pre = v.split("-", 1)
+        base = base.removesuffix(".0")
+        pre = pre.replace(".", "")
+        return f"go{base}{pre}"
+    return f"go{v}"
+
+
+def _escape_module_path(module: str) -> str:
+    """Escape a module path for the module proxy: uppercase letters become
+    `!` + lowercase (e.g. `github.com/Azure/...` -> `github.com/!azure/...`).
+    """
+    return "".join(f"!{c.lower()}" if c.isupper() else c for c in module)
+
+
+def _parse_iso_date(s: str | None) -> date | None:
+    """Parse a module-proxy ISO-8601 timestamp (e.g. `2023-08-01T17:46:51Z`)."""
+    if not s:
+        return None
+    try:
+        normalized = s.rstrip("Z").rstrip()
+        if "T" in normalized:
+            return datetime.fromisoformat(normalized).date()
+        return date.fromisoformat(normalized)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_gitiles_time(s: str | None) -> date | None:
+    """Parse a gitiles git-time string, e.g. `Tue Dec 05 18:12:56 2023 +0000`."""
+    if not s:
+        return None
+    try:
+        return datetime.strptime(s, "%a %b %d %H:%M:%S %Y %z").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def go_extra_candidates(
+    overlay: GoReleaseDateOverlay | None,
+) -> Callable[[str, str, str, str | None], list[_fixdate.Result]] | None:
+    """Build the extra-candidates callable for osv.patch_fix_date.
+
+    Returns a function with the signature patch_fix_date expects
+    (vuln_id, package_name, fix_version, ecosystem) -> list[Result]. The
+    release-date candidate is marked accurate=True so it wins against
+    first-observed and the advisory's low-confidence published date.
+    """
+    if overlay is None:
+        return None
+
+    # Local import - fixdate package isn't always loaded at module-init time.
+    from vunnel.tool import fixdate  # noqa: PLC0415
+
+    def candidates(vuln_id: str, package_name: str, fix_version: str, ecosystem: str | None) -> list[fixdate.Result]:
+        d = overlay.lookup(package_name, fix_version)
+        if d is None:
+            return []
+        return [fixdate.Result(date=d, kind="go-release", accurate=True)]
+
+    return candidates

--- a/src/vunnel/providers/govulndb/parser.py
+++ b/src/vunnel/providers/govulndb/parser.py
@@ -49,7 +49,7 @@ class Parser:
         self.logger = logger
         self.zip_path = os.path.join(self.workspace.input_path, "vulndb.zip")
         self.extract_dir = os.path.join(self.workspace.input_path, "vulndb")
-        self.release_dates = GoReleaseDateOverlay(logger=self.logger)
+        self.release_dates = GoReleaseDateOverlay(logger=self.logger, timeout=self.download_timeout)
 
     def __enter__(self) -> Parser:
         self.fixdater.__enter__()

--- a/src/vunnel/providers/govulndb/parser.py
+++ b/src/vunnel/providers/govulndb/parser.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 
+from vunnel.providers.govulndb.go_release_dates import GoReleaseDateOverlay, go_extra_candidates
 from vunnel.tool import fixdate
 from vunnel.utils import http_wrapper as http
 from vunnel.utils import osv, silent_remove
@@ -48,6 +49,7 @@ class Parser:
         self.logger = logger
         self.zip_path = os.path.join(self.workspace.input_path, "vulndb.zip")
         self.extract_dir = os.path.join(self.workspace.input_path, "vulndb")
+        self.release_dates = GoReleaseDateOverlay(logger=self.logger)
 
     def __enter__(self) -> Parser:
         self.fixdater.__enter__()
@@ -110,11 +112,13 @@ class Parser:
             self._extract()
 
         # go.dev's OSV records carry no per-fix date; patch in database_specific.anchore.fixes
-        # so the grype OSV transformer's existing fix-availability path picks them up. The
-        # advisory's own `published` date rides along as a low-confidence candidate so the
-        # finder can fall back to it when no first-observed dataset has the fix.
+        # so the grype OSV transformer's existing fix-availability path picks them up. The Go
+        # fix *version* is enough to recover the real fix date: go_extra_candidates resolves the
+        # module/stdlib release date (accurate=True) so it wins over the advisory's low-confidence
+        # published date and the first-observed fallback (pinned to this provider's turn-up date).
         self.fixdater.download()
+        extra_candidates = go_extra_candidates(self.release_dates)
 
         for vuln_entry in self._load():
-            osv.patch_fix_date(vuln_entry, self.fixdater)
+            osv.patch_fix_date(vuln_entry, self.fixdater, extra_candidates=extra_candidates)
             yield self._normalize(vuln_entry)

--- a/tests/unit/providers/govulndb/test_go_release_dates.py
+++ b/tests/unit/providers/govulndb/test_go_release_dates.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import datetime
+from types import SimpleNamespace
+
+from vunnel.providers.govulndb.go_release_dates import (
+    GoReleaseDateOverlay,
+    _escape_module_path,
+    _stdlib_version_to_tag,
+    go_extra_candidates,
+)
+
+
+def test_stdlib_version_to_tag():
+    assert _stdlib_version_to_tag("1.21.5") == "go1.21.5"
+    assert _stdlib_version_to_tag("go1.21.5") == "go1.21.5"
+    assert _stdlib_version_to_tag("1.27.0-rc.3") == "go1.27rc3"
+    assert _stdlib_version_to_tag("1.20.0-beta.1") == "go1.20beta1"
+
+
+def test_escape_module_path():
+    assert _escape_module_path("github.com/Azure/azure-sdk-for-go") == "github.com/!azure/azure-sdk-for-go"
+
+
+def test_lookup_module_uses_module_proxy_and_caches(monkeypatch):
+    overlay = GoReleaseDateOverlay()
+    calls = []
+
+    def fake_get(url):
+        calls.append(url)
+        return SimpleNamespace(
+            status_code=200,
+            content=b'{"Time":"2023-08-01T17:46:51Z"}',
+        )
+
+    monkeypatch.setattr(overlay, "_get", fake_get)
+
+    assert overlay.lookup("golang.org/x/image", "0.10.0") == datetime.date(2023, 8, 1)
+    assert overlay.lookup("golang.org/x/image", "0.10.0") == datetime.date(2023, 8, 1)
+    assert calls == ["https://proxy.golang.org/golang.org/x/image/@v/v0.10.0.info"]
+
+
+def test_lookup_stdlib_uses_go_release_tag_and_caches(monkeypatch):
+    overlay = GoReleaseDateOverlay()
+    calls = []
+
+    def fake_get(url):
+        calls.append(url)
+        return SimpleNamespace(
+            status_code=200,
+            content=b')]}\'\n{"committer":{"time":"Tue Dec 05 18:12:56 2023 +0000"}}',
+        )
+
+    monkeypatch.setattr(overlay, "_get", fake_get)
+
+    assert overlay.lookup("stdlib", "1.21.5") == datetime.date(2023, 12, 5)
+    assert overlay.lookup("stdlib", "1.21.5") == datetime.date(2023, 12, 5)
+    assert calls == ["https://go.googlesource.com/go/+/refs/tags/go1.21.5?format=JSON"]
+
+
+def test_go_extra_candidates_marks_release_date_accurate():
+    class Overlay:
+        def lookup(self, module, version):
+            assert module == "stdlib"
+            assert version == "1.21.5"
+            return datetime.date(2023, 12, 5)
+
+    candidates = go_extra_candidates(Overlay())
+
+    assert candidates is not None
+    results = candidates("GO-2023-9999", "stdlib", "1.21.5", "Go")
+
+    assert len(results) == 1
+    assert results[0].date == datetime.date(2023, 12, 5)
+    assert results[0].kind == "go-release"
+    assert results[0].accurate is True
+
+
+def test_go_extra_candidates_returns_empty_when_lookup_misses():
+    class Overlay:
+        def lookup(self, module, version):
+            return None
+
+    candidates = go_extra_candidates(Overlay())
+
+    assert candidates is not None
+    assert candidates("GO-2023-9999", "stdlib", "1.21.5", "Go") == []

--- a/tests/unit/providers/govulndb/test_go_release_dates.py
+++ b/tests/unit/providers/govulndb/test_go_release_dates.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import datetime
 from types import SimpleNamespace
 
+import pytest
+
 from vunnel.providers.govulndb.go_release_dates import (
+    GoReleaseDateLookupError,
     GoReleaseDateOverlay,
     _escape_module_path,
     _stdlib_version_to_tag,
@@ -40,6 +43,20 @@ def test_lookup_module_uses_module_proxy_and_caches(monkeypatch):
     assert calls == ["https://proxy.golang.org/golang.org/x/image/@v/v0.10.0.info"]
 
 
+def test_lookup_module_misses_on_not_found(monkeypatch):
+    overlay = GoReleaseDateOverlay()
+
+    def fake_get(url):
+        return SimpleNamespace(
+            status_code=404,
+            content=b"not found",
+        )
+
+    monkeypatch.setattr(overlay, "_get", fake_get)
+
+    assert overlay.lookup("golang.org/x/image", "0.10.0") is None
+
+
 def test_lookup_stdlib_uses_go_release_tag_and_caches(monkeypatch):
     overlay = GoReleaseDateOverlay()
     calls = []
@@ -56,6 +73,33 @@ def test_lookup_stdlib_uses_go_release_tag_and_caches(monkeypatch):
     assert overlay.lookup("stdlib", "1.21.5") == datetime.date(2023, 12, 5)
     assert overlay.lookup("stdlib", "1.21.5") == datetime.date(2023, 12, 5)
     assert calls == ["https://go.googlesource.com/go/+/refs/tags/go1.21.5?format=JSON"]
+
+
+def test_lookup_raises_when_release_source_fails(monkeypatch):
+    overlay = GoReleaseDateOverlay()
+
+    def fake_get(url):
+        raise GoReleaseDateLookupError(f"failed: {url}")
+
+    monkeypatch.setattr(overlay, "_get", fake_get)
+
+    with pytest.raises(GoReleaseDateLookupError):
+        overlay.lookup("golang.org/x/image", "0.10.0")
+
+
+def test_lookup_raises_when_release_source_returns_invalid_json(monkeypatch):
+    overlay = GoReleaseDateOverlay()
+
+    def fake_get(url):
+        return SimpleNamespace(
+            status_code=200,
+            content=b"not json",
+        )
+
+    monkeypatch.setattr(overlay, "_get", fake_get)
+
+    with pytest.raises(GoReleaseDateLookupError):
+        overlay.lookup("golang.org/x/image", "0.10.0")
 
 
 def test_go_extra_candidates_marks_release_date_accurate():

--- a/tests/unit/providers/govulndb/test_govulndb.py
+++ b/tests/unit/providers/govulndb/test_govulndb.py
@@ -1,3 +1,4 @@
+import datetime
 import shutil
 from unittest.mock import patch
 
@@ -39,6 +40,36 @@ def test_parser(mock_download, mock_extract, helpers, auto_fake_fixdate_finder, 
     assert vuln_tuples[0][1] == "1.3.1"
     assert vuln_tuples[1][0] == "GO-2024-2611"
     assert vuln_tuples[1][1] == "1.3.1"
+
+
+@patch("vunnel.providers.govulndb.parser.Parser._extract")
+@patch("vunnel.providers.govulndb.parser.Parser._download")
+def test_parser_prefers_go_release_date(
+    mock_download,
+    mock_extract,
+    helpers,
+    auto_fake_fixdate_finder,
+    disable_get_requests,
+    monkeypatch,
+):
+    mock_download.return_value = None
+    mock_extract.return_value = None
+    workspace = helpers.provider_workspace_helper(name=Provider.name())
+    mock_data_path = helpers.local_dir("test-fixtures")
+    shutil.copytree(mock_data_path, workspace.input_dir, dirs_exist_ok=True)
+    parser = Parser(ws=workspace, logger=None)
+    monkeypatch.setattr(parser.release_dates, "lookup", lambda module, version: datetime.date(2023, 8, 1))
+
+    vuln_tuples = list(parser.get())
+    fixes = vuln_tuples[0][2]["affected"][0]["ranges"][0]["database_specific"]["anchore"]["fixes"]
+
+    assert fixes == [
+        {
+            "version": "0.10.0",
+            "date": "2023-08-01",
+            "kind": "go-release",
+        },
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/providers/govulndb/test_govulndb.py
+++ b/tests/unit/providers/govulndb/test_govulndb.py
@@ -5,12 +5,18 @@ from unittest.mock import patch
 import pytest
 from vunnel import result, schema
 from vunnel.providers.govulndb import Config, Provider
+from vunnel.providers.govulndb.go_release_dates import GoReleaseDateOverlay
 from vunnel.providers.govulndb.parser import Parser
+
+
+@pytest.fixture
+def no_go_release_date_lookup(monkeypatch):
+    monkeypatch.setattr(GoReleaseDateOverlay, "lookup", lambda self, module, version: None)
 
 
 @patch("vunnel.providers.govulndb.parser.Parser._extract")
 @patch("vunnel.providers.govulndb.parser.Parser._download")
-def test_provider_schema(mock_download, mock_extract, helpers, auto_fake_fixdate_finder, disable_get_requests):
+def test_provider_schema(mock_download, mock_extract, helpers, auto_fake_fixdate_finder, disable_get_requests, no_go_release_date_lookup):
     mock_download.return_value = None
     mock_extract.return_value = None
     workspace = helpers.provider_workspace_helper(name=Provider.name())
@@ -27,7 +33,7 @@ def test_provider_schema(mock_download, mock_extract, helpers, auto_fake_fixdate
 
 @patch("vunnel.providers.govulndb.parser.Parser._extract")
 @patch("vunnel.providers.govulndb.parser.Parser._download")
-def test_parser(mock_download, mock_extract, helpers, auto_fake_fixdate_finder, disable_get_requests):
+def test_parser(mock_download, mock_extract, helpers, auto_fake_fixdate_finder, disable_get_requests, no_go_release_date_lookup):
     mock_download.return_value = None
     mock_extract.return_value = None
     workspace = helpers.provider_workspace_helper(name=Provider.name())
@@ -88,7 +94,7 @@ def test_compatible_schema(schema_version, expected):
 
 @patch("vunnel.providers.govulndb.parser.Parser._extract")
 @patch("vunnel.providers.govulndb.parser.Parser._download")
-def test_provider_via_snapshot(mock_download, mock_extract, helpers, auto_fake_fixdate_finder, disable_get_requests):
+def test_provider_via_snapshot(mock_download, mock_extract, helpers, auto_fake_fixdate_finder, disable_get_requests, no_go_release_date_lookup):
     mock_download.return_value = None
     mock_extract.return_value = None
     workspace = helpers.provider_workspace_helper(name=Provider.name())
@@ -102,7 +108,7 @@ def test_provider_via_snapshot(mock_download, mock_extract, helpers, auto_fake_f
     workspace.assert_result_snapshots()
 
 
-def test_provider_skip_download(helpers, auto_fake_fixdate_finder, monkeypatch):
+def test_provider_skip_download(helpers, auto_fake_fixdate_finder, monkeypatch, no_go_release_date_lookup):
     """With skip_download=True, no HTTP request should be made and pre-staged input is used."""
     workspace = helpers.provider_workspace_helper(name=Provider.name())
     c = Config()


### PR DESCRIPTION
## Description

Improve Go vulnerability fix-availability dates by deriving high-confidence fix-date candidates from the actual Go release/module version that introduced the fix.

Go vuln DB OSV records do not include per-fix availability dates, and the top-level `published` field represents vulnerability disclosure/publication timing rather than when the fixed version became available. Falling back to first-observed is
also inaccurate for this provider because most Go records date to when the provider was first enabled.

This change keeps the shared fix-date finder behavior unchanged and updates only the `govulndb` provider to pass provider-specific `accurate=True` candidates into `osv.patch_fix_date(...)`.

For fixed versions:

- `stdlib` and `toolchain` dates are resolved from the corresponding `golang/go` release tag.
- Go module dates, including `golang.org/x/...`, are resolved from the Go module proxy version metadata.
- If no release date can be resolved, behavior falls back to the existing advisory/first-observed candidate flow.

## Why

This makes Go fix dates line up with when the fixed Go/toolchain/module version was actually released, instead of using GHSA/OSV publication dates or first-observed dates.

This is especially important for historical Go vulnerabilities where first-observed commonly reflects provider turn-up time rather than real fix availability.

## Testing

Added focused tests for:

- Go stdlib/toolchain version-to-tag normalization.
- Go module proxy release-date lookup.
- stdlib release tag date lookup.
- release-date lookup caching.
- `accurate=True` extra candidate generation.
- provider-level behavior showing Go release dates are preferred over first-observed fallback.

Replaces the fix offered in https://github.com/anchore/vunnel/pull/1309 based on the feedback on that PR.